### PR TITLE
Fixed question text wrapping/overflow + page scroll bug

### DIFF
--- a/frontend/beCompliant/src/components/table/TableCell.tsx
+++ b/frontend/beCompliant/src/components/table/TableCell.tsx
@@ -23,7 +23,7 @@ export const TableCell = ({
         value={value}
         answerType={column.type}
         questionId={row.original.fields.ID}
-        questionName={row.original.fields.Aktivitet}
+        questionName={row.original.fields.Sikkerhetskontroller}
         choices={column.options?.choices}
       />
     );
@@ -70,5 +70,9 @@ export const TableCell = ({
         </Tag>
       );
   }
-  return <Text fontSize={'md'}>{value}</Text>;
+  return (
+    <Text whiteSpace="normal" fontSize={'md'}>
+      {value}
+    </Text>
+  );
 };

--- a/frontend/beCompliant/src/components/table/pagination/PaginationButtonContainer.tsx
+++ b/frontend/beCompliant/src/components/table/pagination/PaginationButtonContainer.tsx
@@ -1,8 +1,8 @@
 import { Flex, Icon } from '@kvib/react';
-import { Table } from '@tanstack/react-table';
+import { Table, Updater } from '@tanstack/react-table';
 import { PaginationActionButton } from './PaginationActionButton';
 import { PaginationRelativeButtons } from './PaginationRelativeButtons';
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 
 interface Props<TData> {
   table: Table<TData>;
@@ -15,21 +15,12 @@ export function PaginationButtonContainer<TData>({ table }: Props<TData>) {
   const numberOfRows = table.getRowCount();
   const numberOfPages = Math.ceil(numberOfRows / pageSize);
   const ref = useRef<HTMLDivElement>(null);
-  const [isFirstRender, setIsFirstRender] = useState<boolean>(false);
 
-  // these 2 useEffects are used to avoid horisontal displacement when
-  // jumping between pages in the table
-  useEffect(() => {
-    if (isFirstRender) {
-      setIsFirstRender(false);
+  const scrollToPagination = () => {
+    if (ref.current !== null) {
+      ref.current.scrollIntoView({ behavior: 'auto', block: 'start' });
     }
-  }, [isFirstRender]);
-
-  useEffect(() => {
-    if (isFirstRender || ref.current === null) return;
-    // Scroll to the bottom of the table when the page index changes
-    ref.current.scrollIntoView({ behavior: 'auto', block: 'start' });
-  }, [isFirstRender, index]);
+  };
 
   return (
     <Flex
@@ -43,12 +34,18 @@ export function PaginationButtonContainer<TData>({ table }: Props<TData>) {
       <PaginationActionButton
         ariaLabel={'Gå til forrige side'}
         isDisplayed={table.getCanPreviousPage()}
-        onClick={() => table.previousPage()}
+        onClick={() => {
+          table.previousPage();
+          scrollToPagination();
+        }}
       >
         <Icon size={30} icon="chevron_left" />
       </PaginationActionButton>
       <PaginationActionButton
-        onClick={() => table.setPageIndex(0)}
+        onClick={() => {
+          table.setPageIndex(0);
+          scrollToPagination();
+        }}
         ariaLabel={'Gå til side 1'}
         isCurrent={index === 0}
       >
@@ -57,12 +54,18 @@ export function PaginationButtonContainer<TData>({ table }: Props<TData>) {
       <PaginationRelativeButtons
         numberOfPages={numberOfPages}
         currentIndex={index}
-        setIndex={table.setPageIndex}
+        setIndex={(index: Updater<number>) => {
+          table.setPageIndex(index);
+          scrollToPagination();
+        }}
       />
 
       {numberOfPages > 1 && (
         <PaginationActionButton
-          onClick={() => table.setPageIndex(numberOfPages - 1)}
+          onClick={() => {
+            table.setPageIndex(numberOfPages - 1);
+            scrollToPagination();
+          }}
           ariaLabel={'Gå til siste side'}
           isCurrent={index === numberOfPages - 1}
         >
@@ -70,7 +73,10 @@ export function PaginationButtonContainer<TData>({ table }: Props<TData>) {
         </PaginationActionButton>
       )}
       <PaginationActionButton
-        onClick={() => table.nextPage()}
+        onClick={() => {
+          table.nextPage();
+          scrollToPagination();
+        }}
         ariaLabel={'Gå til neste side'}
         isDisplayed={table.getCanNextPage()}
       >

--- a/frontend/beCompliant/src/components/table/pagination/PaginationRelativeButtons.tsx
+++ b/frontend/beCompliant/src/components/table/pagination/PaginationRelativeButtons.tsx
@@ -17,7 +17,7 @@ export function PaginationRelativeButtons({
   if (numberOfPages <= 2) {
     return <></>;
   }
-  // If less then 7 total pages display all pages without ...
+  // If less then 7 total pages display all pages without "..."
   if (numberOfPages <= 7) {
     return [...Array(numberOfPages - 2)].map((_, index) => {
       return (

--- a/frontend/beCompliant/src/types/tableTypes.ts
+++ b/frontend/beCompliant/src/types/tableTypes.ts
@@ -53,7 +53,7 @@ export type Fields = {
   Pri: string;
   Løpenummer: number;
   Ledetid: string;
-  Aktivitet: string;
+  Sikkerhetskontroller: string;
   Område: string;
   Hvem: string[];
   Kode: string;


### PR DESCRIPTION
## Background
The text in the question column did not wrap anything despite being to wide. 
When you first render the page you the page is scrolled to the bottom which is not wanted behaviour.

## Solution
Fixed issues mentioned above. Added whitespace to the text in the tablecell. Also removed the useState and useEffect hooks and instead run the scrolling when the button is clicked


![image](https://github.com/user-attachments/assets/248dd6ef-88c1-4bbb-86c0-421ef30d2680)

