### PR TITLE
Rearrange combine function such that answer overwrites comment when merging

### DIFF
--- a/frontend/beCompliant/src/utils/tablePageUtil.ts
+++ b/frontend/beCompliant/src/utils/tablePageUtil.ts
@@ -48,8 +48,8 @@ export const updateToCombinedData = (
       ...item,
       fields: {
         ...item.fields,
-        ...answersMatch,
         ...commentsMatch,
+        ...answersMatch,
         Status: answersMatch?.Svar ? 'Utfylt' : 'Ikke utfylt',
       },
     };


### PR DESCRIPTION
## Background
The "Når" or updated column in the table only updated when comments were submitted and not answers. We thought that the status of the answers is the most important and the updated value of the answer should dictate the value of the "Når"/updated column.


## Solution
After some discussion in the team we landed on only showing the updated value of the answer is the most important. The old solution combined the data from the backend with comments and answers. Both of these data models have the updated field with individual values. When combining the data, since the comments were the last in the function the comment updated value would overwrite the answer updated value if it existed. For now a simple solution is to switch the logic such that the answer data will, if both are present, overwrite the comment updated value. In the future a more complex solution should possibly implemented. Either showing both values, or perhaps showing the newest value. 