### PR TITLE
Avoid refetching table data so eagerly

### DIFF
--- a/frontend/beCompliant/src/hooks/useFetchTable.ts
+++ b/frontend/beCompliant/src/hooks/useFetchTable.ts
@@ -13,6 +13,8 @@ export function useFetchTable(tableId: string, team?: string) {
 
   return useQuery({
     queryKey: queryKeys,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
     queryFn: () =>
       axiosFetch<Table>({ url: url }).then((response) => response.data),
   });


### PR DESCRIPTION
## Background
Kontrollerdataen refetcher hver gang vinduet får fokus, og hvis man navigerer til en annen route, og så tilbake. Det er unødvendig, siden dataen ikke er så dynamisk, og lastetiden er lang.

## Solution
Tanstack query har noen enkle verdier man kan sette for å styre cachingen. `refetchOnWindowFocus` er et flagg som sier om dataen skal lastes inn på nytt når vinduet får fokus. Det er default `true`, så setter den til `false`. Setter også `refetchOnMount` til `false` for å forhindre refetching når man navigerer bort og tilbake.

Resolves #195 
