### PR TITLE
Make all keys unique, fix bug where answers would move when using a filtered table

### DIFF
--- a/frontend/beCompliant/src/components/MobileFilter.tsx
+++ b/frontend/beCompliant/src/components/MobileFilter.tsx
@@ -68,7 +68,7 @@ const MobileFilter = ({
 
             {tableMetadata?.fields.map((metaColumn, index) => (
               <TableFilter
-                key={index}
+                key={metaColumn.id}
                 filterName={metaColumn.name}
                 filterOptions={metaColumn.options}
                 activeFilters={activeFilters}

--- a/frontend/beCompliant/src/components/MobileTableView.tsx
+++ b/frontend/beCompliant/src/components/MobileTableView.tsx
@@ -84,6 +84,7 @@ const MobileTableView = ({
                 record={item}
                 setFetchNewAnswers={setFetchNewAnswers}
                 team={team}
+                key={item.fields?.ID}
               />
             </div>
           </Flex>

--- a/frontend/beCompliant/src/components/answer/Answer.tsx
+++ b/frontend/beCompliant/src/components/answer/Answer.tsx
@@ -14,6 +14,7 @@ interface AnswerProps {
   record: RecordType;
   setFetchNewAnswers: Dispatch<SetStateAction<boolean>>;
   team?: string;
+  key: string;
 }
 
 export const Answer = ({
@@ -22,6 +23,7 @@ export const Answer = ({
   record,
   setFetchNewAnswers,
   team,
+  key,
 }: AnswerProps) => {
   const [selectedAnswer, setSelectedAnswer] = useState<string | undefined>(
     answer
@@ -89,9 +91,10 @@ export const Answer = ({
       onChange={handleChange}
       value={selectedAnswer}
       width="170px"
+      key={key}
     >
-      {choices.map((choice, index) => (
-        <option value={choice} key={index}>
+      {choices.map((choice) => (
+        <option value={choice} key={choice}>
           {choice}
         </option>
       ))}

--- a/frontend/beCompliant/src/components/questionRow/QuestionRow.tsx
+++ b/frontend/beCompliant/src/components/questionRow/QuestionRow.tsx
@@ -13,27 +13,30 @@ interface QuestionRowProps {
   setFetchNewAnswers: Dispatch<SetStateAction<boolean>>;
   tableColumns: Field[];
   team?: string;
+  key: string;
 }
 
 export const QuestionRow = ({
-                              record,
-                              choices,
-                              setFetchNewAnswers,
-                              tableColumns,
-                              team,
-                            }: QuestionRowProps) => {
+    record,
+    choices,
+    setFetchNewAnswers,
+    tableColumns,
+    team,
+    key,
+  }: QuestionRowProps) => {
   const arrayToString = (list: string[]): string => list.join(', ');
   return (
-    <Tr>
+    <Tr key={key}>
       <Td>{record.fields.Svar ? formatDateTime(record.fields.updated) : ''}</Td>
       <Td className="finished">{record.fields.Status}</Td>
 
-      {tableColumns.map((column: Field, index: number) => {
+      {tableColumns.map((column: Field) => {
         const columnKey = column.name as keyof Fields;
         if (columnKey === 'Svar') {
           return (
-            <Td className="answer" key={index}>
+            <Td className="answer" key={key}>
               <Answer
+                key={key}
                 choices={choices}
                 answer={record.fields.Svar ? record.fields.Svar : ''}
                 record={record}
@@ -46,7 +49,7 @@ export const QuestionRow = ({
         const cellValue = record.fields[columnKey];
 
         if(!cellValue){
-          return <Td key={index} />
+          return <Td key={key} />
         }
 
         const cellRenderValue = Array.isArray(cellValue)
@@ -58,13 +61,13 @@ export const QuestionRow = ({
 
         if(columnChoices && columnChoices.length > 0){
           return (
-            <Td key={index}>
+            <Td key={key}>
               <ChoiceTag cellValue={cellValue} cellRenderValue={cellRenderValue} choices={columnChoices}/>
             </Td>
           );
         }
 
-        return <Td key={index}>{cellRenderValue}</Td>;
+        return <Td key={key}>{cellRenderValue}</Td>;
       })}
     </Tr>
   );

--- a/frontend/beCompliant/src/components/tableActions/TableActions.tsx
+++ b/frontend/beCompliant/src/components/tableActions/TableActions.tsx
@@ -27,9 +27,9 @@ export const TableActions = (props: TableActionProps) => {
               setActiveFilters={setActiveFilters}
             />
 
-            {tableMetadata?.fields.map((metaColumn, index) => (
+            {tableMetadata?.fields.map((metaColumn) => (
               <TableFilter
-                key={index}
+                key={metaColumn.id}
                 filterName={metaColumn.name}
                 filterOptions={metaColumn.options}
                 activeFilters={activeFilters}

--- a/frontend/beCompliant/src/components/tableActions/TableFilter.tsx
+++ b/frontend/beCompliant/src/components/tableActions/TableFilter.tsx
@@ -64,8 +64,8 @@ export const TableFilter = ({
           onChange={handleFilterChange}
           value={currentValue}
         >
-          {filterOptions?.choices.map((choice, index) => (
-            <option value={choice.name} key={index}>
+          {filterOptions?.choices.map((choice) => (
+            <option value={choice.name} key={choice.id}>
               {choice.name}
             </option>
           ))}

--- a/frontend/beCompliant/src/pages/Table.tsx
+++ b/frontend/beCompliant/src/pages/Table.tsx
@@ -196,7 +196,6 @@ export const MainTableComponent = () => {
                 <Thead>
                   <Tr>
                     <Th>Når</Th>
-                    <Th>Status</Th>
                     {tableMetaData.fields.map((field) => (
                       <Th key={field.id}>{field.name}</Th>
                     ))}

--- a/frontend/beCompliant/src/pages/Table.tsx
+++ b/frontend/beCompliant/src/pages/Table.tsx
@@ -197,15 +197,15 @@ export const MainTableComponent = () => {
                   <Tr>
                     <Th>Når</Th>
                     <Th>Status</Th>
-                    {tableMetaData.fields.map((field, index) => (
-                      <Th key={index}>{field.name}</Th>
+                    {tableMetaData.fields.map((field) => (
+                      <Th key={field.id}>{field.name}</Th>
                     ))}
                   </Tr>
                 </Thead>
                 <Tbody>
-                  {filteredData.map((item: RecordType, index: number) => (
+                  {filteredData.map((item: RecordType) => (
                     <QuestionRow
-                      key={index}
+                      key={item.fields.ID}
                       record={item}
                       choices={choices}
                       setFetchNewAnswers={setFetchNewAnswers}


### PR DESCRIPTION
When using index as the key, it may create problems. Example: An answer uses the index as key and you remove a row from the table. Since the index still exists, the answer will visually "jump" to the same index, which is now the "next" row (with the same index)