### PR TITLE
keep filters after page refresh

### DIFF
--- a/frontend/beCompliant/src/components/tableActions/TableActions.tsx
+++ b/frontend/beCompliant/src/components/tableActions/TableActions.tsx
@@ -2,7 +2,6 @@ import { Flex, Heading, Icon } from '@kvib/react';
 import { TableFilter, TableFilters } from './TableFilter';
 import { Field } from '../../api/types';
 import { useEffect } from 'react';
-import { log } from 'console';
 
 interface Props {
   filters: TableFilters;
@@ -16,7 +15,7 @@ export const TableActions = ({
   const { filterOptions, activeFilters, setActiveFilters } = tableFilterProps;
 
   useEffect(() => {
-    const storedFilter = localStorage.getItem('filter');
+    const storedFilter = localStorage.getItem('filters');
     const parsedFilter = storedFilter ? JSON.parse(storedFilter) : {};
     if (parsedFilter && Object.keys(parsedFilter).length > 0) {
       setActiveFilters(parsedFilter);
@@ -25,7 +24,7 @@ export const TableActions = ({
 
   useEffect(() => {
     if (activeFilters && Object.keys(activeFilters).length > 0) {
-      localStorage.setItem('filter', JSON.stringify(activeFilters));
+      localStorage.setItem('filters', JSON.stringify(activeFilters));
     }
   }, [activeFilters]);
 

--- a/frontend/beCompliant/src/components/tableActions/TableActions.tsx
+++ b/frontend/beCompliant/src/components/tableActions/TableActions.tsx
@@ -1,6 +1,8 @@
 import { Flex, Heading, Icon } from '@kvib/react';
 import { TableFilter, TableFilters } from './TableFilter';
 import { Field } from '../../api/types';
+import { useEffect } from 'react';
+import { log } from 'console';
 
 interface Props {
   filters: TableFilters;
@@ -12,6 +14,20 @@ export const TableActions = ({
   tableMetadata,
 }: Props) => {
   const { filterOptions, activeFilters, setActiveFilters } = tableFilterProps;
+
+  useEffect(() => {
+    const storedFilter = localStorage.getItem('filter');
+    const parsedFilter = storedFilter ? JSON.parse(storedFilter) : {};
+    if (parsedFilter && Object.keys(parsedFilter).length > 0) {
+      setActiveFilters(parsedFilter);
+    }
+  }, [setActiveFilters]);
+
+  useEffect(() => {
+    if (activeFilters && Object.keys(activeFilters).length > 0) {
+      localStorage.setItem('filter', JSON.stringify(activeFilters));
+    }
+  }, [activeFilters]);
 
   return (
     <Flex flexDirection="column" gap="2" marginX="10">

--- a/frontend/beCompliant/src/components/tableActions/TableActions.tsx
+++ b/frontend/beCompliant/src/components/tableActions/TableActions.tsx
@@ -9,11 +9,9 @@ interface Props {
 }
 
 export const TableActions = ({
-  filters: tableFilterProps,
+  filters: { filterOptions, activeFilters, setActiveFilters },
   tableMetadata,
 }: Props) => {
-  const { filterOptions, activeFilters, setActiveFilters } = tableFilterProps;
-
   useEffect(() => {
     const storedFilter = localStorage.getItem('filters');
     const parsedFilter = storedFilter ? JSON.parse(storedFilter) : {};


### PR DESCRIPTION
## Background
The filters are resetting on page refresh.

## Solution
Filters are now saved to localstorage to keep the settings after page refresh

Resolves #issue-this-pr-resolves
#189 
