### PR TITLE
Update scope when requesting obo-token

### DIFF
--- a/backend/src/main/kotlin/no/bekk/services/MicrosoftService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/MicrosoftService.kt
@@ -31,7 +31,7 @@ class MicrosoftService {
                             append("client_id", AppConfig.oAuth.clientId)
                             append("client_secret", AppConfig.oAuth.clientSecret)
                             append("assertion", it.token)
-                            append("scope", "Group.Read.All")
+                            append("scope", "GroupMember.Read.All")
                             append("requested_token_use", "on_behalf_of")
                         }
                     )


### PR DESCRIPTION
## Background
The prod app-registration in Microsoft Entra ID only has the API Permission `GroupMember.Read.All` towards Graph API, so the backend is unable to request an obo-token successfully with the scope "Group.Read.All" in prod.

## Solution
The solution is to set the scope to `GroupMember.Read.All` as this is the narrowest scope we need to access group information of the logged in user. I also added this scope on your local Entra ID tenant, so it should not break the local development experience. 

Resolves #issue-this-pr-resolves
