### PR TITLE
Bugfix filter localstorage

### DIFF
--- a/frontend/beCompliant/src/components/tableActions/TableActions.tsx
+++ b/frontend/beCompliant/src/components/tableActions/TableActions.tsx
@@ -15,15 +15,17 @@ export const TableActions = ({
   useEffect(() => {
     const storedFilter = localStorage.getItem('filters');
     const parsedFilter = storedFilter ? JSON.parse(storedFilter) : {};
+
     if (parsedFilter && Object.keys(parsedFilter).length > 0) {
       setActiveFilters(parsedFilter);
     }
   }, [setActiveFilters]);
 
   useEffect(() => {
-    if (activeFilters && Object.keys(activeFilters).length > 0) {
-      localStorage.setItem('filters', JSON.stringify(activeFilters));
-    }
+    console.log('test');
+    console.log(activeFilters);
+
+    localStorage.setItem('filters', JSON.stringify(activeFilters));
   }, [activeFilters]);
 
   return (

--- a/frontend/beCompliant/src/components/tableActions/TableActions.tsx
+++ b/frontend/beCompliant/src/components/tableActions/TableActions.tsx
@@ -15,16 +15,12 @@ export const TableActions = ({
   useEffect(() => {
     const storedFilter = localStorage.getItem('filters');
     const parsedFilter = storedFilter ? JSON.parse(storedFilter) : {};
-
     if (parsedFilter && Object.keys(parsedFilter).length > 0) {
       setActiveFilters(parsedFilter);
     }
   }, [setActiveFilters]);
 
   useEffect(() => {
-    console.log('test');
-    console.log(activeFilters);
-
     localStorage.setItem('filters', JSON.stringify(activeFilters));
   }, [activeFilters]);
 


### PR DESCRIPTION
## Background
The pull request that uses localstorage to store filter states had a bug where selecting "alle" aka removing the filter option did not update the filter state in localstorage.

## Solution
Removed unnecessary if-check checking if active filters are not empty before updating localstorage.

Resolves #issue-this-pr-resolves
#196 
