### PR TITLE
Refresh session cookie every request

### DIFF
--- a/backend/src/main/kotlin/no/bekk/authentication/Authentication.kt
+++ b/backend/src/main/kotlin/no/bekk/authentication/Authentication.kt
@@ -8,6 +8,7 @@ import io.ktor.http.*
 import io.ktor.http.auth.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
+import io.ktor.server.application.ApplicationCallPipeline.ApplicationPhase.Plugins
 import io.ktor.server.auth.*
 import io.ktor.server.auth.jwt.*
 import io.ktor.server.response.*
@@ -30,6 +31,14 @@ fun Application.installSessions() {
             cookie.maxAgeInSeconds = 360
             cookie.secure
             cookie.httpOnly = true
+        }
+    }
+
+    // Intercept every request to refresh the session cookie
+    intercept(Plugins) {
+        val session: UserSession? = call.sessions.get<UserSession>()
+        if (session != null) {
+            call.sessions.set("user_session", session)
         }
     }
 }

--- a/backend/src/main/kotlin/no/bekk/authentication/Authentication.kt
+++ b/backend/src/main/kotlin/no/bekk/authentication/Authentication.kt
@@ -28,7 +28,7 @@ fun Application.installSessions() {
     install(Sessions) {
         cookie<UserSession>("user_session") {
             cookie.path = "/"
-            cookie.maxAgeInSeconds = 360
+            cookie.maxAgeInSeconds = 15 * 60
             cookie.secure
             cookie.httpOnly = true
         }


### PR DESCRIPTION
## Background
Session cookien utløper etter seks minutter, samme hva. Selv om du trykker deg rundt i appen og gjør nettverkskall blir man fortsatt kastet ut når tokenet utløper.

## Solution
Legger på en intercept på alle nettverkskall som resetter cookien. Da får man en "sliding expiration"

Resolves #192 
