### PR TITLE
Trying build with shadowJar

### DIFF
--- a/.github/workflows/build-deploy-backend.yml
+++ b/.github/workflows/build-deploy-backend.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Execute Gradle build
         working-directory: backend
-        run: ./gradlew buildFatJar
+        run: ./gradlew shadowJar
 
       - name: Set tag
         id: set-tag

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,6 +6,6 @@ RUN mkdir /app
 EXPOSE 8080
 RUN adduser -D user && chown -R user /app
 WORKDIR .
-COPY build/libs/backend-all.jar /app/regelrett.jar
+COPY build/libs/*.jar /app/regelrett.jar
 USER user
 ENTRYPOINT ["java","-jar","/app/regelrett.jar"]

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 val ktor_version: String by project
 val kotlin_version: String by project
 val logback_version: String by project
@@ -6,6 +8,7 @@ plugins {
     kotlin("jvm") version "1.9.24"
     id("io.ktor.plugin") version "2.3.12"
     kotlin("plugin.serialization") version "1.5.0"
+    id("com.gradleup.shadow") version "8.3.0"
 }
 
 group = "no.bekk"
@@ -60,4 +63,8 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
 }
 
-//tasks.register("prepareKotlinBuildScriptModel"){}
+tasks {
+    withType<ShadowJar> {
+        mergeServiceFiles()
+    }
+}


### PR DESCRIPTION
## Background
Migration scripts are not picked up correctly when starting the application only from the jar. Flyway has an issue on it, and several others experience the same [issue](https://github.com/flyway/flyway/issues/3811)

## Solution
According to the issue, a fix is to include the shadowJar-plugin and configure it with `mergeServiceFiles()` task. I do not know the details of the solution, but it's worth a shot.

Resolves #issue-this-pr-resolves
