### PR TITLE
Frontend internal model

### DIFF
--- a/backend/src/main/kotlin/no/bekk/controllers/TableController.kt
+++ b/backend/src/main/kotlin/no/bekk/controllers/TableController.kt
@@ -23,13 +23,13 @@ class TableController {
         databaseRepository.getCommentsByTeamIdFromDatabase(it)
     } ?: mutableListOf()
 
-    suspend fun getTableFromAirTable(tableId: String, team: String?): Table {
+    private suspend fun getTableFromAirTable(tableInternalId: String, tableReferenceId: String, team: String?): Table {
         val metodeverkData = airTableService.fetchDataFromMetodeverk()
         val airTableMetadata = airTableService.fetchDataFromMetadata()
 
-        val tableMetadata = airTableMetadata.tables.first { it.id == tableId }
+        val tableMetadata = airTableMetadata.tables.first { it.id == tableReferenceId }
         if (tableMetadata.fields == null) {
-            throw IllegalArgumentException("Table $tableId has no fields")
+            throw IllegalArgumentException("Table $tableReferenceId has no fields")
         }
 
         val answers = getAnswers(team)
@@ -52,10 +52,39 @@ class TableController {
         }
 
         return Table(
-            id = tableMetadata.id,
+            id = tableInternalId,
             name = tableMetadata.name,
             fields = fields,
             records = questions
         )
+    }
+
+    suspend fun getTable(tableId: String, team: String?): Table {
+        val (tableReferenceId, tableSource) = tableMapping(tableId)
+        when (tableSource) {
+            TableSources.AIRTABLE ->
+                return getTableFromAirTable(
+                    tableInternalId = tableId,
+                    tableReferenceId = tableReferenceId,
+                    team = team
+                )
+            else -> throw IllegalArgumentException("Table source $tableSource not supported")
+        }
+    }
+}
+
+enum class TableSources {
+    AIRTABLE
+}
+
+data class TableReference(
+    val id: String,
+    val source: TableSources
+)
+
+fun tableMapping(tableId: String): TableReference {
+    return when (tableId) {
+        "570e9285-3228-4396-b82b-e9752e23cd73" -> TableReference("tblLZbUqA0XnUgC2v", TableSources.AIRTABLE)
+        else -> throw IllegalArgumentException("Table $tableId not found")
     }
 }

--- a/backend/src/main/kotlin/no/bekk/model/internal/Question.kt
+++ b/backend/src/main/kotlin/no/bekk/model/internal/Question.kt
@@ -14,7 +14,7 @@ data class Question(
     val question: String,
     val metadata: QuestionMetadata,
     val answers: List<Answer>,
-    val comments: List<Comment>? = null,
+    val comments: List<Comment>,
     val updated: String?,
 )
 

--- a/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
@@ -1,5 +1,6 @@
 package no.bekk.routes
 
