### PR TITLE
fix multiselect when filtering

### DIFF
--- a/frontend/beCompliant/src/utils/tablePageUtil.ts
+++ b/frontend/beCompliant/src/utils/tablePageUtil.ts
@@ -38,14 +38,27 @@ export const filterData = (
         }
       }
 
-      const recordField = record.metadata.optionalFields?.find(
+      const values = record.metadata.optionalFields?.find(
         (field) => field.key === fieldName
-      )?.value[0];
-      if (typeof recordField === 'string')
-        return recordField === filter.filterValue;
-      if (typeof recordField === 'number')
-        return recordField === filter.filterValue;
-      return false;
+      )?.value;
+
+      if (!values) return false;
+
+      return values.some((value) => {
+        if (
+          typeof filter.filterValue === 'string' &&
+          typeof value === 'string'
+        ) {
+          return value === filter.filterValue;
+        }
+        if (
+          typeof filter.filterValue === 'number' &&
+          typeof value === 'number'
+        ) {
+          return value === filter.filterValue;
+        }
+        return false;
+      });
     });
   }, data);
 };


### PR DESCRIPTION
## Background
bare første verdien dersom det var flere ble tatt hensyn til i filtrering. Dette førte til at dersom man filtrerte på "hvem" ble bare første verdien "sett på". F.eks. har AR-006 både IT og plattformteam. Dersom man filtrerte på IT ville den vises, men ble borte hvis man filtrerte på plattformteam.

## Solution
Endret filterData funksjonen til å sjekke om en av verdiene matcher i stedet for å kun ta hensyn til `value[0]`

Resolves #issue-this-pr-resolves
#193 