### PR TITLE
Remove authentication and mock groups for local development

### DIFF
--- a/backend/src/main/kotlin/no/bekk/authentication/Authentication.kt
+++ b/backend/src/main/kotlin/no/bekk/authentication/Authentication.kt
@@ -12,6 +12,7 @@ import io.ktor.server.auth.*
 import io.ktor.server.auth.jwt.*
 import io.ktor.server.response.*
 import io.ktor.server.sessions.*
+import no.bekk.plugins.Config
 import no.bekk.services.MicrosoftService
 import java.net.URL
 import java.util.concurrent.TimeUnit
@@ -95,13 +96,18 @@ fun Application.initializeAuthentication(httpClient: HttpClient = applicationHtt
 
 suspend fun getGroupsOrEmptyList(call: ApplicationCall): List<String> {
 
-    val microsoftService = MicrosoftService()
+    if (Config.isDevelopment) {
+        // Return mock groups for local development
+        return listOf("Mock-Team-1", "Mock-Team-2")
+    } else {
+        val microsoftService = MicrosoftService()
 
-    val graphApiToken = call.sessions.get<UserSession>()?.let {
-        microsoftService.requestTokenOnBehalfOf(it)
-    } ?: throw IllegalStateException("Unable to retrieve on-behalf-of token")
+        val graphApiToken = call.sessions.get<UserSession>()?.let {
+            microsoftService.requestTokenOnBehalfOf(it)
+        } ?: throw IllegalStateException("Unable to retrieve on-behalf-of token")
 
-    return microsoftService.fetchGroupNames(graphApiToken)
+        return microsoftService.fetchGroupNames(graphApiToken)
+    }
 }
 
 suspend fun hasTeamAccess(call: ApplicationCall, teamId: String?): Boolean {

--- a/backend/src/main/kotlin/no/bekk/plugins/Config.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/Config.kt
@@ -1,6 +1,8 @@
 package no.bekk.plugins
 
+import io.ktor.util.*
+
 object Config {
     val isDevelopment: Boolean
-        get() = System.getenv("ENVIRONMENT") == "development"
+        get() = System.getenv("ENVIRONMENT").toLowerCasePreservingASCIIRules() == "development"
 }

--- a/backend/src/main/kotlin/no/bekk/plugins/Config.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/Config.kt
@@ -1,0 +1,6 @@
+package no.bekk.plugins
+
+object Config {
+    val isDevelopment: Boolean
+        get() = System.getenv("ENVIRONMENT") == "development"
+}

--- a/backend/src/main/kotlin/no/bekk/plugins/Routing.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/Routing.kt
@@ -24,7 +24,18 @@ fun Application.configureRouting() {
 
         authenticationRouting()
 
-        authenticate("auth-jwt"){
+        if(!Config.isDevelopment){
+            authenticate("auth-jwt"){
+                alleRouting()
+                answerRouting()
+                commentRouting()
+                kontrollereRouting()
+                metodeverkRouting()
+                questionRouting()
+                tableRouting()
+                userInfoRouting()
+            }
+        } else {
             alleRouting()
             answerRouting()
             commentRouting()
@@ -34,5 +45,6 @@ fun Application.configureRouting() {
             tableRouting()
             userInfoRouting()
         }
+
     }
 }

--- a/backend/src/main/kotlin/no/bekk/routes/AuthenticationRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/AuthenticationRouting.kt
@@ -10,19 +10,17 @@ import no.bekk.authentication.UserSession
 import no.bekk.plugins.Config
 
 fun Route.authenticationRouting() {
-    get("/token") {
-        val userSession: UserSession? = call.sessions.get<UserSession>()
-        if(userSession != null) {
-            call.respondText(userSession.token)
-        }
-    }
 
     get("/auth-status"){
-        val userSession: UserSession? = call.sessions.get<UserSession>()
-        if (userSession != null){
+        if(Config.isDevelopment) {
             call.respond(HttpStatusCode.OK, mapOf("authenticated" to true))
         } else {
-            call.respond(HttpStatusCode.Unauthorized, mapOf("authenticated" to false))
+            val userSession: UserSession? = call.sessions.get<UserSession>()
+            if (userSession != null){
+                call.respond(HttpStatusCode.OK, mapOf("authenticated" to true))
+            } else {
+                call.respond(HttpStatusCode.Unauthorized, mapOf("authenticated" to false))
+            }
         }
     }
 


### PR DESCRIPTION
## Background
After implementing authentication with Entra Id it is not possible to develop locally without correctly authenticating with Entra ID. 

## Solution
To solve this there should optimally be a Entra ID development area where we could authenticate mocked users to with a client id and client secret. Due to time restrictions and uncertainty of how to create an "optimal" solution as described above, a simple fix is to abstract away authentication and group authorization for local development

## How to test
Add a system variable as such `"ENVIRONMENT" "development"`