### PR TITLE
Reduce logging

### DIFF
--- a/backend/src/main/resources/logback.xml
+++ b/backend/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
             <pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
-    <root level="trace">
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
     <logger name="org.eclipse.jetty" level="INFO"/>


### PR DESCRIPTION
## Background

We were logging a lot as we logged every trace

## Solution

Change logging level to info, which hopefully will give more relevant logs, such as errors and warnings
