### PR TITLE
Make optionField nullable

### DIFF
--- a/frontend/beCompliant/src/hooks/datafetcher.ts
+++ b/frontend/beCompliant/src/hooks/datafetcher.ts
@@ -84,7 +84,7 @@ export const useMetodeverkFetcher = (team?: string) => {
       const optionField = aktivitetsTable.fields.filter(
         (field: Field) => field.name === 'Svar'
       )[0];
-      const options = optionField.options;
+      const options = optionField?.options;
       const answerOptions = options?.choices;
       setChoices(answerOptions ?? []);
     }


### PR DESCRIPTION
## Background

Accessing team pages in the frontend crashes if the optionField is missing.

## Solution

Make it nullable so that it doesn't crash if there are no options.