### PR TITLE
Add env variable to allowed hosts in cors config

### DIFF
--- a/backend/src/main/kotlin/no/bekk/plugins/Cors.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/Cors.kt
@@ -6,7 +6,7 @@ import io.ktor.server.plugins.cors.routing.*
 
 fun Application.configureCors() {
     install(CORS) {
-        allowHost("localhost:3000") // Allow requests from client-host [For development]
+        allowHost(System.getenv("FRONTEND_URL_HOST"))
         allowHeader(HttpHeaders.ContentType)
     }
 }

--- a/backend/src/main/kotlin/no/bekk/plugins/Cors.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/Cors.kt
@@ -7,6 +7,16 @@ import io.ktor.server.plugins.cors.routing.*
 fun Application.configureCors() {
     install(CORS) {
         allowHost(System.getenv("FRONTEND_URL_HOST"))
+        allowCredentials = true
+        allowSameOrigin = true
         allowHeader(HttpHeaders.ContentType)
+        allowHeader(HttpHeaders.Authorization)
+        allowHeader(HttpHeaders.AccessControlAllowOrigin)
+        allowMethod(HttpMethod.Get)
+        allowMethod(HttpMethod.Post)
+        allowMethod(HttpMethod.Put)
+        allowMethod(HttpMethod.Delete)
+        allowMethod(HttpMethod.Options)
+        allowMethod(HttpMethod.Patch)
     }
 }


### PR DESCRIPTION
## Background
Allowed cors headers only allowed localhost:3000. This needs to be an env variable to allow frontend host injected in dev environment. 

## Solution
Change hardcoded host to env variable.