+import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -7,12 +8,20 @@ import no.bekk.controllers.TableController
 
 fun Route.tableRouting() {
     val tableController = TableController()
-    route("/airtable") {
+    route("/table") {
         get("/{tableId}") {
-            val tableId = call.parameters["tableId"] ?: throw IllegalArgumentException("TableId is required")
+            val tableId = call.parameters["tableId"]
+            if (tableId == null) {
+                call.respond(HttpStatusCode.BadRequest,"TableId is missing")
+                return@get
+            }
             val team = call.request.queryParameters["team"]
-            val table = tableController.getTableFromAirTable(tableId, team)
-            call.respond(table)
+            try {
+                val table = tableController.getTable(tableId, team)
+                call.respond(table)
+            } catch (e: IllegalArgumentException) {
+                call.respond(HttpStatusCode.InternalServerError, "An error occured: ${e.message}")
+            }
         }
     }
 }

--- a/frontend/beCompliant/src/api/apiConfig.ts
+++ b/frontend/beCompliant/src/api/apiConfig.ts
@@ -4,6 +4,7 @@ const PATH_ANSWER = '/answer';
 const PATH_COMMENTS = '/comments';
 const PATH_METODEVERK = '/metodeverk';
 const PATH_KONTROLLERE = '/kontrollere';
+const PATH_TABLE = '/table';
 
 // Base URLs
 
@@ -42,5 +43,14 @@ export const apiConfig = {
   kontrollere: {
     queryKey: (team?: string) => [PATH_KONTROLLERE, team],
     url: (team?: string) => `${API_URL_BASE}/${team}${PATH_KONTROLLERE}`,
+  },
+  table: {
+    queryKey: (tableId: string) => [PATH_TABLE, tableId],
+    url: (tableId: string) => `${API_URL_BASE}${PATH_TABLE}/${tableId}`,
+    withTeam: {
+      queryKey: (tableId: string, team: string) => [PATH_TABLE, tableId, team],
+      url: (tableId: string, team: string) =>
+        `${API_URL_BASE}${PATH_TABLE}/${tableId}?team=${team}`,
+    },
   },
 } as const;

--- a/frontend/beCompliant/src/api/types.ts
+++ b/frontend/beCompliant/src/api/types.ts
@@ -1,0 +1,68 @@
+export enum AnswerType {
+  SELECT_MULTIPLE = 'SELECT_MULTIPLE',
+  SELECT_SINGLE = 'SELECT_SINGLE',
+  TEXT_MULTI_LINE = 'TEXT_MULTI_LINE',
+  TEXT_SINGLE_LINE = 'TEXT_SINGLE_LINE',
+}
+
+export type Answer = {
+  actor: string;
+  answer: string;
+  quesiton: string;
+  questionId: string;
+  team: string | null;
+  updated: Date;
+};
+
+export type AnswerMetadata = {
+  type: AnswerType;
+  options: string[] | null;
+};
+
+export type Comment = {
+  actor: string;
+  comment: string;
+  questionId: string;
+  team: string | undefined;
+  updated: Date;
+};
+
+export type Field = {
+  options: string[] | null;
+  name: string;
+  type: OptionalFieldType;
+};
+
+export enum OptionalFieldType {
+  OPTION_MULTIPLE = 'OPTION_MULTIPLE',
+  OPTION_SINGLE = 'OPTION_SINGLE',
+  TEXT = 'TEXT',
+}
+
+export type OptionalField = {
+  key: string;
+  options: string[] | null;
+  type: OptionalFieldType;
+  value: string[];
+};
+
+export type Question = {
+  answers: Answer[];
+  comments: Comment[];
+  id: string;
+  metadata: QuestionMetadata;
+  question: string;
+  updated: string | null;
+};
+
+export type QuestionMetadata = {
+  answerMetadata: AnswerMetadata;
+  optionalFields: OptionalField[] | null;
+};
+
+export type Table = {
+  id: string;
+  fields: Field[];
+  name: string;
+  records: Question[];
+};

--- a/frontend/beCompliant/src/hooks/useFetchTable.ts
+++ b/frontend/beCompliant/src/hooks/useFetchTable.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import { axiosFetch } from '../api/Fetch';
+import { apiConfig } from '../api/apiConfig';
+import { Table } from '../api/types';
+
+export function useFetchTable(tableId: string, team?: string) {
+  const queryKeys = team
+    ? apiConfig.table.withTeam.queryKey(tableId, team)
+    : apiConfig.table.queryKey(tableId);
+  const url = team
+    ? apiConfig.table.withTeam.url(tableId, team)
+    : apiConfig.table.url(tableId);
+
+  return useQuery({
+    queryKey: queryKeys,
+    queryFn: () =>
+      axiosFetch<Table>({ url: url }).then((response) => response.data),
+  });
+}


### PR DESCRIPTION
## Background

We have created a new internal model in the backend that the data sources should be mapped to before it is served to the frontend. This way we have more control over the data the frontend receives, and are less tangled into Airtable specific rarities.

Now we want to fetch this data as a model in the frontend.

## Solution

Refactored the backend a bit because we don't actually want the frontend to have any relationship with the datasources we are fetching from (such as Airtable), so I scrubbe the source away from the endpoint. Also, creating a semi-mapping between an internal schema id and the Airtable id, such that we know which service to use to fetch the data in case we have multiple data providers.

In the frontend I have created types for all the data that we get from the backend, these are mirrors of the data classes found in the `internal` folder in the backend. The data is fetchable using a new hook, which required some expanding of the `apiConfig`.

