### PR TITLE
Sort TanStack table

### DIFF
--- a/frontend/beCompliant/src/components/Table.tsx
+++ b/frontend/beCompliant/src/components/Table.tsx
@@ -1,7 +1,16 @@
-import { Table, TableContainer, Tbody, Th, Thead, Tr } from '@kvib/react';
+import {
+  CellContext,
+  ColumnDef,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
 import { Choice, Field } from '../hooks/datafetcher';
 import { RecordType } from '../pages/TablePage';
-import { QuestionRow } from './questionRow/QuestionRow';
+import { DataTable } from './table/DataTable';
+import { DataTableCell } from './table/DataTableCell';
+import { DataTableHeader } from './table/DataTableHeader';
+import { Question } from './table/Question';
 
 type TableComponentProps = {
   data: RecordType[];
@@ -10,35 +19,24 @@ type TableComponentProps = {
   choices: Choice[];
 };
 
-export function TableComponent({
-  data,
-  fields,
-  choices,
-  team,
-}: TableComponentProps) {
-  return (
-    <TableContainer>
-      <Table variant="striped" colorScheme="gray">
-        <Thead>
-          <Tr>
-            <Th>Når</Th>
-            {fields.map((field) => (
-              <Th key={field.id}>{field.name}</Th>
-            ))}
-          </Tr>
-        </Thead>
-        <Tbody>
-          {data.map((item: RecordType) => (
-            <QuestionRow
-              key={item.fields.ID}
-              record={item}
-              choices={choices}
-              tableColumns={fields}
-              team={team}
-            />
-          ))}
-        </Tbody>
-      </Table>
-    </TableContainer>
-  );
+export function TableComponent({ data, fields }: TableComponentProps) {
+  const columns: ColumnDef<any, any>[] = fields.map((field) => ({
+    header: ({ column }) => (
+      <DataTableHeader column={column} header={field.name} />
+    ),
+    accessorKey: 'fields.' + field.name,
+    cell: ({ cell, getValue }: CellContext<any, any>) => (
+      <DataTableCell cell={cell}>
+        <Question value={getValue()} column={field} />
+      </DataTableCell>
+    ),
+  }));
+
+  const table = useReactTable({
+    columns: columns,
+    data: data,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+  return <DataTable table={table} />;
 }

--- a/frontend/beCompliant/src/components/Table.tsx
+++ b/frontend/beCompliant/src/components/Table.tsx
@@ -5,7 +5,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import { Choice, Field } from '../hooks/datafetcher';
+import { Field } from '../hooks/datafetcher';
 import { RecordType } from '../pages/TablePage';
 import { DataTable } from './table/DataTable';
 import { DataTableCell } from './table/DataTableCell';
@@ -15,8 +15,6 @@ import { Question } from './table/Question';
 type TableComponentProps = {
   data: RecordType[];
   fields: Field[];
-  team?: string;
-  choices: Choice[];
 };
 
 export function TableComponent({ data, fields }: TableComponentProps) {

--- a/frontend/beCompliant/src/components/Table.tsx
+++ b/frontend/beCompliant/src/components/Table.tsx
@@ -1,3 +1,4 @@
+import { Table, TableContainer, Tbody, Th, Thead, Tr } from '@kvib/react';
 import {
   CellContext,
   ColumnDef,
@@ -5,19 +6,20 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import { Field } from '../hooks/datafetcher';
+import { Choice, Field } from '../hooks/datafetcher';
 import { RecordType } from '../pages/TablePage';
+import { QuestionRow } from './questionRow/QuestionRow';
 import { DataTable } from './table/DataTable';
 import { DataTableCell } from './table/DataTableCell';
 import { DataTableHeader } from './table/DataTableHeader';
 import { Question } from './table/Question';
 
-type TableComponentProps = {
+type NewTableComponentProps = {
   data: RecordType[];
   fields: Field[];
 };
 
-export function TableComponent({ data, fields }: TableComponentProps) {
+export function NewTableComponent({ data, fields }: NewTableComponentProps) {
   const columns: ColumnDef<any, any>[] = fields.map((field) => ({
     header: ({ column }) => (
       <DataTableHeader column={column} header={field.name} />
@@ -37,4 +39,46 @@ export function TableComponent({ data, fields }: TableComponentProps) {
     getSortedRowModel: getSortedRowModel(),
   });
   return <DataTable table={table} />;
+}
+
+// delete this type and component when new table component using DataTable is finished,
+// the thing that is missing the handling of the Answer component.
+type TableComponentProps = {
+  data: RecordType[];
+  fields: Field[];
+  choices: Choice[];
+  team?: string;
+};
+
+export function TableComponent({
+  data,
+  fields,
+  choices,
+  team,
+}: TableComponentProps) {
+  return (
+    <TableContainer>
+      <Table variant="striped" colorScheme="gray">
+        <Thead>
+          <Tr>
+            <Th>Når</Th>
+            {fields.map((field) => (
+              <Th key={field.id}>{field.name}</Th>
+            ))}
+          </Tr>
+        </Thead>
+        <Tbody>
+          {data.map((item: RecordType) => (
+            <QuestionRow
+              key={item.fields.ID}
+              record={item}
+              choices={choices}
+              tableColumns={fields}
+              team={team}
+            />
+          ))}
+        </Tbody>
+      </Table>
+    </TableContainer>
+  );
 }

--- a/frontend/beCompliant/src/components/table/DataTableHeader.tsx
+++ b/frontend/beCompliant/src/components/table/DataTableHeader.tsx
@@ -1,12 +1,30 @@
-import {TableColumnHeaderProps, Th} from "@kvib/react";
-import {Column} from "@tanstack/react-table";
+import { Button, Icon, TableColumnHeaderProps, Th } from '@kvib/react';
+import { Column } from '@tanstack/react-table';
 
 interface Props<TData, TValue> extends TableColumnHeaderProps {
-    column: Column<TData, TValue>
-    header: string
+  column: Column<TData, TValue>;
+  header: string;
 }
 
-
-export function DataTableHeader<TData, TValue>({column, header, ...rest}: Props<TData, TValue>) {
-    return (<Th key={column.columnDef.id} {...rest}>{header}</Th>)
+export function DataTableHeader<TData, TValue>({
+  column,
+  header,
+  ...rest
+}: Props<TData, TValue>) {
+  return (
+    <Th key={column.columnDef.id} {...rest}>
+      <Button variant="ghost" onClick={column.getToggleSortingHandler()}>
+        {header}
+        {column.getIsSorted() && (
+          <Icon
+            icon={
+              column.getIsSorted() === 'desc'
+                ? 'arrow_drop_down'
+                : 'arrow_drop_up'
+            }
+          />
+        )}
+      </Button>
+    </Th>
+  );
 }

--- a/frontend/beCompliant/src/components/table/DataTableHeader.tsx
+++ b/frontend/beCompliant/src/components/table/DataTableHeader.tsx
@@ -15,15 +15,22 @@ export function DataTableHeader<TData, TValue>({
     <Th key={column.columnDef.id} {...rest}>
       <Button variant="ghost" onClick={column.getToggleSortingHandler()}>
         {header}
-        {column.getIsSorted() && (
-          <Icon
-            icon={
-              column.getIsSorted() === 'desc'
-                ? 'arrow_drop_down'
-                : 'arrow_drop_up'
-            }
-          />
-        )}
+        <Icon
+          aria-label={
+            column.getIsSorted() != false
+              ? column.getIsSorted() === 'desc'
+                ? 'Sortert synkende'
+                : 'Sortert stigende'
+              : 'Ikke sortert'
+          }
+          icon={
+            column.getIsSorted() != false
+              ? column.getIsSorted() === 'desc'
+                ? 'keyboard_arrow_down'
+                : 'keyboard_arrow_up'
+              : 'unfold_more'
+          }
+        />
       </Button>
     </Th>
   );

--- a/frontend/beCompliant/src/components/table/Question.tsx
+++ b/frontend/beCompliant/src/components/table/Question.tsx
@@ -8,14 +8,18 @@ type QuestionProps = {
 };
 
 export const Question = ({ value, column }: QuestionProps) => {
+  if (value == null) {
+    return <></>;
+  }
+
   const backgroundColor = column.options?.choices?.find(
     (choice) => choice.name === value
   )?.color;
   const backgroundColorHex = colorUtils.getHexForColor(
-    backgroundColor ?? 'none'
+    backgroundColor ?? 'grayLight1'
   );
   const useWhiteTextColor = colorUtils.shouldUseLightTextOnColor(
-    backgroundColor ?? 'none'
+    backgroundColor ?? 'grayLight1'
   );
   if (column.name === 'Svar') {
     // TODO add support for the Answer component
@@ -28,7 +32,8 @@ export const Question = ({ value, column }: QuestionProps) => {
     case 'singleSelect':
       return (
         <Tag
-          backgroundColor={backgroundColorHex ?? undefined}
+          colorScheme={undefined}
+          backgroundColor={backgroundColorHex ?? 'white'}
           textColor={useWhiteTextColor ? 'white' : 'black'}
         >
           {value}

--- a/frontend/beCompliant/src/components/table/Question.tsx
+++ b/frontend/beCompliant/src/components/table/Question.tsx
@@ -1,0 +1,39 @@
+import { Box, Tag } from '@kvib/react';
+import { Field } from '../../hooks/datafetcher';
+import colorUtils from '../../utils/colorUtils';
+
+type QuestionProps = {
+  value: any;
+  column: Field;
+};
+
+export const Question = ({ value, column }: QuestionProps) => {
+  const backgroundColor = column.options?.choices?.find(
+    (choice) => choice.name === value
+  )?.color;
+  const backgroundColorHex = colorUtils.getHexForColor(
+    backgroundColor ?? 'none'
+  );
+  const useWhiteTextColor = colorUtils.shouldUseLightTextOnColor(
+    backgroundColor ?? 'none'
+  );
+  if (column.name === 'Svar') {
+    // TODO add support for the Answer component
+    return <Box>{value}</Box>;
+  }
+
+  switch (column.type) {
+    case 'multipleSelects':
+      return <Box>{Array.isArray(value) ? value.join(', ') : value}</Box>;
+    case 'singleSelect':
+      return (
+        <Tag
+          backgroundColor={backgroundColorHex ?? undefined}
+          textColor={useWhiteTextColor ? 'white' : 'black'}
+        >
+          {value}
+        </Tag>
+      );
+  }
+  return <Box>{value}</Box>;
+};


### PR DESCRIPTION
## Background

We want to be able to sort our table, and it not being tighly bound to the current amount of column.

## Solution

* Added sorting of the column to the `DataColumnHeader` component. Allows you to sort ascending, descending and neither.
* Rewrite `TableComponent` to use `DataTable`, with generically defined column definitions. These definitions should probably be memoized in a hook, but one thing at a time.
* Created a `Question` component that _should_ be able to replace `QuestionRow` in the long run. This component looks at the data about the column to determine styling, instead of it having to be passed down as a part of the row data. The **only** missing feature here is to handle the `Answer` component, which is not incidentally the most complex. The biggest issue right now is that we actually can't see it, which makes it hard to replicate the behaviour as well.
* Fixed color handling if there is no data (or set color) in a column's data.

These changes are not in use. They will replace the old table _when_ we have solved the `Answer` issue. This is to avoid pushing new features without supporting all the old features.

## Demo

https://github.com/kartverket/regelrett/assets/47326965/0670a31e-6a2d-40c0-85a1-8531b224b6ab

