### PR TITLE
Store hidden column state in localstorage

### DIFF
--- a/frontend/beCompliant/src/hooks/useLocalstorageState.ts
+++ b/frontend/beCompliant/src/hooks/useLocalstorageState.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-const useLocalstorageState = <T>(key: string, initialValue: T) => {
+export const useLocalstorageState = <T>(key: string, initialValue: T) => {
   const [value, setValue] = useState(() => {
     const storedValue = window.localStorage.getItem(key);
 
@@ -17,5 +17,3 @@ const useLocalstorageState = <T>(key: string, initialValue: T) => {
 
   return [value, setValue];
 };
-
-export default useLocalstorageState;

--- a/frontend/beCompliant/src/hooks/useLocalstorageState.ts
+++ b/frontend/beCompliant/src/hooks/useLocalstorageState.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+const useLocalstorageState = <T>(key: string, initialValue: T) => {
+  const [value, setValue] = useState(() => {
+    const storedValue = window.localStorage.getItem(key);
+
+    if (storedValue) {
+      return JSON.parse(storedValue);
+    } else {
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  }, [value, setValue]);
+
+  return [value, setValue];
+};
+
+export default useLocalstorageState;

--- a/frontend/beCompliant/src/pages/TablePage.tsx
+++ b/frontend/beCompliant/src/pages/TablePage.tsx
@@ -21,7 +21,7 @@ import { useFetchComments } from '../hooks/useFetchComments';
 import { useFetchMetodeverk } from '../hooks/useFetchMetodeverk';
 import { ActiveFilter, Fields, Option } from '../types/tableTypes';
 import { filterData, updateToCombinedData } from '../utils/tablePageUtil';
-import useLocalstorageState from '../hooks/useLocalstorageState';
+import { useLocalstorageState } from '../hooks/useLocalstorageState';
 
 export const MainTableComponent = () => {
   const params = useParams();

--- a/frontend/beCompliant/src/pages/TablePage.tsx
+++ b/frontend/beCompliant/src/pages/TablePage.tsx
@@ -9,11 +9,9 @@ import {
   TagLabel,
   useMediaQuery,
 } from '@kvib/react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { sortData } from '../utils/sorter';
-
 import { TableActions } from '../components/tableActions/TableActions';
-
 import { useParams } from 'react-router-dom';
 import MobileTableView from '../components/MobileTableView';
 import { TableComponent } from '../components/Table';
@@ -23,13 +21,16 @@ import { useFetchComments } from '../hooks/useFetchComments';
 import { useFetchMetodeverk } from '../hooks/useFetchMetodeverk';
 import { ActiveFilter, Fields, Option } from '../types/tableTypes';
 import { filterData, updateToCombinedData } from '../utils/tablePageUtil';
+import useLocalstorageState from '../hooks/useLocalstorageState';
 
 export const MainTableComponent = () => {
   const params = useParams();
   const team = params.teamName;
 
   const [activeFilters, setActiveFilters] = useState<ActiveFilter[]>([]);
-  const [columnVisibility, setColumnVisibility] = useState({});
+  const [columnVisibility, setColumnVisibility] = useLocalstorageState<
+    Record<string, boolean>
+  >('columnVisibility', {});
 
   const [fieldSortedBy, setFieldSortedBy] = useState<keyof Fields>(
     '' as keyof Fields
@@ -65,7 +66,7 @@ export const MainTableComponent = () => {
   };
 
   const unhideColumn = (name: string) => {
-    setColumnVisibility((prev) => ({
+    setColumnVisibility((prev: Record<string, boolean>) => ({
       ...prev,
       [name]: true,
     }));


### PR DESCRIPTION
## Background

Nå kan man skjule kolonner som ikke er interessante, men de nullstiller seg når siden laster inn på nytt. Da må man skjule de samme kolonnene hver gang man bruker tjenesten.

## Solution

Løsningen er å lagre tilstanden om skjulte kolonner i localstorage. Da blir de husket mellom hver session.