### PR TITLE
Comment edit mode

### DIFF
--- a/backend/src/main/kotlin/no/bekk/database/DatabaseRepository.kt
+++ b/backend/src/main/kotlin/no/bekk/database/DatabaseRepository.kt
@@ -244,4 +244,21 @@ class DatabaseRepository {
             return statement.executeUpdate()
         }
     }
+
+    fun deleteCommentFromDatabase(comment: DatabaseComment) {
+        val connection = getDatabaseConnection()
+        try {
+            connection.use { conn ->
+                val statement = conn.prepareStatement(
+                    "DELETE FROM comments WHERE question_id = ? AND team = ?"
+                )
+                statement.setString(1, comment.questionId)
+                statement.setString(2, comment.team)
+                statement.executeUpdate()
+            }
+        } catch (e: SQLException) {
+            e.printStackTrace()
+            throw RuntimeException("Error deleting comment from database", e)
+        }
+    }
 }

--- a/backend/src/main/kotlin/no/bekk/routes/CommentRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/CommentRouting.kt
@@ -42,14 +42,7 @@ fun Route.commentRouting() {
     delete("/comments") {
         val commentRequestJson = call.receiveText()
         val databaseCommentRequest = Json.decodeFromString<DatabaseComment>(commentRequestJson)
-        val databaseComment = DatabaseComment(
-            questionId = databaseCommentRequest.questionId,
-            comment = databaseCommentRequest.comment,
-            team = databaseCommentRequest.team,
-            updated = "",
-            actor = databaseCommentRequest.actor,
-        )
-        databaseRepository.deleteCommentFromDatabase(databaseComment)
+        databaseRepository.deleteCommentFromDatabase(databaseCommentRequest)
         call.respondText("Comment was successfully deleted.")
     }
 }

--- a/backend/src/main/kotlin/no/bekk/routes/CommentRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/CommentRouting.kt
@@ -38,4 +38,18 @@ fun Route.commentRouting() {
             call.respond(HttpStatusCode.BadRequest, "Team id not found")
         }
     }
+
+    delete("/comments") {
+        val commentRequestJson = call.receiveText()
+        val databaseCommentRequest = Json.decodeFromString<DatabaseComment>(commentRequestJson)
+        val databaseComment = DatabaseComment(
+            questionId = databaseCommentRequest.questionId,
+            comment = databaseCommentRequest.comment,
+            team = databaseCommentRequest.team,
+            updated = "",
+            actor = databaseCommentRequest.actor,
+        )
+        databaseRepository.deleteCommentFromDatabase(databaseComment)
+        call.respondText("Comment was successfully deleted.")
+    }
 }

--- a/frontend/beCompliant/src/components/table/AnswerCell.tsx
+++ b/frontend/beCompliant/src/components/table/AnswerCell.tsx
@@ -4,14 +4,12 @@ import { useParams } from 'react-router-dom';
 import { useSubmitAnswers } from '../../hooks/useSubmitAnswers';
 import { Choice } from '../../types/tableTypes';
 import colorUtils from '../../utils/colorUtils';
-import { Comment } from './Comment';
 
 type AnswerCellProps = {
   value: any;
   answerType: string;
   questionId: string;
   questionName: string;
-  comment: string;
   choices?: Choice[];
 };
 
