### PR TITLE
Sort routing and separate the comment into own column

### DIFF
--- a/backend/src/main/kotlin/no/bekk/controllers/TableController.kt
+++ b/backend/src/main/kotlin/no/bekk/controllers/TableController.kt
@@ -2,15 +2,16 @@ package no.bekk.controllers
 
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import no.bekk.database.DatabaseRepository
 import no.bekk.domain.mapToQuestion
 import no.bekk.model.airtable.AirTableFieldType
 import no.bekk.model.airtable.mapAirTableFieldTypeToOptionalFieldType
 import no.bekk.services.AirTableService
 import no.bekk.model.internal.*
-import no.bekk.plugins.databaseRepository
 
 class TableController {
     private val airTableService = AirTableService()
+    private val databaseRepository = DatabaseRepository()
 
     private fun getAnswers(team: String?) = team?.let {
         databaseRepository.getAnswersByTeamIdFromDatabase(team)

--- a/backend/src/main/kotlin/no/bekk/database/DatabaseAnswer.kt
+++ b/backend/src/main/kotlin/no/bekk/database/DatabaseAnswer.kt
@@ -1,0 +1,13 @@
+package no.bekk.database
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DatabaseAnswer(
+    val actor: String,
+    val questionId: String,
+    val question: String,
+    val Svar: String? = null,
+    val updated: String,
+    val team: String?
+)

--- a/backend/src/main/kotlin/no/bekk/database/DatabaseComment.kt
+++ b/backend/src/main/kotlin/no/bekk/database/DatabaseComment.kt
@@ -1,0 +1,12 @@
+package no.bekk.database
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DatabaseComment(
+    val actor: String,
+    val questionId: String,
+    val comment: String,
+    val team: String?,
+    val updated: String
+)

--- a/backend/src/main/kotlin/no/bekk/database/DatabaseRepository.kt
+++ b/backend/src/main/kotlin/no/bekk/database/DatabaseRepository.kt
@@ -4,8 +4,6 @@ package no.bekk.database
 import no.bekk.configuration.getDatabaseConnection
 import java.sql.Connection
 import java.sql.SQLException
-import no.bekk.plugins.DatabaseAnswer
-import no.bekk.plugins.DatabaseComment
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.Table
 

--- a/backend/src/main/kotlin/no/bekk/domain/MetodeverkResponse.kt
+++ b/backend/src/main/kotlin/no/bekk/domain/MetodeverkResponse.kt
@@ -5,12 +5,12 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import no.bekk.database.DatabaseAnswer
+import no.bekk.database.DatabaseComment
 import no.bekk.model.airtable.AirTableFieldType
 import no.bekk.model.airtable.mapAirTableFieldTypeToAnswerType
 import no.bekk.model.airtable.mapAirTableFieldTypeToOptionalFieldType
 import no.bekk.model.internal.*
-import no.bekk.plugins.DatabaseAnswer
-import no.bekk.plugins.DatabaseComment
 import java.util.*
 
 @Serializable
@@ -24,6 +24,12 @@ data class Record(
     val id: String,
     val createdTime: String,
     val fields: JsonElement
+)
+
+@Serializable
+data class CombinedData(
+    val metodeverkData: JsonElement,
+    val metaData: JsonElement
 )
 
 fun Record.mapToQuestion(

--- a/backend/src/main/kotlin/no/bekk/plugins/Routing.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/Routing.kt
@@ -2,32 +2,18 @@ package no.bekk.plugins
 
 import io.ktor.http.*
 import io.ktor.server.application.*
-import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.encodeToJsonElement
-import no.bekk.services.AirTableService
-import no.bekk.database.DatabaseRepository
-import no.bekk.routes.questionRouting
-import no.bekk.routes.tableRouting
-import java.sql.SQLException
-
-val airTableService = AirTableService()
-val databaseRepository = DatabaseRepository()
+import no.bekk.routes.*
 
 fun Application.configureRouting() {
 
-    @Serializable
-    data class CombinedData(
-        val metodeverkData: JsonElement,
-        val metaData: JsonElement
-    )
-
     routing {
+        alleRouting()
+        answerRouting()
+        commentRouting()
+        kontrollereRouting()
+        metodeverkRouting()
         questionRouting()
         tableRouting()
     }
@@ -43,135 +29,4 @@ fun Application.configureRouting() {
             call.respondText("Health OK", ContentType.Text.Plain)
         }
     }
-
-    routing {
-        get("/metodeverk") {
-            val data = airTableService.fetchDataFromMetodeverk()
-            val meta = airTableService.fetchDataFromMetadata()
-            val metodeverkData = Json.encodeToJsonElement(data)
-            val metaData = Json.encodeToJsonElement(meta)
-            val combinedData = CombinedData(metodeverkData, metaData)
-            val combinedJson = Json.encodeToString(combinedData)
-            call.respondText(combinedJson, contentType = ContentType.Application.Json)
-        }
-    }
-
-    routing {
-        get("/alle") {
-            val data = airTableService.fetchDataFromAlle()
-            call.respondText(data.records.toString())
-        }
-    }
-
-    routing {
-        get("/{teamid}/kontrollere") {
-            val teamid = call.parameters["teamid"]
-            if (teamid != null) {
-                val data = airTableService.fetchDataFromMetodeverk()
-                val meta = airTableService.fetchDataFromMetadata()
-                val metodeverkData = Json.encodeToJsonElement(data)
-                val metaData = Json.encodeToJsonElement(meta)
-                val combinedData = CombinedData(metodeverkData, metaData)
-                val combinedJson = Json.encodeToString(combinedData)
-                call.respondText(combinedJson, contentType = ContentType.Application.Json)
-            } else {
-                call.respond(HttpStatusCode.BadRequest, "Id not found")
-            }
-        }
-    }
-
-    routing {
-        get("/answers") {
-            var answers = mutableListOf<DatabaseAnswer>()
-            try {
-                answers = databaseRepository.getAnswersFromDatabase()
-                val answersJson = Json.encodeToString(answers)
-                call.respondText(answersJson, contentType = ContentType.Application.Json)
-            } catch (e: SQLException) {
-                e.printStackTrace()
-                call.respond(HttpStatusCode.InternalServerError, "Error fetching answers")
-            }
-        }
-    }
-
-    routing {
-        get("/answers/{teamId}") {
-            val teamId = call.parameters["teamId"]
-            var answers = mutableListOf<DatabaseAnswer>()
-            if (teamId != null) {
-                answers = databaseRepository.getAnswersByTeamIdFromDatabase(teamId)
-                val answersJson = Json.encodeToString(answers)
-                call.respondText(answersJson, contentType = ContentType.Application.Json)
-            } else {
-                call.respond(HttpStatusCode.BadRequest, "Team id not found")
-            }
-        }
-    }
-
-    routing {
-        post("/answer") {
-            val answerRequestJson = call.receiveText()
-            val answerRequest = Json.decodeFromString<DatabaseAnswer>(answerRequestJson)
-            val answer = DatabaseAnswer(
-                question = answerRequest.question,
-                questionId = answerRequest.questionId,
-                Svar = answerRequest.Svar,
-                actor = answerRequest.actor,
-                updated = "",
-                team = answerRequest.team,
-            )
-            databaseRepository.getAnswerFromDatabase(answer)
-            call.respondText("Answer was successfully submitted.")
-        }
-    }
-
-    routing {
-        post("/comments") {
-            val commentRequestJson = call.receiveText()
-            val databaseCommentRequest = Json.decodeFromString<DatabaseComment>(commentRequestJson)
-            val databaseComment = DatabaseComment(
-                questionId = databaseCommentRequest.questionId,
-                comment = databaseCommentRequest.comment,
-                team = databaseCommentRequest.team,
-                updated = "",
-                actor = databaseCommentRequest.actor,
-            )
-            databaseRepository.getCommentFromDatabase(databaseComment)
-            call.respondText("Comment was successfully submitted.")
-        }
-    }
-
-    routing {
-        get("/comments/{teamId}") {
-            val teamId = call.parameters["teamId"]
-            val databaseComments: MutableList<DatabaseComment>
-            if (teamId != null) {
-                databaseComments = databaseRepository.getCommentsByTeamIdFromDatabase(teamId)
-                val commentsJson = Json.encodeToString(databaseComments)
-                call.respondText(commentsJson, contentType = ContentType.Application.Json)
-            } else {
-                call.respond(HttpStatusCode.BadRequest, "Team id not found")
-            }
-        }
-    }
-
 }
-
-@Serializable
-data class DatabaseAnswer(
-    val actor: String,
-    val questionId: String,
-    val question: String,
-    val Svar: String? = null,
-    val updated: String,
-    val team: String?
-)
-
-@Serializable
-data class DatabaseComment(
-    val actor: String,
-    val questionId: String,
-    val comment: String,
-    val team: String?,
-    val updated: String
-)

--- a/backend/src/main/kotlin/no/bekk/routes/AlleRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/AlleRouting.kt
@@ -1,0 +1,16 @@
+package no.bekk.routes
+
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import no.bekk.services.AirTableService
+
+fun Route.alleRouting() {
+
+    val airTableService = AirTableService()
+
+    get("/alle") {
+        val data = airTableService.fetchDataFromAlle()
+        call.respondText(data.records)
+    }
+}

--- a/backend/src/main/kotlin/no/bekk/routes/AnswerRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/AnswerRouting.kt
@@ -1,0 +1,53 @@
+package no.bekk.routes
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import no.bekk.database.DatabaseAnswer
+import no.bekk.database.DatabaseRepository
+import java.sql.SQLException
+
+fun Route.answerRouting() {
+    val databaseRepository = DatabaseRepository()
+
+    post("/answer") {
+        val answerRequestJson = call.receiveText()
+        val answerRequest = Json.decodeFromString<DatabaseAnswer>(answerRequestJson)
+        val answer = DatabaseAnswer(
+            question = answerRequest.question,
+            questionId = answerRequest.questionId,
+            Svar = answerRequest.Svar,
+            actor = answerRequest.actor,
+            updated = "",
+            team = answerRequest.team,
+        )
+        databaseRepository.getAnswerFromDatabase(answer)
+        call.respondText("Answer was successfully submitted.")
+    }
+
+    get("/answers") {
+        try {
+            val answers = databaseRepository.getAnswersFromDatabase()
+            val answersJson = Json.encodeToString(answers)
+            call.respondText(answersJson, contentType = ContentType.Application.Json)
+        } catch (e: SQLException) {
+            e.printStackTrace()
+            call.respond(HttpStatusCode.InternalServerError, "Error fetching answers")
+        }
+    }
+
+    get("/answers/{teamId}") {
+        val teamId = call.parameters["teamId"]
+        if (teamId != null) {
+            val answers = databaseRepository.getAnswersByTeamIdFromDatabase(teamId)
+            val answersJson = Json.encodeToString(answers)
+            call.respondText(answersJson, contentType = ContentType.Application.Json)
+        } else {
+            call.respond(HttpStatusCode.BadRequest, "Team id not found")
+        }
+    }
+}

--- a/backend/src/main/kotlin/no/bekk/routes/CommentRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/CommentRouting.kt
@@ -1,0 +1,41 @@
+package no.bekk.routes
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import no.bekk.database.DatabaseComment
+import no.bekk.database.DatabaseRepository
+
+fun Route.commentRouting() {
+    val databaseRepository = DatabaseRepository()
+
+    post("/comments") {
+        val commentRequestJson = call.receiveText()
+        val databaseCommentRequest = Json.decodeFromString<DatabaseComment>(commentRequestJson)
+        val databaseComment = DatabaseComment(
+            questionId = databaseCommentRequest.questionId,
+            comment = databaseCommentRequest.comment,
+            team = databaseCommentRequest.team,
+            updated = "",
+            actor = databaseCommentRequest.actor,
+        )
+        databaseRepository.getCommentFromDatabase(databaseComment)
+        call.respondText("Comment was successfully submitted.")
+    }
+
+    get("/comments/{teamId}") {
+        val teamId = call.parameters["teamId"]
+        val databaseComments: MutableList<DatabaseComment>
+        if (teamId != null) {
+            databaseComments = databaseRepository.getCommentsByTeamIdFromDatabase(teamId)
+            val commentsJson = Json.encodeToString(databaseComments)
+            call.respondText(commentsJson, contentType = ContentType.Application.Json)
+        } else {
+            call.respond(HttpStatusCode.BadRequest, "Team id not found")
+        }
+    }
+}

--- a/backend/src/main/kotlin/no/bekk/routes/KontrollereRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/KontrollereRouting.kt
@@ -1,0 +1,30 @@
+package no.bekk.routes
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+import no.bekk.domain.CombinedData
+import no.bekk.services.AirTableService
+
+fun Route.kontrollereRouting() {
+    val airTableService = AirTableService()
+
+    get("/{teamid}/kontrollere") {
+        val teamid = call.parameters["teamid"]
+        if (teamid != null) {
+            val data = airTableService.fetchDataFromMetodeverk()
+            val meta = airTableService.fetchDataFromMetadata()
+            val metodeverkData = Json.encodeToJsonElement(data)
+            val metaData = Json.encodeToJsonElement(meta)
+            val combinedData = CombinedData(metodeverkData, metaData)
+            val combinedJson = Json.encodeToString(combinedData)
+            call.respondText(combinedJson, contentType = ContentType.Application.Json)
+        } else {
+            call.respond(HttpStatusCode.BadRequest, "Id not found")
+        }
+    }
+}

--- a/backend/src/main/kotlin/no/bekk/routes/MetodeverkRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/MetodeverkRouting.kt
@@ -1,0 +1,26 @@
+package no.bekk.routes
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+import no.bekk.domain.CombinedData
+import no.bekk.services.AirTableService
+
+fun Route.metodeverkRouting() {
+
+    val airTableService = AirTableService()
+
+    get("/metodeverk") {
+        val data = airTableService.fetchDataFromMetodeverk()
+        val meta = airTableService.fetchDataFromMetadata()
+        val metodeverkData = Json.encodeToJsonElement(data)
+        val metaData = Json.encodeToJsonElement(meta)
+        val combinedData = CombinedData(metodeverkData, metaData)
+        val combinedJson = Json.encodeToString(combinedData)
+        call.respondText(combinedJson, contentType = ContentType.Application.Json)
+    }
+}

--- a/frontend/beCompliant/src/components/Table.tsx
+++ b/frontend/beCompliant/src/components/Table.tsx
@@ -6,13 +6,15 @@ import {
   getSortedRowModel,
   useReactTable,
 } from '@tanstack/react-table';
+import { useParams } from 'react-router-dom';
+import { useColumnVisibility } from '../hooks/useColumnVisibility';
+import { Field, RecordType } from '../types/tableTypes';
+import { formatDateTime } from '../utils/formatTime';
+import { Comment } from './table/Comment';
 import { DataTable } from './table/DataTable';
 import { DataTableCell } from './table/DataTableCell';
 import { DataTableHeader } from './table/DataTableHeader';
 import { TableCell } from './table/TableCell';
-import { Field, RecordType } from '../types/tableTypes';
-import { formatDateTime } from '../utils/formatTime';
-import { useColumnVisibility } from '../hooks/useColumnVisibility';
 
 type TableComponentProps = {
   data: RecordType[];
@@ -20,6 +22,9 @@ type TableComponentProps = {
 };
 
 export function TableComponent({ data, fields }: TableComponentProps) {
+  const params = useParams();
+  const team = params.teamName;
+
   const [
     columnVisibility,
     setColumnVisibility,
@@ -80,6 +85,40 @@ export function TableComponent({ data, fields }: TableComponentProps) {
       </DataTableCell>
     ),
   });
+
+  const commentColumn: ColumnDef<any, any> = {
+    header: ({ column }) => {
+      return (
+        <DataTableHeader
+          column={column}
+          header={'Kommentar'}
+          setColumnVisibility={setColumnVisibility}
+        />
+      );
+    },
+    id: 'Kommentar',
+    accessorFn: (row) => row.fields['comment'] ?? '',
+    cell: ({ cell, getValue, row }: CellContext<any, any>) => (
+      <DataTableCell cell={cell}>
+        <Comment
+          comment={getValue()}
+          questionId={row.original.fields.ID}
+          team={team}
+        />
+      </DataTableCell>
+    ),
+  };
+
+  // Find the index of the column where field.name is "Svar"
+  const svarIndex = columns.findIndex((column) => column.id === 'Svar');
+
+  // If the column is found, inject the new column right after it
+  if (svarIndex !== -1) {
+    columns.splice(svarIndex + 1, 0, commentColumn);
+  } else {
+    // If not found, push it at the end (or handle it differently as needed)
+    columns.push(commentColumn);
+  }
 
   const table = useReactTable({
     columns: columns,

--- a/frontend/beCompliant/src/components/table/AnswerCell.tsx
+++ b/frontend/beCompliant/src/components/table/AnswerCell.tsx
@@ -102,7 +102,6 @@ export function AnswerCell({
               </option>
             ))}
           </Select>
-          <Comment comment={comment} questionId={questionId} team={team} />
         </Stack>
       );
   }
@@ -113,7 +112,6 @@ export function AnswerCell({
       <Button colorScheme={'blue'} onClick={submitTextAnswer}>
         Submit
       </Button>
-      <Comment comment={comment} questionId={questionId} team={team} />
     </Stack>
   );
 }

--- a/frontend/beCompliant/src/components/table/Comment.tsx
+++ b/frontend/beCompliant/src/components/table/Comment.tsx
@@ -10,22 +10,18 @@ type CommentProps = {
 
 export function Comment({ comment, questionId, team }: CommentProps) {
   const [selectedComment, setComment] = useState<string | undefined>(comment);
-  const [commentIsOpen, setCommentIsOpen] = useState<boolean>(comment !== '');
   const { mutate: submitComment, isPending: isLoadingComment } =
     useSubmitComment();
 
   const handleCommentSubmit = () => {
     if (selectedComment !== comment) {
-      submitComment(
-        {
-          actor: 'Unknown',
-          questionId: questionId,
-          team: team,
-          comment: selectedComment,
-          updated: '',
-        },
-        { onSuccess: () => setCommentIsOpen(false) }
-      );
+      submitComment({
+        actor: 'Unknown',
+        questionId: questionId,
+        team: team,
+        comment: selectedComment,
+        updated: '',
+      });
     }
   };
 
@@ -35,33 +31,20 @@ export function Comment({ comment, questionId, team }: CommentProps) {
 
   return (
     <>
-      <Button
-        onClick={() => setCommentIsOpen(!commentIsOpen)}
+      <Textarea
+        marginBottom={2}
         marginTop={2}
-        size="xs"
-        width="170px"
+        defaultValue={comment}
+        onChange={handleCommentState}
+        size="sm"
+      />
+      <Button
         colorScheme={'blue'}
+        onClick={handleCommentSubmit}
+        isLoading={isLoadingComment}
       >
-        Kommentar
+        Lagre kommentar
       </Button>
-      {commentIsOpen && (
-        <>
-          <Textarea
-            marginBottom={2}
-            marginTop={2}
-            defaultValue={comment}
-            onChange={handleCommentState}
-            size="sm"
-          />
-          <Button
-            colorScheme={'blue'}
-            onClick={handleCommentSubmit}
-            isLoading={isLoadingComment}
-          >
-            Lagre kommentar
-          </Button>
-        </>
-      )}
     </>
   );
 }


### PR DESCRIPTION
## Background

This PR became a combo of backend refactoring and frontend featuring. We wanted to sort all the routes into separate files, and also have the Comment field as its own column in the table.

## Solution

* Made own files for all route domains except the basic health endpoint stuff. Not sure if all of the ones are necessary/useful but decided to not remove any in this PR, just refactor.
* Moved data classes used in serialization for specific routes to domain specific folders.
* Moved the comment data into its own column, and place it after the answer column if possible. Now it's possible to hide comments as any other column, and they'll always be visible if not. This solution is hard-coded and frankly not pretty, another good reason to use the abstraction layer previously introduced in the backend.

## Screenshots

![image](https://github.com/user-attachments/assets/e83cc435-b8d4-4f4a-b1ee-3168d4fd0609)
