### PR TITLE
Add refetching to userAnswersFetcher hook and create new Table component

### DIFF
--- a/frontend/beCompliant/src/components/MobileTableView.tsx
+++ b/frontend/beCompliant/src/components/MobileTableView.tsx
@@ -1,15 +1,14 @@
 import { Button, Flex, Text, useTheme } from '@kvib/react';
-import { RecordType } from '../pages/Table';
-import { Answer } from './answer/Answer';
-import { Dispatch, SetStateAction, useState } from 'react';
-import MobileFilter from './MobileFilter';
+import { useState } from 'react';
 import { Choice, TableMetaData } from '../hooks/datafetcher';
+import { RecordType } from '../pages/TablePage';
+import MobileFilter from './MobileFilter';
+import { Answer } from './answer/Answer';
 import { TableFilterProps } from './tableActions/TableFilter';
 
 interface Props {
   filteredData: RecordType[];
   choices: Choice[];
-  setFetchNewAnswers: Dispatch<SetStateAction<boolean>>;
   team?: string;
   tableFilterProps: TableFilterProps;
   tableMetadata?: TableMetaData;
@@ -18,7 +17,6 @@ interface Props {
 const MobileTableView = ({
   filteredData,
   choices,
-  setFetchNewAnswers,
   team,
   tableFilterProps,
   tableMetadata,
@@ -82,7 +80,6 @@ const MobileTableView = ({
                 choices={choices}
                 answer={item.fields.Svar ? item.fields.Svar : ''}
                 record={item}
-                setFetchNewAnswers={setFetchNewAnswers}
                 team={team}
                 key={item.fields?.ID}
               />

--- a/frontend/beCompliant/src/components/Table.tsx
+++ b/frontend/beCompliant/src/components/Table.tsx
@@ -1,0 +1,44 @@
+import { Table, TableContainer, Tbody, Th, Thead, Tr } from '@kvib/react';
+import { Choice, Field } from '../hooks/datafetcher';
+import { RecordType } from '../pages/TablePage';
+import { QuestionRow } from './questionRow/QuestionRow';
+
+type TableComponentProps = {
+  data: RecordType[];
+  fields: Field[];
+  team?: string;
+  choices: Choice[];
+};
+
+export function TableComponent({
+  data,
+  fields,
+  choices,
+  team,
+}: TableComponentProps) {
+  return (
+    <TableContainer>
+      <Table variant="striped" colorScheme="gray">
+        <Thead>
+          <Tr>
+            <Th>Når</Th>
+            {fields.map((field) => (
+              <Th key={field.id}>{field.name}</Th>
+            ))}
+          </Tr>
+        </Thead>
+        <Tbody>
+          {data.map((item: RecordType) => (
+            <QuestionRow
+              key={item.fields.ID}
+              record={item}
+              choices={choices}
+              tableColumns={fields}
+              team={team}
+            />
+          ))}
+        </Tbody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/frontend/beCompliant/src/components/answer/Answer.tsx
+++ b/frontend/beCompliant/src/components/answer/Answer.tsx
@@ -1,7 +1,8 @@
 import { Button, Select, Textarea, useToast } from '@kvib/react';
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useAnswersFetcher } from '../../hooks/answersFetcher';
 import { Choice } from '../../hooks/datafetcher';
-import { RecordType } from '../../pages/Table';
+import { RecordType } from '../../pages/TablePage';
 import colorUtils from '../../utils/colorUtils';
 
 export type AnswerType = {
@@ -15,7 +16,6 @@ interface AnswerProps {
   choices: Choice[] | [];
   answer: string;
   record: RecordType;
-  setFetchNewAnswers: Dispatch<SetStateAction<boolean>>;
   team?: string;
   comment?: string;
 }
@@ -24,7 +24,6 @@ export const Answer = ({
   choices,
   answer,
   record,
-  setFetchNewAnswers,
   team,
   comment,
 }: AnswerProps) => {
@@ -33,6 +32,8 @@ export const Answer = ({
   );
   const [selectedComment, setComment] = useState<string | undefined>(comment);
   const [commentIsOpen, setCommentIsOpen] = useState<boolean>(comment !== '');
+
+  const { setFetchAnswers } = useAnswersFetcher();
 
   const backgroundColor = selectedAnswer
     ? colorUtils.getHexForColor(
@@ -74,7 +75,7 @@ export const Answer = ({
         duration: 5000,
         isClosable: true,
       });
-      setFetchNewAnswers(true);
+      setFetchAnswers(true);
     } catch (error) {
       console.error('There was an error with the submitAnswer request:', error);
       toast({

--- a/frontend/beCompliant/src/components/questionRow/QuestionRow.tsx
+++ b/frontend/beCompliant/src/components/questionRow/QuestionRow.tsx
@@ -1,27 +1,24 @@
-import { Dispatch, SetStateAction } from 'react';
 import { Td, Tr } from '@kvib/react';
-import { Answer } from '../answer/Answer';
-import './questionRow.css';
-import { formatDateTime } from '../../utils/formatTime';
-import { Fields, RecordType } from '../../pages/Table';
 import { Choice, Field } from '../../hooks/datafetcher';
+import { Fields, RecordType } from '../../pages/TablePage';
+import { formatDateTime } from '../../utils/formatTime';
+import { Answer } from '../answer/Answer';
 import { ChoiceTag } from '../choiceTag/ChoiceTag';
+import './questionRow.css';
 
 interface QuestionRowProps {
   record: RecordType;
   choices: Choice[];
-  setFetchNewAnswers: Dispatch<SetStateAction<boolean>>;
   tableColumns: Field[];
   team?: string;
 }
 
 export const QuestionRow = ({
-    record,
-    choices,
-    setFetchNewAnswers,
-    tableColumns,
-    team,
-  }: QuestionRowProps) => {
+  record,
+  choices,
+  tableColumns,
+  team,
+}: QuestionRowProps) => {
   const arrayToString = (list: string[]): string => list.join(', ');
   return (
     <Tr key={record.fields.ID}>
@@ -36,7 +33,6 @@ export const QuestionRow = ({
                 choices={choices}
                 answer={record.fields.Svar ? record.fields.Svar : ''}
                 record={record}
-                setFetchNewAnswers={setFetchNewAnswers}
                 team={team}
                 comment={record.fields.comment ? record.fields.comment : ''}
               />
@@ -45,8 +41,8 @@ export const QuestionRow = ({
         }
         const cellValue = record.fields[columnKey];
 
-        if(!cellValue){
-          return <Td key={column.id}/>
+        if (!cellValue) {
+          return <Td key={column.id} />;
         }
 
         const cellRenderValue = Array.isArray(cellValue)
@@ -59,7 +55,11 @@ export const QuestionRow = ({
         if (columnChoices && columnChoices.length > 0) {
           return (
             <Td key={column.id}>
-              <ChoiceTag cellValue={cellValue} cellRenderValue={cellRenderValue} choices={columnChoices}/>
+              <ChoiceTag
+                cellValue={cellValue}
+                cellRenderValue={cellRenderValue}
+                choices={columnChoices}
+              />
             </Td>
           );
         }

--- a/frontend/beCompliant/src/components/tableActions/TableFilter.tsx
+++ b/frontend/beCompliant/src/components/tableActions/TableFilter.tsx
@@ -1,7 +1,7 @@
-import { Box, Select, Heading } from '@kvib/react';
+import { Box, Heading, Select } from '@kvib/react';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { Option } from '../../hooks/datafetcher';
-import { ActiveFilter } from '../../pages/Table';
+import { ActiveFilter } from '../../pages/TablePage';
 
 export type TableFilterProps = {
   filterName: string;

--- a/frontend/beCompliant/src/components/tableActions/TableSorter.tsx
+++ b/frontend/beCompliant/src/components/tableActions/TableSorter.tsx
@@ -1,6 +1,6 @@
+import { Icon, Select, useTheme } from '@kvib/react';
 import { Dispatch, SetStateAction } from 'react';
-import { Fields } from '../../pages/Table';
-import { Select, useTheme, Icon } from '@kvib/react';
+import { Fields } from '../../pages/TablePage';
 
 export type TableSorterProps = {
   fieldSortedBy: keyof Fields;
@@ -21,7 +21,7 @@ export const TableSorter = (props: TableSorterProps) => {
       onChange={handleSortedData}
       variant="unstyled"
       style={{ color: theme.colors.green[500] }}
-      icon={<Icon icon="sort"/>}
+      icon={<Icon icon="sort" />}
       iconColor={theme.colors.green[500]}
     >
       <option value="Pri">Prioritet</option>

--- a/frontend/beCompliant/src/components/tableStatistics/TableStatistics.tsx
+++ b/frontend/beCompliant/src/components/tableStatistics/TableStatistics.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@kvib/react';
-import { RecordType } from '../../pages/Table';
+import { RecordType } from '../../pages/TablePage';
 
 interface TableStatisticsProps {
   filteredData: RecordType[];

--- a/frontend/beCompliant/src/hooks/answersFetcher.ts
+++ b/frontend/beCompliant/src/hooks/answersFetcher.ts
@@ -1,12 +1,9 @@
 import { useEffect, useState } from 'react';
 import { AnswerType } from '../components/answer/Answer';
 
-export const useAnswersFetcher = (
-  fetchNewAnswers: any,
-  setFetchNewAnswers: any,
-  team?: string
-) => {
+export const useAnswersFetcher = (team?: string) => {
   const [answers, setAnswers] = useState<AnswerType[]>();
+  const [fetchAnswers, setFetchAnswers] = useState(false);
   const [error, setError] = useState<Error>();
   const [loading, setLoading] = useState<boolean>(false);
   const URL = team
@@ -27,8 +24,8 @@ export const useAnswersFetcher = (
       }
     };
 
-    if (fetchNewAnswers) fetcher();
-    setFetchNewAnswers(false);
-  }, [fetchNewAnswers]);
-  return { answers, error, loading };
+    if (fetchAnswers) fetcher();
+    setFetchAnswers(false);
+  }, [fetchAnswers]);
+  return { answers, error, loading, setFetchAnswers };
 };

--- a/frontend/beCompliant/src/hooks/datafetcher.ts
+++ b/frontend/beCompliant/src/hooks/datafetcher.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { RecordType } from '../pages/Table';
+import { RecordType } from '../pages/TablePage';
 
 export type TableMetaData = {
   id: string;

--- a/frontend/beCompliant/src/pages/TablePage.tsx
+++ b/frontend/beCompliant/src/pages/TablePage.tsx
@@ -1,26 +1,15 @@
-import {
-  TableContainer,
-  Table,
-  Thead,
-  Tr,
-  Th,
-  Tbody,
-  Center,
-  Spinner,
-  useMediaQuery,
-  Heading,
-} from '@kvib/react';
-import { useState, useEffect } from 'react';
-import { useAnswersFetcher } from '../hooks/answersFetcher';
-import { QuestionRow } from '../components/questionRow/QuestionRow';
+import { Center, Heading, Spinner, useMediaQuery } from '@kvib/react';
+import { useEffect, useState } from 'react';
 import { AnswerType } from '../components/answer/Answer';
-import { sortData } from '../utils/sorter';
+import { useAnswersFetcher } from '../hooks/answersFetcher';
 import { Option, useMetodeverkFetcher } from '../hooks/datafetcher';
-import { useParams } from 'react-router-dom';
+import { sortData } from '../utils/sorter';
 
 import { TableActions } from '../components/tableActions/TableActions';
 
+import { useParams } from 'react-router-dom';
 import MobileTableView from '../components/MobileTableView';
+import { TableComponent } from '../components/Table';
 import { TableStatistics } from '../components/tableStatistics/TableStatistics';
 import { useCommentsFetcher } from '../hooks/commentsFetcher';
 
@@ -52,13 +41,7 @@ export type ActiveFilter = {
 export const MainTableComponent = () => {
   const params = useParams();
   const team = params.teamName;
-
-  const [fetchNewAnswers, setFetchNewAnswers] = useState(true);
-  const { answers, loading: answersLoading } = useAnswersFetcher(
-    fetchNewAnswers,
-    setFetchNewAnswers,
-    team
-  );
+  const { answers, loading: answersLoading } = useAnswersFetcher(team);
   const {
     data,
     dataError,
@@ -67,7 +50,7 @@ export const MainTableComponent = () => {
     loading: metodeverkLoading,
   } = useMetodeverkFetcher(team);
 
-  const { comments } = useCommentsFetcher(team)
+  const { comments } = useCommentsFetcher(team);
   const [fieldSortedBy, setFieldSortedBy] = useState<keyof Fields>(
     '' as keyof Fields
   );
@@ -102,7 +85,7 @@ export const MainTableComponent = () => {
       );
       const commentsMatch = comments?.find(
         (comment: any) => comment.questionId === item.fields.ID
-        )
+      );
       const combinedData = {
         ...item,
         fields: {
@@ -192,34 +175,12 @@ export const MainTableComponent = () => {
               tableMetadata={tableMetaData}
               tableSorterProps={tableSorterProps}
             />
-            <TableContainer>
-              <Table
-                variant="striped"
-                colorScheme="gray"
-                style={{ tableLayout: 'auto' }}
-              >
-                <Thead>
-                  <Tr>
-                    <Th>Når</Th>
-                    {tableMetaData.fields.map((field) => (
-                      <Th key={field.id}>{field.name}</Th>
-                    ))}
-                  </Tr>
-                </Thead>
-                <Tbody>
-                  {filteredData.map((item: RecordType) => (
-                    <QuestionRow
-                      key={item.fields.ID}
-                      record={item}
-                      choices={choices}
-                      setFetchNewAnswers={setFetchNewAnswers}
-                      tableColumns={tableMetaData.fields}
-                      team={team}
-                    />
-                  ))}
-                </Tbody>
-              </Table>
-            </TableContainer>
+            <TableComponent
+              data={filteredData}
+              fields={tableMetaData.fields}
+              team={team}
+              choices={choices}
+            />
           </>
         ) : (
           'No data to display...'
@@ -235,7 +196,6 @@ export const MainTableComponent = () => {
       <MobileTableView
         filteredData={filteredData}
         choices={choices}
-        setFetchNewAnswers={setFetchNewAnswers}
         team={team}
         tableFilterProps={tableFilterProps}
         tableMetadata={tableMetaData}

--- a/frontend/beCompliant/src/routes.tsx
+++ b/frontend/beCompliant/src/routes.tsx
@@ -1,6 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom';
 import FrontPage from './pages/FrontPage';
-import { MainTableComponent } from './pages/Table';
+import { MainTableComponent } from './pages/TablePage';
 
 const router = createBrowserRouter([
   {

--- a/frontend/beCompliant/src/utils/sorter.tsx
+++ b/frontend/beCompliant/src/utils/sorter.tsx
@@ -1,4 +1,4 @@
-import { Fields, RecordType } from '../pages/Table';
+import { Fields, RecordType } from '../pages/TablePage';
 
 export const sortData = (
   data: RecordType[],


### PR DESCRIPTION
## Background

We want to create a more generic table component that can accept any set of columns. To achieve this we need tos separate the data handling from the data we want to display.

## Solution

This isn't an end goal, but I decided to do it gradually to avoid making too many changes in one go. It's easier if we discuss step by step.

* Refactored the name of the `Table` file to be `TablePage`. It's a route, that does a lot of data fetching, manipulation and presentation, it is not a pure component.
* Added the state of fetching new answers to the `useAnswersFetcher`, instead of simply passing it through `Table` -> `QuestionRow` -> `Answer`. This way Table has no state except its data.
* Created a new Table component that accepts the data to display, the fields that make up the table, as well as the team and choices. I would like to refactor such that the last two don't have to be passed, but is instead handled by the `Answer` component instead, and the team is a part of a hook. But, one step at a time.

Plus a lot of prettier, cuz I have lexiographic imports in my settings 🤠 