### PR TITLE
Update deploy workflows

### DIFF
--- a/.github/workflows/build-deploy-backend.yml
+++ b/.github/workflows/build-deploy-backend.yml
@@ -76,6 +76,8 @@ jobs:
 
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v3
+        with:
+          build-root-directory: backend
 
       - name: Execute Gradle build
         working-directory: backend

--- a/.github/workflows/build-deploy-backend.yml
+++ b/.github/workflows/build-deploy-backend.yml
@@ -125,7 +125,7 @@ jobs:
           echo "image_url=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-docker.outputs.digest }}" >> $GITHUB_OUTPUT  
 
   pharos:
-    name: Run Pharos on docker image
+    name: Run Pharos
     needs: build
     permissions:
       actions: read

--- a/.github/workflows/build-deploy-backend.yml
+++ b/.github/workflows/build-deploy-backend.yml
@@ -162,6 +162,6 @@ jobs:
         run: |
           echo "\"${{ needs.build.outputs.image_url }}\"" > "env/atgcp1-dev/regelrett-main/${{ env.ARGO_VERSION_FILE }}"
           git config --global user.email "noreply@kartverket.no"
-          git config --global user.name "Regelrett Backend CI"
+          git config --global user.name "Regelrett CI"
           git commit -am "Update ${{ env.ARGO_VERSION_FILE }}"
           git push

--- a/.github/workflows/build-deploy-backend.yml
+++ b/.github/workflows/build-deploy-backend.yml
@@ -1,6 +1,19 @@
 name: Build and deploy backend to SKIP
 on:
   workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'Commit hash to deploy'
+        default: ''
+        type: string
+      dev:
+        description: 'Deploy to dev'
+        required: true
+        type: boolean
+      prod:
+        description: 'Deploy to prod'
+        required: true
+        type: boolean
   pull_request:
     branches:
       - main
@@ -38,7 +51,20 @@ jobs:
       image_url: ${{ steps.setOutput.outputs.image_url }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.commit_sha == '') }}
+        uses: actions/checkout@v4
+
+      - name: Checkout code
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.commit_sha == '' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout specific commit
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.commit_sha == '' }}
+        run: git checkout ${{ github.event.inputs.commit_sha }}
+
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
@@ -48,8 +74,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
 
-#      - name: Generate and submit dependency graph
-#        uses: gradle/actions/dependency-submission@v3
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v3
 
       - name: Execute Gradle build
         working-directory: backend
@@ -111,22 +137,31 @@ jobs:
         with:
           image_url: ${{ needs.build.outputs.image_url }}
 
-  deploy:
-    name: Deploy to SKIP
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  deploy-dev:
+    name: Deploy to dev
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.dev == 'true')) }}
     needs: build
     runs-on: ubuntu-latest
+    environment:
+      name: dev
+    permissions:
+      id-token: write
     steps:
-      - name: Checkout apps-repo
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+        id: octo-sts
+        with:
+          scope: kartverket/skvis-apps
+          identity: regelrett-backend
+      - name: Checkout skvis-apps
+        uses: actions/checkout@v4
         with:
           repository: kartverket/skvis-apps
           ref: main
-          token: ${{ secrets.ARGO_PAT }}
+          token: ${{ steps.octo-sts.outputs.token }}
       - name: Update version
         run: |
           echo "\"${{ needs.build.outputs.image_url }}\"" > "env/atgcp1-dev/regelrett-main/${{ env.ARGO_VERSION_FILE }}"
           git config --global user.email "noreply@kartverket.no"
-          git config --global user.name "Regelrett CI"
-          git commit -am "Update Regelrett frontend ${{ env.ARGO_VERSION_FILE }}"
+          git config --global user.name "Regelrett Backend CI"
+          git commit -am "Update ${{ env.ARGO_VERSION_FILE }}"
           git push

--- a/.github/workflows/build-deploy-frontend.yml
+++ b/.github/workflows/build-deploy-frontend.yml
@@ -1,6 +1,19 @@
 name: Build and deploy frontend to SKIP
 on:
   workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'Commit hash to deploy'
+        default: ''
+        type: string
+      dev:
+        description: 'Deploy to dev'
+        required: true
+        type: boolean
+      prod:
+        description: 'Deploy to prod'
+        required: true
+        type: boolean
   pull_request:
     branches:
       - main
@@ -34,7 +47,19 @@ jobs:
       image_url: ${{ steps.setOutput.outputs.image_url }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.commit_sha == '') }}
+        uses: actions/checkout@v4
+
+      - name: Checkout code
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.commit_sha == '' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout specific commit
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.commit_sha == '' }}
+        run: git checkout ${{ github.event.inputs.commit_sha }}
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
@@ -106,22 +131,31 @@ jobs:
         with:
           image_url: ${{ needs.build.outputs.image_url }}
 
-  deploy:
-    name: Deploy to SKIP
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  deploy-dev:
+    name: Deploy to dev
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.dev == 'true')) }}
     needs: build
     runs-on: ubuntu-latest
+    environment:
+      name: dev
+    permissions:
+      id-token: write
     steps:
-      - name: Checkout apps-repo
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+        id: octo-sts
+        with:
+          scope: kartverket/skvis-apps
+          identity: regelrett-frontend
+      - name: Checkout skvis-apps
+        uses: actions/checkout@v4
         with:
           repository: kartverket/skvis-apps
           ref: main
-          token: ${{ secrets.ARGO_PAT }}
+          token: ${{ steps.octo-sts.outputs.token }}
       - name: Update version
         run: |
           echo "\"${{ needs.build.outputs.image_url }}\"" > "env/atgcp1-dev/regelrett-main/${{ env.ARGO_VERSION_FILE }}"
           git config --global user.email "noreply@kartverket.no"
-          git config --global user.name "Regelrett CI"
-          git commit -am "Update Regelrett frontend ${{ env.ARGO_VERSION_FILE }}"
+          git config --global user.name "Regelrett Backend CI"
+          git commit -am "Update ${{ env.ARGO_VERSION_FILE }}"
           git push

--- a/.github/workflows/build-deploy-frontend.yml
+++ b/.github/workflows/build-deploy-frontend.yml
@@ -156,6 +156,6 @@ jobs:
         run: |
           echo "\"${{ needs.build.outputs.image_url }}\"" > "env/atgcp1-dev/regelrett-main/${{ env.ARGO_VERSION_FILE }}"
           git config --global user.email "noreply@kartverket.no"
-          git config --global user.name "Regelrett Backend CI"
+          git config --global user.name "Regelrett CI"
           git commit -am "Update ${{ env.ARGO_VERSION_FILE }}"
           git push

--- a/.github/workflows/build-deploy-frontend.yml
+++ b/.github/workflows/build-deploy-frontend.yml
@@ -117,7 +117,7 @@ jobs:
           echo "image_url=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-docker.outputs.digest }}" >> $GITHUB_OUTPUT    
 
   pharos:
-    name: Run Pharos with Required Permissions
+    name: Run Pharos
     needs: build
     permissions:
       actions: read


### PR DESCRIPTION
## Background
Want to not use a personal access token to deploy to SKIP.

## Solution
Removes the use of a personal access token and instead uses OctoSTS to update image-url in [skvis-apps](https://github.com/kartverket/skvis-apps). Also configure the workflows to trigger on `workflow_dispatch` with the option of choosing which commit to deploy and which deployment environments to deploy to. The workflows currently only supports deploying to dev.

Resolves non-existing issue