@@ -20,7 +18,6 @@ export function AnswerCell({
   answerType,
   questionId,
   questionName,
-  comment,
   choices,
 }: AnswerCellProps) {
   const params = useParams();
@@ -72,7 +69,6 @@ export function AnswerCell({
         <Stack spacing={2}>
           <Textarea value={selectedAnswer} onChange={handleTextAreaAnswer} />
           <Button onClick={submitTextAnswer}>Submit</Button>
-          <Comment comment={comment} questionId={questionId} team={team} />
         </Stack>
       );
     case 'singleSelect':

--- a/frontend/beCompliant/src/components/table/Comment.tsx
+++ b/frontend/beCompliant/src/components/table/Comment.tsx
@@ -1,4 +1,12 @@
-import { Button, Textarea } from '@kvib/react';
+import {
+  Center,
+  HStack,
+  IconButton,
+  Spacer,
+  Stack,
+  Text,
+  Textarea,
+} from '@kvib/react';
 import { useState } from 'react';
 import { useSubmitComment } from '../../hooks/useSubmitComment';
 
@@ -10,6 +18,7 @@ type CommentProps = {
 
 export function Comment({ comment, questionId, team }: CommentProps) {
   const [selectedComment, setComment] = useState<string | undefined>(comment);
+  const [editMode, setEditMode] = useState<boolean>(false);
   const { mutate: submitComment, isPending: isLoadingComment } =
     useSubmitComment();
 
@@ -29,8 +38,47 @@ export function Comment({ comment, questionId, team }: CommentProps) {
     setComment(e.target.value);
   };
 
+  if (!editMode) {
+    // change this when the new data model is implemented. Because this should not be an empty string
+    if (comment === '') {
+      return (
+        <Center>
+          <IconButton
+            aria-label="Legg til kommentar"
+            colorScheme="blue"
+            icon="add_comment"
+            variant="secondary"
+            onClick={() => setEditMode(true)}
+          />
+        </Center>
+      );
+    }
+    return (
+      <HStack minWidth="200px">
+        <Text size="sm">{comment}</Text>
+        <Spacer />
+        <Stack>
+          <IconButton
+            aria-label="Rediger kommentar"
+            colorScheme="blue"
+            icon="edit"
+            variant="secondary"
+            onClick={() => setEditMode(true)}
+          />
+          <IconButton
+            aria-label="Slett kommentar"
+            colorScheme="red"
+            icon="delete"
+            variant="secondary"
+            onClick={() => setComment('')}
+          />
+        </Stack>
+      </HStack>
+    );
+  }
+
   return (
-    <>
+    <HStack minWidth="200px">
       <Textarea
         marginBottom={2}
         marginTop={2}
@@ -38,13 +86,23 @@ export function Comment({ comment, questionId, team }: CommentProps) {
         onChange={handleCommentState}
         size="sm"
       />
-      <Button
-        colorScheme={'blue'}
-        onClick={handleCommentSubmit}
-        isLoading={isLoadingComment}
-      >
-        Lagre kommentar
-      </Button>
-    </>
+      <Spacer />
+      <Stack>
+        <IconButton
+          aria-label="Rediger kommentar"
+          colorScheme="blue"
+          icon="check"
+          variant="primary"
+          onClick={handleCommentSubmit}
+        />
+        <IconButton
+          aria-label="Slett kommentar"
+          colorScheme="red"
+          icon="delete"
+          variant="primary"
+          onClick={() => setComment('')}
+        />
+      </Stack>
+    </HStack>
   );
 }

--- a/frontend/beCompliant/src/components/table/Comment.tsx
+++ b/frontend/beCompliant/src/components/table/Comment.tsx
@@ -2,7 +2,6 @@ import {
   Center,
   HStack,
   IconButton,
-  Spacer,
   Stack,
   Text,
   Textarea,
@@ -51,7 +50,7 @@ export function Comment({ comment, questionId, team }: CommentProps) {
 
   if (editMode) {
     return (
-      <HStack minWidth="200px">
+      <HStack minWidth="200px" justifyContent="space-between">
         <Textarea
           marginBottom={2}
           marginTop={2}
@@ -59,7 +58,6 @@ export function Comment({ comment, questionId, team }: CommentProps) {
           onChange={(e) => setEditedComment(e.target.value)}
           size="sm"
         />
-        <Spacer />
         <Stack>
           <IconButton
             aria-label="Lagre kommentar"
@@ -98,9 +96,8 @@ export function Comment({ comment, questionId, team }: CommentProps) {
   }
   return (
     <>
-      <HStack minWidth="200px">
+      <HStack minWidth="200px" justifyContent="space-between">
         <Text size="sm">{comment}</Text>
-        <Spacer />
         <Stack>
           <IconButton
             aria-label="Rediger kommentar"

--- a/frontend/beCompliant/src/components/table/Comment.tsx
+++ b/frontend/beCompliant/src/components/table/Comment.tsx
@@ -1,14 +1,7 @@
 import {
-  Button,
   Center,
   HStack,
   IconButton,
-  Modal,
-  ModalBody,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
   Spacer,
   Stack,
   Text,
@@ -16,71 +9,8 @@ import {
   useDisclosure,
 } from '@kvib/react';
 import { useState } from 'react';
-import { useDeleteComment } from '../../hooks/useDeleteComment';
 import { useSubmitComment } from '../../hooks/useSubmitComment';
-
-type DeleteCommentModalProps = {
-  onOpen: () => void;
-  onClose: () => void;
-  isOpen: boolean;
-  comment: string;
-  questionId: string;
-  team: string | undefined;
-  setEditMode: (value: boolean) => void;
-};
-function DeleteCommentModal({
-  onOpen,
-  onClose,
-  isOpen,
-  comment,
-  questionId,
-  team,
-  setEditMode,
-}: DeleteCommentModalProps) {
-  const { mutate: deleteComment, isPending: isLoading } =
-    useDeleteComment(setEditMode);
-  const handleCommentDelete = () => {
-    deleteComment({
-      actor: 'Unknown',
-      questionId: questionId,
-      team: team,
-      comment: comment,
-      updated: new Date(),
-    });
-    setEditMode(false);
-  };
-
-  return (
-    <Modal onClose={onClose} isOpen={isOpen} isCentered>
-      <ModalOverlay />
-      <ModalContent>
-        <ModalHeader>Slett kommentar</ModalHeader>
-        <ModalBody>
-          <Stack>
-            <Text size="sm">Er du sikker på at du vil slette kommentaren?</Text>
-          </Stack>
-        </ModalBody>
-        <ModalFooter>
-          <HStack justifyContent="end">
-            <Button variant="tertiary" colorScheme="blue" onClick={onClose}>
-              Avbryt
-            </Button>
-            <Button
-              aria-label="Slett kommentar"
-              variant="primary"
-              colorScheme="red"
-              leftIcon="delete"
-              onClick={handleCommentDelete}
-              isLoading={isLoading}
-            >
-              Slett kommentar
-            </Button>
-          </HStack>
-        </ModalFooter>
-      </ModalContent>
-    </Modal>
-  );
-}
+import { DeleteCommentModal } from './DeleteCommentModal';
 
 // Replace with type from api when the internal data model is implemented
 type CommentProps = {
@@ -114,12 +44,6 @@ export function Comment({ comment, questionId, team }: CommentProps) {
     }
   };
 
-  const handleEditedCommentState = (
-    e: React.ChangeEvent<HTMLTextAreaElement>
-  ) => {
-    setEditedComment(e.target.value);
-  };
-
   const handleDiscardChanges = () => {
     setEditedComment(comment);
     setEditMode(false);
@@ -132,7 +56,7 @@ export function Comment({ comment, questionId, team }: CommentProps) {
           marginBottom={2}
           marginTop={2}
           defaultValue={editedComment}
-          onChange={handleEditedCommentState}
+          onChange={(e) => setEditedComment(e.target.value)}
           size="sm"
         />
         <Spacer />

--- a/frontend/beCompliant/src/components/table/Comment.tsx
+++ b/frontend/beCompliant/src/components/table/Comment.tsx
@@ -6,6 +6,7 @@ import {
   Modal,
   ModalBody,
   ModalContent,
+  ModalFooter,
   ModalHeader,
   ModalOverlay,
   Spacer,
@@ -36,7 +37,8 @@ function DeleteCommentModal({
   team,
   setEditMode,
 }: DeleteCommentModalProps) {
-  const { mutate: deleteComment } = useDeleteComment();
+  const { mutate: deleteComment, isPending: isLoading } =
+    useDeleteComment(setEditMode);
   const handleCommentDelete = () => {
     deleteComment({
       actor: 'Unknown',
@@ -56,22 +58,25 @@ function DeleteCommentModal({
         <ModalBody>
           <Stack>
             <Text size="sm">Er du sikker på at du vil slette kommentaren?</Text>
-            <HStack justifyContent="end">
-              <Button variant="ghost" colorScheme="blue" onClick={onClose}>
-                Avbryt
-              </Button>
-              <Button
-                aria-label="Slett kommentar"
-                variant="primary"
-                colorScheme="red"
-                leftIcon="delete"
-                onClick={handleCommentDelete}
-              >
-                Slett kommentar
-              </Button>
-            </HStack>
           </Stack>
         </ModalBody>
+        <ModalFooter>
+          <HStack justifyContent="end">
+            <Button variant="tertiary" colorScheme="blue" onClick={onClose}>
+              Avbryt
+            </Button>
+            <Button
+              aria-label="Slett kommentar"
+              variant="primary"
+              colorScheme="red"
+              leftIcon="delete"
+              onClick={handleCommentDelete}
+              isLoading={isLoading}
+            >
+              Slett kommentar
+            </Button>
+          </HStack>
+        </ModalFooter>
       </ModalContent>
     </Modal>
   );
@@ -89,7 +94,8 @@ export function Comment({ comment, questionId, team }: CommentProps) {
     comment
   );
   const [editMode, setEditMode] = useState<boolean>(false);
-  const { mutate: submitComment } = useSubmitComment();
+  const { mutate: submitComment, isPending: isLoading } =
+    useSubmitComment(setEditMode);
   const {
     isOpen: isDeleteOpen,
     onOpen: onDeleteOpen,
@@ -106,7 +112,6 @@ export function Comment({ comment, questionId, team }: CommentProps) {
         updated: '',
       });
     }
-    setEditMode(false);
   };
 
   const handleEditedCommentState = (
@@ -138,6 +143,7 @@ export function Comment({ comment, questionId, team }: CommentProps) {
             icon="check"
             variant="primary"
             onClick={handleCommentSubmit}
+            isLoading={isLoading}
           />
           <IconButton
             aria-label="Slett kommentar"
@@ -145,6 +151,7 @@ export function Comment({ comment, questionId, team }: CommentProps) {
             icon="close"
             variant="primary"
             onClick={handleDiscardChanges}
+            isLoading={isLoading}
           />
         </Stack>
       </HStack>

--- a/frontend/beCompliant/src/components/table/DeleteCommentModal.tsx
+++ b/frontend/beCompliant/src/components/table/DeleteCommentModal.tsx
@@ -1,0 +1,75 @@
+import {
+  Button,
+  HStack,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Stack,
+  Text,
+} from '@kvib/react';
+import { useDeleteComment } from '../../hooks/useDeleteComment';
+
+type DeleteCommentModalProps = {
+  onOpen: () => void;
+  onClose: () => void;
+  isOpen: boolean;
+  comment: string;
+  questionId: string;
+  team: string | undefined;
+  setEditMode: (value: boolean) => void;
+};
+export function DeleteCommentModal({
+  onClose,
+  isOpen,
+  comment,
+  questionId,
+  team,
+  setEditMode,
+}: DeleteCommentModalProps) {
+  const { mutate: deleteComment, isPending: isLoading } =
+    useDeleteComment(setEditMode);
+  const handleCommentDelete = () => {
+    deleteComment({
+      actor: 'Unknown',
+      questionId: questionId,
+      team: team,
+      comment: comment,
+      updated: new Date(),
+    });
+    setEditMode(false);
+  };
+
+  return (
+    <Modal onClose={onClose} isOpen={isOpen} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Slett kommentar</ModalHeader>
+        <ModalBody>
+          <Stack>
+            <Text size="sm">Er du sikker på at du vil slette kommentaren?</Text>
+          </Stack>
+        </ModalBody>
+        <ModalFooter>
+          <HStack justifyContent="end">
+            <Button variant="tertiary" colorScheme="blue" onClick={onClose}>
+              Avbryt
+            </Button>
+            <Button
+              aria-label="Slett kommentar"
+              variant="primary"
+              colorScheme="red"
+              leftIcon="delete"
+              onClick={handleCommentDelete}
+              isLoading={isLoading}
+            >
+              Slett kommentar
+            </Button>
+          </HStack>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/frontend/beCompliant/src/components/table/TableCell.tsx
+++ b/frontend/beCompliant/src/components/table/TableCell.tsx
@@ -24,7 +24,6 @@ export const TableCell = ({
         answerType={column.type}
         questionId={row.original.fields.ID}
         questionName={row.original.fields.Aktivitet}
-        comment={row.original.fields.comment ?? ''}
         choices={column.options?.choices}
       />
     );

--- a/frontend/beCompliant/src/hooks/useDeleteComment.ts
+++ b/frontend/beCompliant/src/hooks/useDeleteComment.ts
@@ -1,0 +1,50 @@
+import { useToast } from '@kvib/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { axiosFetch } from '../api/Fetch';
+import { apiConfig } from '../api/apiConfig';
+import { Comment } from '../api/types';
+
+export function useDeleteComment() {
+  const URL = apiConfig.comments.url;
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation({
+    mutationKey: apiConfig.comments.queryKey,
+    mutationFn: (body: Comment) => {
+      return axiosFetch({
+        url: URL,
+        method: 'DELETE',
+        data: JSON.stringify(body),
+      });
+    },
+    onSuccess: () => {
+      const toastId = 'delete-comment-success';
+      if (!toast.isActive(toastId)) {
+        toast({
+          title: 'Suksess',
+          description: 'Kommentaren din er slettet',
+          status: 'success',
+          duration: 5000,
+          isClosable: true,
+        });
+      }
+      return queryClient.invalidateQueries({
+        queryKey: apiConfig.comments.queryKey,
+      });
+    },
+    onError: () => {
+      const toastId = 'delete-comment-error';
+      if (!toast.isActive(toastId)) {
+        toast({
+          id: toastId,
+          title: 'Å nei!',
+          description: 'Det har skjedd en feil. Prøv på nytt',
+          status: 'error',
+          duration: 5000,
+          isClosable: true,
+        });
+      }
+    },
+  });
+}

--- a/frontend/beCompliant/src/hooks/useDeleteComment.ts
+++ b/frontend/beCompliant/src/hooks/useDeleteComment.ts
@@ -4,7 +4,7 @@ import { axiosFetch } from '../api/Fetch';
 import { apiConfig } from '../api/apiConfig';
 import { Comment } from '../api/types';
 
-export function useDeleteComment() {
+export function useDeleteComment(setEditMode: (editMode: boolean) => void) {
   const URL = apiConfig.comments.url;
   const queryClient = useQueryClient();
   const toast = useToast();
@@ -18,7 +18,7 @@ export function useDeleteComment() {
         data: JSON.stringify(body),
       });
     },
-    onSuccess: () => {
+    onSuccess: async () => {
       const toastId = 'delete-comment-success';
       if (!toast.isActive(toastId)) {
         toast({
@@ -29,9 +29,10 @@ export function useDeleteComment() {
           isClosable: true,
         });
       }
-      return queryClient.invalidateQueries({
+      await queryClient.invalidateQueries({
         queryKey: apiConfig.comments.queryKey,
       });
+      setEditMode(false);
     },
     onError: () => {
       const toastId = 'delete-comment-error';

--- a/frontend/beCompliant/src/hooks/useSubmitComment.ts
+++ b/frontend/beCompliant/src/hooks/useSubmitComment.ts
@@ -1,7 +1,7 @@
+import { useToast } from '@kvib/react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { axiosFetch } from '../api/Fetch';
 import { apiConfig } from '../api/apiConfig';
-import { useToast } from '@kvib/react';
 
 type SubmitCommentsRequest = {
   actor: string;
@@ -11,7 +11,7 @@ type SubmitCommentsRequest = {
   updated: string;
 };
 
-export function useSubmitComment() {
+export function useSubmitComment(setEditMode: (editMode: boolean) => void) {
   const URL = apiConfig.comments.url;
   const queryClient = useQueryClient();
   const toast = useToast();
@@ -25,7 +25,7 @@ export function useSubmitComment() {
         data: JSON.stringify(body),
       });
     },
-    onSuccess: () => {
+    onSuccess: async () => {
       const toastId = 'submit-comment-success';
       if (!toast.isActive(toastId)) {
         toast({
@@ -36,9 +36,10 @@ export function useSubmitComment() {
           isClosable: true,
         });
       }
-      return queryClient.invalidateQueries({
+      await queryClient.invalidateQueries({
         queryKey: apiConfig.comments.queryKey,
       });
+      setEditMode(false);
     },
     onError: () => {
       const toastId = 'submit-comment-error';


### PR DESCRIPTION
## Background

We want to improve the experience of using comments. Today it is just a text field that you can update. If you start to edit it you'll have to refresh to get the old state, and it is technically impossible to delete a comment.

## Solution

Create different "modes" for the comment component:
* If the question has no comment it simply shows an add comment button. In read mode you can either choose to edit the comment, or delete it completely.
* When you choose to delete it you'll get a confirmation modal to make sure that you want to commit to it. I have added m

ethods to the backend to be able to delete comments now, and this will trigger it using it a new hook.
* In edit mode you can either submit the comment which will update the database, or you can discard the changes. This will result in the field going back to read mode, with the original comment showing again.

## Screen recording

https://github.com/user-attachments/assets/2477741b-d68f-4067-b608-2565f9c782a5
