### PR TITLE
refactored controllers to service and removed controller dir

### DIFF
--- a/backend/src/main/kotlin/no/bekk/routes/QuestionRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/QuestionRouting.kt
@@ -3,13 +3,13 @@ package no.bekk.routes
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import no.bekk.controllers.QuestionController
+import no.bekk.services.QuestionService
 
 fun Route.questionRouting() {
-    val questionController = QuestionController()
+    val questionService = QuestionService()
     route("/questions") {
         get {
-            val questions = questionController.getTestQuestions()
+            val questions = questionService.getTestQuestions()
             call.respond(questions)
         }
     }

--- a/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
@@ -4,10 +4,10 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import no.bekk.services.TableController
+import no.bekk.services.TableService
 
 fun Route.tableRouting() {
-    val tableController = TableController()
+    val tableService = TableService()
     route("/table") {
         get("/{tableId}") {
             val tableId = call.parameters["tableId"]
@@ -17,7 +17,7 @@ fun Route.tableRouting() {
             }
             val team = call.request.queryParameters["team"]
             try {
-                val table = tableController.getTable(tableId, team)
+                val table = tableService.getTable(tableId, team)
                 call.respond(table)
             } catch (e: IllegalArgumentException) {
                 call.respond(HttpStatusCode.InternalServerError, "An error occured: ${e.message}")

--- a/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
@@ -4,7 +4,7 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import no.bekk.controllers.TableController
+import no.bekk.services.TableController
 
 fun Route.tableRouting() {
     val tableController = TableController()

--- a/backend/src/main/kotlin/no/bekk/services/QuestionService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/QuestionService.kt
@@ -1,11 +1,11 @@
-package no.bekk.controllers
+package no.bekk.services
 
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import no.bekk.model.internal.Question
 import java.io.File
 
-class QuestionController {
+class QuestionService {
 
     private val testFile = File("resources/testQuestions.json")
     private val testQuestions = testFile.readText()

--- a/backend/src/main/kotlin/no/bekk/services/TableService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/TableService.kt
@@ -1,4 +1,4 @@
-package no.bekk.controllers
+package no.bekk.services
 
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -6,7 +6,6 @@ import no.bekk.database.DatabaseRepository
 import no.bekk.domain.mapToQuestion
 import no.bekk.model.airtable.AirTableFieldType
 import no.bekk.model.airtable.mapAirTableFieldTypeToOptionalFieldType
-import no.bekk.services.AirTableService
 import no.bekk.model.internal.*
 
 class TableController {

--- a/backend/src/main/kotlin/no/bekk/services/TableService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/TableService.kt
@@ -8,7 +8,7 @@ import no.bekk.model.airtable.AirTableFieldType
 import no.bekk.model.airtable.mapAirTableFieldTypeToOptionalFieldType
 import no.bekk.model.internal.*
 
-class TableController {
+class TableService {
     private val airTableService = AirTableService()
     private val databaseRepository = DatabaseRepository()
 


### PR DESCRIPTION
## Background
Ktor uses the naming convention "Routes" not "Controller". The files in the controller repo contains business logic that should be under services.

## Solution
Moved the controller files to services directory and renamed them to have a Service suffix.