### PR TITLE
Center team selection

### DIFF
--- a/frontend/beCompliant/src/components/layout/Page.tsx
+++ b/frontend/beCompliant/src/components/layout/Page.tsx
@@ -7,7 +7,6 @@ export function Page({ children, ...rest }: FlexProps) {
       direction="column"
       gap={{ base: '6', md: '8' }}
       py={'10'}
-      bg={'gray.50'}
       {...rest}
     >
       {children}

--- a/frontend/beCompliant/src/pages/FrontPage.tsx
+++ b/frontend/beCompliant/src/pages/FrontPage.tsx
@@ -15,7 +15,12 @@ const FrontPage = () => {
       >
         {teams.map((team) => {
           return (
-            <Link as={ReactRouterLink} to={`team/${team}`} key={team}>
+            <Link
+              as={ReactRouterLink}
+              to={`team/${team}`}
+              key={team}
+              colorScheme={'blue'}
+            >
               {team}
             </Link>
           );

--- a/frontend/beCompliant/src/pages/FrontPage.tsx
+++ b/frontend/beCompliant/src/pages/FrontPage.tsx
@@ -7,24 +7,28 @@ const FrontPage = () => {
 
   return (
     <Page gap={'4'} alignItems={'center'}>
-      <Heading>Dine team</Heading>
-      <VStack
-        align="start"
-        divider={<StackDivider />}
-        style={{ width: '40ch' }}
-      >
-        {teams.map((team) => {
-          return (
-            <Link
-              as={ReactRouterLink}
-              to={`team/${team}`}
-              key={team}
-              colorScheme={'blue'}
-            >
-              {team}
-            </Link>
-          );
-        })}
+      <VStack>
+        <Heading textAlign={'left'} width={'100%'}>
+          Dine team
+        </Heading>
+        <VStack
+          align="start"
+          divider={<StackDivider />}
+          style={{ width: '40ch' }}
+        >
+          {teams.map((team) => {
+            return (
+              <Link
+                as={ReactRouterLink}
+                to={`team/${team}`}
+                key={team}
+                colorScheme={'blue'}
+              >
+                {team}
+              </Link>
+            );
+          })}
+        </VStack>
       </VStack>
     </Page>
   );

--- a/frontend/beCompliant/src/pages/FrontPage.tsx
+++ b/frontend/beCompliant/src/pages/FrontPage.tsx
@@ -6,7 +6,7 @@ const FrontPage = () => {
   const teams = ['Team 1', 'Team 2', 'Team 3'];
 
   return (
-    <Page gap={'4'}>
+    <Page gap={'4'} alignItems={'center'}>
       <Heading>Dine team</Heading>
       <VStack
         align="start"

--- a/frontend/beCompliant/src/routes.tsx
+++ b/frontend/beCompliant/src/routes.tsx
@@ -4,16 +4,16 @@ import {
   Outlet,
 } from 'react-router-dom';
 import FrontPage from './pages/FrontPage';
-import { Header } from '@kvib/react';
+import { Header, Box } from '@kvib/react';
 import { ActivityPage } from './pages/ActivityPage';
 
 const router = createBrowserRouter([
   {
     element: (
-      <>
+      <Box backgroundColor={'gray.50'} height={'100vh'}>
         <Header logoLinkProps={{ as: ReactRouterLink, marginLeft: '2' }} />
         <Outlet />
-      </>
+      </Box>
     ),
     children: [
       {


### PR DESCRIPTION
## Background
![image](https://github.com/user-attachments/assets/3f194f5d-75ad-449f-8912-d9fecc37c74b)

The landingpage with links to each team was left aligned in another pr. The content should be centered. The title should also be centered, but the text should be left aligned. The colour on the links should also be blue to follow the new theme. Lastly the page content should take up 100 viewport height with the gray background colour for a cohesive design

## Solution
Mostly added some css styling to solve these issues. And added a new flexbox in the frontpage to center content and be able to left align title text

![image](https://github.com/user-attachments/assets/2f8b237b-eaa5-4193-8fc8-b112e8b90b27)
