### PR TITLE
Fix not being able to reset filters

### DIFF
--- a/frontend/beCompliant/src/components/tableActions/TableActions.tsx
+++ b/frontend/beCompliant/src/components/tableActions/TableActions.tsx
@@ -21,7 +21,7 @@ export const TableActions = ({
   }, [setActiveFilters]);
 
   useEffect(() => {
-    if (activeFilters && Object.keys(activeFilters).length > 0) {
+    if (activeFilters) {
       localStorage.setItem('filters', JSON.stringify(activeFilters));
     }
   }, [activeFilters]);


### PR DESCRIPTION
## Background
Hvis man bare har ett aktivt filter, og prøver å nullstille den, så blir ikke det husket når man laster inn siden på nytt.

## Solution
Fjerner koden som sjekker om aktivefiltre er tom. Ødelegger jeg noe annet ved å gjøre det? Ser ikke sånn ut i min testing 🤔