### PR TITLE
Create fronted env files for urls

### DIFF
--- a/frontend/beCompliant/.env
+++ b/frontend/beCompliant/.env
@@ -1,0 +1,2 @@
+VITE_BACKEND_URL=http://localhost:8080
+VITE_FRONTEND_URL=http://localhost:3000

--- a/frontend/beCompliant/.env.production
+++ b/frontend/beCompliant/.env.production
@@ -1,0 +1,2 @@
+VITE_BACKEND_URL=https://api.regelrett.atgcp1-dev.kartverket-intern.cloud
+VITE_FRONTEND_URL=https://regelrett.atgcp1-dev.kartverket-intern.cloud

--- a/frontend/beCompliant/.gitignore
+++ b/frontend/beCompliant/.gitignore
@@ -22,4 +22,3 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-.env

--- a/frontend/beCompliant/src/main.tsx
+++ b/frontend/beCompliant/src/main.tsx
@@ -14,9 +14,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <KvibProvider>
       <QueryClientProvider client={queryClient}>
         <App />
-        {import.meta.env.VITE_ENV === 'development' && (
-          <ReactQueryDevtools initialIsOpen={false} />
-        )}
+        {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
       </QueryClientProvider>
     </KvibProvider>
   </React.StrictMode>


### PR DESCRIPTION
## Background
The previous solution to inject the urls for the frontend and backend weren't working in production. Since the urls are not sensitive information they can be stored in .env files in the frontend folder.

## Solution
Create an .env file for local development and a .env file for dev/production. The .env files contain the urls for the frontend and backend service. Vite prioritizes .env files with `MODE` higher than standard .env files. Furthermore, Vite only loads .env files with modes conditionally. When running `npm run dev` only the .env file is loaded and if `npm run build` both files are loaded, but **.env.production** is prioritized. You can read more about how Vite configures and handles environment variables here https://vitejs.dev/guide/env-and-mode
