### PR TITLE
Fix db config null handling

### DIFF
--- a/backend/src/main/kotlin/no/bekk/configuration/ConfigureDatabase.kt
+++ b/backend/src/main/kotlin/no/bekk/configuration/ConfigureDatabase.kt
@@ -4,11 +4,12 @@ import java.sql.DriverManager
 import com.typesafe.config.ConfigFactory
 
 fun getDatabaseConnection(): Connection {
+    val dbHost = getEnvVariableOrConfig("DB_HOST", "ktor.database.host")
     val dbName = getEnvVariableOrConfig("DB_NAME", "ktor.database.name")
     val dbUser = getEnvVariableOrConfig("DB_USER", "ktor.database.user")
     val dbPassword = getEnvVariableOrConfig("DB_PASSWORD", "ktor.database.password")
 
-    val databaseUrl = "jdbc:postgresql://localhost:5432/$dbName?currentSchema=regelrett"
+    val databaseUrl = "jdbc:postgresql://$dbHost:5432/$dbName?currentSchema=regelrett"
 
     return DriverManager.getConnection(databaseUrl, dbUser, dbPassword)
 }

--- a/backend/src/main/kotlin/no/bekk/configuration/ConfigureDatabase.kt
+++ b/backend/src/main/kotlin/no/bekk/configuration/ConfigureDatabase.kt
@@ -4,13 +4,18 @@ import java.sql.DriverManager
 import com.typesafe.config.ConfigFactory
 
 fun getDatabaseConnection(): Connection {
-    val config = ConfigFactory.load()
-    val databaseConfig = config.getConfig("ktor.database")
-    val dbName = System.getenv("DB_NAME") ?: databaseConfig.getString("name")
-    val dbUser = System.getenv("DB_USER") ?: databaseConfig.getString("user")
-    val dbPassword = System.getenv("DB_PASSWORD") ?: databaseConfig.getString("password")
+    val dbName = getEnvVariableOrConfig("DB_NAME", "ktor.database.name")
+    val dbUser = getEnvVariableOrConfig("DB_USER", "ktor.database.user")
+    val dbPassword = getEnvVariableOrConfig("DB_PASSWORD", "ktor.database.password")
 
     val databaseUrl = "jdbc:postgresql://localhost:5432/$dbName?currentSchema=regelrett"
 
     return DriverManager.getConnection(databaseUrl, dbUser, dbPassword)
+}
+
+fun getEnvVariableOrConfig(envVar: String, configPath: String): String {
+    val config = ConfigFactory.load()
+    return System.getenv(envVar)
+        ?: if (config.hasPath(configPath)) config.getString(configPath)
+        else throw IllegalArgumentException("$envVar or $configPath must be provided")
 }

--- a/backend/src/main/kotlin/no/bekk/plugins/Cors.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/Cors.kt
@@ -3,10 +3,11 @@ package no.bekk.plugins
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.plugins.cors.routing.*
+import no.bekk.configuration.getEnvVariableOrConfig
 
 fun Application.configureCors() {
     install(CORS) {
-        allowHost(System.getenv("FRONTEND_URL_HOST"))
+        allowHost(getEnvVariableOrConfig("FRONTEND_URL_HOST", "ktor.deployment.frontendUrlHost"))
         allowCredentials = true
         allowSameOrigin = true
         allowHeader(HttpHeaders.ContentType)

--- a/backend/src/main/kotlin/no/bekk/plugins/FlywayMigrate.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/FlywayMigrate.kt
@@ -6,12 +6,11 @@ import org.flywaydb.core.Flyway
 
 fun Application.runFlywayMigration() {
     val dbHost = getEnvVariableOrConfig("DB_HOST", "ktor.database.host")
-    val dbPort = getEnvVariableOrConfig("DB_PORT", "ktor.database.port")
     val dbName = getEnvVariableOrConfig("DB_NAME", "ktor.database.name")
     val dbUser = getEnvVariableOrConfig("DB_USER", "ktor.database.user")
     val dbPassword = getEnvVariableOrConfig("DB_PASSWORD", "ktor.database.password")
 
-    val dbUrl = "jdbc:postgresql://$dbHost:$dbPort/$dbName"
+    val dbUrl = "jdbc:postgresql://$dbHost:5432/$dbName"
 
     val flyway = Flyway.configure()
         .createSchemas(true)

--- a/backend/src/main/kotlin/no/bekk/plugins/FlywayMigrate.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/FlywayMigrate.kt
@@ -1,14 +1,15 @@
 package no.bekk.plugins
 
 import io.ktor.server.application.*
+import no.bekk.configuration.getEnvVariableOrConfig
 import org.flywaydb.core.Flyway
 
 fun Application.runFlywayMigration() {
-    val dbHost = System.getenv("DB_HOST") ?: environment.config.property("ktor.database.host").getString()
-    val dbPort = System.getenv("DB_PORT") ?: environment.config.property("ktor.database.port").getString()
-    val dbName = System.getenv("DB_NAME") ?: environment.config.property("ktor.database.name").getString()
-    val dbUser = System.getenv("DB_USER") ?: environment.config.property("ktor.database.user").getString()
-    val dbPassword = System.getenv("DB_PASSWORD") ?: environment.config.property("ktor.database.password").getString()
+    val dbHost = getEnvVariableOrConfig("DB_HOST", "ktor.database.host")
+    val dbPort = getEnvVariableOrConfig("DB_PORT", "ktor.database.port")
+    val dbName = getEnvVariableOrConfig("DB_NAME", "ktor.database.name")
+    val dbUser = getEnvVariableOrConfig("DB_USER", "ktor.database.user")
+    val dbPassword = getEnvVariableOrConfig("DB_PASSWORD", "ktor.database.password")
 
     val dbUrl = "jdbc:postgresql://$dbHost:$dbPort/$dbName"
 

--- a/backend/src/main/resources/application.conf.template
+++ b/backend/src/main/resources/application.conf.template
@@ -4,6 +4,7 @@ ktor {
     }
     deployment {
         port = 8080
+        frontendUrlHost = "localhost:3000"
     }
     database {
         host = "localhost"

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,6 +13,7 @@ services:
       - DB_NAME=kontrollere
       - DB_USER=insert_username_here
       - DB_PASSWORD=password_here
+      - AIRTABLE_ACCESS_TOKEN=insert_token_here
     build:
       context: ./backend
       dockerfile: Dockerfile


### PR DESCRIPTION
## Background
When running in SKIP the configuration files are not added since its has the template suffix. This caused a null point exception. Also, host was hardcoded which breaks docker compose.

## Solution
Created a funciton that checks if environment variables or config variables exist. In SKIP we still won't have config values because the files is not added by dockerfile. But as long as there exists ENV variables the function will not throw an exception. The config file should maybe be added in the future or at least be consistent with environment variables.
