### PR TITLE
Datatable answer column

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -58,3 +58,5 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
 
 }
+
+tasks.register("prepareKotlinBuildScriptModel"){}

--- a/frontend/beCompliant/src/components/Table.tsx
+++ b/frontend/beCompliant/src/components/Table.tsx
@@ -1,4 +1,3 @@
-import { Table, TableContainer, Tbody, Th, Thead, Tr } from '@kvib/react';
 import {
   CellContext,
   ColumnDef,
@@ -7,21 +6,19 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import { Choice, Field } from '../hooks/datafetcher';
-import { RecordType } from '../pages/TablePage';
-import { QuestionRow } from './questionRow/QuestionRow';
+import { Field, RecordType } from '../types/tableTypes';
 import { DataTable } from './table/DataTable';
 import { DataTableCell } from './table/DataTableCell';
 import { DataTableHeader } from './table/DataTableHeader';
-import { Question } from './table/Question';
+import { TableCell } from './table/TableCell';
 
 type NewTableComponentProps = {
   data: RecordType[];
   fields: Field[];
 };
 
-export function NewTableComponent({ data, fields }: NewTableComponentProps) {
-  const columns: ColumnDef<any, any>[] = fields.map((field) => ({
+export function TableComponent({ data, fields }: NewTableComponentProps) {
+  const columns: ColumnDef<any, any>[] = fields.map((field, index) => ({
     header: ({ column }) => (
       <DataTableHeader column={column} header={field.name} />
     ),
@@ -31,9 +28,14 @@ export function NewTableComponent({ data, fields }: NewTableComponentProps) {
         ? row.fields[field.name].join(', ')
         : row.fields[field.name];
     },
-    cell: ({ cell, getValue }: CellContext<any, any>) => (
+    cell: ({ cell, getValue, row }: CellContext<any, any>) => (
       <DataTableCell cell={cell}>
-        <Question value={getValue()} column={field} />
+        <TableCell
+          value={getValue()}
+          column={field}
+          row={row}
+          answerable={index == 3}
+        />
       </DataTableCell>
     ),
   }));
@@ -46,46 +48,4 @@ export function NewTableComponent({ data, fields }: NewTableComponentProps) {
     getFilteredRowModel: getFilteredRowModel(),
   });
   return <DataTable table={table} />;
-}
-
-// delete this type and component when new table component using DataTable is finished,
-// the thing that is missing the handling of the Answer component.
-type TableComponentProps = {
-  data: RecordType[];
-  fields: Field[];
-  choices: Choice[];
-  team?: string;
-};
-
-export function TableComponent({
-  data,
-  fields,
-  choices,
-  team,
-}: TableComponentProps) {
-  return (
-    <TableContainer>
-      <Table variant="striped" colorScheme="gray">
-        <Thead>
-          <Tr>
-            <Th>Når</Th>
-            {fields.map((field) => (
-              <Th key={field.id}>{field.name}</Th>
-            ))}
-          </Tr>
-        </Thead>
-        <Tbody>
-          {data.map((item: RecordType) => (
-            <QuestionRow
-              key={item.fields.ID}
-              record={item}
-              choices={choices}
-              tableColumns={fields}
-              team={team}
-            />
-          ))}
-        </Tbody>
-      </Table>
-    </TableContainer>
-  );
 }

--- a/frontend/beCompliant/src/components/table/AnswerCell.tsx
+++ b/frontend/beCompliant/src/components/table/AnswerCell.tsx
@@ -86,7 +86,7 @@ export function AnswerCell({
         (choice) => choice.name === selectedAnswer
       );
       const selectedAnswerBackgroundColor = selectedChoice
-        ? colorUtils.getHexForColor(selectedChoice.color) ?? undefined
+        ? colorUtils.getHexForColor(selectedChoice.color)
         : undefined;
       return (
         <Stack spacing={2}>

--- a/frontend/beCompliant/src/components/table/AnswerCell.tsx
+++ b/frontend/beCompliant/src/components/table/AnswerCell.tsx
@@ -1,0 +1,119 @@
+import { Button, Input, Select, Stack, Textarea } from '@kvib/react';
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useSubmitAnswers } from '../../hooks/useSubmitAnswers';
+import { Choice } from '../../types/tableTypes';
+import colorUtils from '../../utils/colorUtils';
+import { Comment } from './Comment';
+
+type AnswerCellProps = {
+  value: any;
+  answerType: string;
+  questionId: string;
+  questionName: string;
+  comment: string;
+  choices?: Choice[];
+};
+
+export function AnswerCell({
+  value,
+  answerType,
+  questionId,
+  questionName,
+  comment,
+  choices,
+}: AnswerCellProps) {
+  const params = useParams();
+  const team = params.teamName;
+
+  const [selectedAnswer, setSelectedAnswer] = useState<string | undefined>(
+    value
+  );
+
+  const { mutate: submitAnswer } = useSubmitAnswers();
+
+  const handleInputAnswer = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    setSelectedAnswer(value);
+  };
+
+  const handleTextAreaAnswer = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const { value } = e.target;
+    setSelectedAnswer(value);
+  };
+
+  const submitTextAnswer = () => {
+    submitAnswer({
+      actor: 'Unknown',
+      questionId: questionId,
+      question: questionName,
+      Svar: selectedAnswer ?? '',
+      updated: '',
+      team: team,
+    });
+  };
+
+  const handleSelectionAnswer = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newAnswer: string = e.target.value;
+    if (newAnswer.length > 0) {
+      setSelectedAnswer(newAnswer);
+      submitAnswer({
+        actor: 'Unknown',
+        questionId: questionId,
+        question: questionName,
+        Svar: newAnswer,
+        updated: '',
+        team: team,
+      });
+    }
+  };
+
+  switch (answerType) {
+    case 'multilineText':
+      return (
+        <Stack spacing={2}>
+          <Textarea value={selectedAnswer} onChange={handleTextAreaAnswer} />
+          <Button onClick={submitTextAnswer}>Submit</Button>
+          <Comment comment={comment} questionId={questionId} team={team} />
+        </Stack>
+      );
+    case 'singleSelect':
+      if (!choices)
+        throw new Error(
+          `Failed to fetch choices for single selection answer cell`
+        );
+      const selectedChoice = choices.find(
+        (choice) => choice.name === selectedAnswer
+      );
+      const selectedAnswerBackgroundColor = selectedChoice
+        ? colorUtils.getHexForColor(selectedChoice.color) ?? undefined
+        : undefined;
+      return (
+        <Stack spacing={2}>
+          <Select
+            aria-label="select"
+            placeholder="Velg alternativ"
+            onChange={handleSelectionAnswer}
+            value={selectedAnswer}
+            width="170px"
+            style={{ backgroundColor: selectedAnswerBackgroundColor }}
+          >
+            {choices.map((choice) => (
+              <option value={choice.name} key={choice.id}>
+                {choice.name}
+              </option>
+            ))}
+          </Select>
+          <Comment comment={comment} questionId={questionId} team={team} />
+        </Stack>
+      );
+  }
+
+  return (
+    <Stack spacing={2}>
+      <Input value={selectedAnswer} onChange={handleInputAnswer} />
+      <Button onClick={submitTextAnswer}>Submit</Button>
+      <Comment comment={comment} questionId={questionId} team={team} />
+    </Stack>
+  );
+}

--- a/frontend/beCompliant/src/components/table/Comment.tsx
+++ b/frontend/beCompliant/src/components/table/Comment.tsx
@@ -1,0 +1,62 @@
+import { Button, Textarea } from '@kvib/react';
+import { useState } from 'react';
+import { useSubmitComment } from '../../hooks/useSubmitComment';
+
+type CommentProps = {
+  comment: string;
+  questionId: string;
+  team: string | undefined;
+};
+
+export function Comment({ comment, questionId, team }: CommentProps) {
+  const [selectedComment, setComment] = useState<string | undefined>(comment);
+  const [commentIsOpen, setCommentIsOpen] = useState<boolean>(comment !== '');
+  const { mutate: submitComment, isPending: isLoadingComment } =
+    useSubmitComment();
+
+  const handleCommentSubmit = () => {
+    if (selectedComment !== comment) {
+      submitComment(
+        {
+          actor: 'Unknown',
+          questionId: questionId,
+          team: team,
+          comment: selectedComment,
+          updated: '',
+        },
+        { onSuccess: () => setCommentIsOpen(false) }
+      );
+    }
+  };
+
+  const handleCommentState = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setComment(e.target.value);
+  };
+
+  return (
+    <>
+      <Button
+        onClick={() => setCommentIsOpen(!commentIsOpen)}
+        marginTop={2}
+        size="xs"
+        width="170px"
+      >
+        Kommentar
+      </Button>
+      {commentIsOpen && (
+        <>
+          <Textarea
+            marginBottom={2}
+            marginTop={2}
+            defaultValue={comment}
+            onChange={handleCommentState}
+            size="sm"
+          />
+          <Button onClick={handleCommentSubmit} isLoading={isLoadingComment}>
+            Lagre kommentar
+          </Button>
+        </>
+      )}
+    </>
+  );
+}

--- a/frontend/beCompliant/src/components/table/TableCell.tsx
+++ b/frontend/beCompliant/src/components/table/TableCell.tsx
@@ -1,0 +1,63 @@
+import { Box, Tag } from '@kvib/react';
+import { Row } from '@tanstack/react-table';
+import { Choice, Field, RecordType } from '../../types/tableTypes';
+import colorUtils from '../../utils/colorUtils';
+import { AnswerCell } from './AnswerCell';
+
+type QuestionProps = {
+  value: any;
+  column: Field;
+  row: Row<RecordType>;
+  answerable?: boolean;
+};
+
+export const TableCell = ({
+  value,
+  column,
+  row,
+  answerable = false,
+}: QuestionProps) => {
+  if (answerable) {
+    return (
+      <AnswerCell
+        value={value}
+        answerType={column.type}
+        questionId={row.original.fields.ID}
+        questionName={row.original.fields.Aktivitet}
+        comment={row.original.fields.comment ?? ''}
+        choices={column.options?.choices}
+      />
+    );
+  }
+
+  if (value == null) {
+    return <></>;
+  }
+  const backgroundColor = column.options?.choices?.find(
+    (choice: Choice) => choice.name === value
+  )?.color;
+  const backgroundColorHex = colorUtils.getHexForColor(
+    backgroundColor ?? 'grayLight1'
+  );
+  const useWhiteTextColor = colorUtils.shouldUseLightTextOnColor(
+    backgroundColor ?? 'grayLight1'
+  );
+
+  switch (column.type) {
+    case 'multipleSelects':
+      return <Box>{value}</Box>;
+    case 'singleSelect':
+      return (
+        <Tag
+          colorScheme={undefined}
+          backgroundColor={backgroundColorHex ?? 'white'}
+          textColor={useWhiteTextColor ? 'white' : 'black'}
+        >
+          {value}
+        </Tag>
+      );
+    default:
+      console.log(value, column.type);
+  }
+  return <Box>{value}</Box>;
+};

--- a/frontend/beCompliant/src/components/table/TableCell.tsx
+++ b/frontend/beCompliant/src/components/table/TableCell.tsx
@@ -4,7 +4,7 @@ import { Choice, Field, RecordType } from '../../types/tableTypes';
 import colorUtils from '../../utils/colorUtils';
 import { AnswerCell } from './AnswerCell';
 
-type QuestionProps = {
+type TableCellProps = {
   value: any;
   column: Field;
   row: Row<RecordType>;
@@ -16,7 +16,7 @@ export const TableCell = ({
   column,
   row,
   answerable = false,
-}: QuestionProps) => {
+}: TableCellProps) => {
   if (answerable) {
     return (
       <AnswerCell

--- a/frontend/beCompliant/src/components/table/TableCell.tsx
+++ b/frontend/beCompliant/src/components/table/TableCell.tsx
@@ -44,8 +44,6 @@ export const TableCell = ({
   );
 
   switch (column.type) {
-    case 'multipleSelects':
-      return <Box>{value}</Box>;
     case 'singleSelect':
       return (
         <Tag
@@ -56,8 +54,6 @@ export const TableCell = ({
           {value}
         </Tag>
       );
-    default:
-      console.log(value, column.type);
   }
   return <Box>{value}</Box>;
 };

--- a/frontend/beCompliant/src/pages/TablePage.tsx
+++ b/frontend/beCompliant/src/pages/TablePage.tsx
@@ -11,8 +11,8 @@ import { TableStatistics } from '../components/tableStatistics/TableStatistics';
 import { useFetchAnswers } from '../hooks/useFetchAnswers';
 import { useFetchComments } from '../hooks/useFetchComments';
 import { useFetchMetodeverk } from '../hooks/useFetchMetodeverk';
-import { filterData, updateToCombinedData } from '../utils/tablePageUtil';
 import { ActiveFilter, Fields, Option } from '../types/tableTypes';
+import { filterData, updateToCombinedData } from '../utils/tablePageUtil';
 
 export const MainTableComponent = () => {
   const params = useParams();
@@ -123,12 +123,7 @@ export const MainTableComponent = () => {
         tableMetadata={tableMetaData}
         tableSorterProps={tableSorterProps}
       />
-      <TableComponent
-        data={sortedData}
-        fields={tableMetaData.fields}
-        team={team}
-        choices={choices}
-      />
+      <TableComponent data={sortedData} fields={tableMetaData.fields} />
     </>
   );
 };


### PR DESCRIPTION
## Background

We have made a more generic table that uses the Tanstack library, but we haven't replaced the old one yet because it did not support the answer column.

## Solution

In this solution, I've went for an index-based way of figuring out which column is the answer column (3). This means that we can't have multiple answers per question, and it can't be moved around. **But** we can change the name of the column without it breaking!

* Renamed the `Question` component to instead be named `TableCell` which is a more descriptive name as it represents a single cell in the table. Extended it to accept a new prop to it that informs the component if the cell is "answerable", resulting in rendering a new `AnswerCell` instead of a static view.
* Created a new `AnswerCell` component, that renders different ways to answer the question depending on the type of the column. That means that it no longer needs to be a selection answer, but could be a free text answer instead. The backend is designed in such a way that we need to pass in the question name and Id as well, which I'm not a huge fan of as it makes it hard to decouple the Airtable format from the answer type.
* Refactored the comment part of an answer into its own `Comment` component that handles its own state.
* Replaced the old TableComponent with the new one and deleted the old one from the table cell. Still missing to fix the mobile view and deleting replaced components, but should be done in a separate PR.

(and a tiny fix for a build issue I had in the backend, by adding an empty task to the gradle file)

## Screen recording

https://github.com/kartverket/regelrett/assets/47326965/f8023a96-8948-402c-810c-53e6e733f26d
