### PR TITLE
Delete .env.production to use injected env-vars instead

### DIFF
--- a/frontend/beCompliant/.env.production
+++ b/frontend/beCompliant/.env.production
@@ -1,2 +1,0 @@
-VITE_FRONTEND_URL=https://regelrett.atgcp1-dev.kartverket-intern.cloud
-VITE_BACKEND_URL=https://api.regelrett.atgcp1-dev.kartverket-intern.cloud


### PR DESCRIPTION
## Background
Want to inject `VITE_BACKEND_URL` and `VITE_FRONTEND_URL` instead of building the base-image with values from `.env.production`.

## Solution
Deletes `.env.production` and instead injects the correct environment variables in [skvis-apps](https://github.com/kartverket/skvis-apps/blob/main/applications/regelrett-frontend.libsonnet).

Resolves #issue-this-pr-resolves
