### PR TITLE
add colors to alternatives

### DIFF
--- a/backend/src/main/kotlin/no/bekk/model/internal/Table.kt
+++ b/backend/src/main/kotlin/no/bekk/model/internal/Table.kt
@@ -3,10 +3,16 @@ package no.bekk.model.internal
 import kotlinx.serialization.Serializable
 
 @Serializable
+data class Option(
+    val name: String,
+    val color: String? = null,
+)
+
+@Serializable
 data class Field(
     val type: OptionalFieldType,
     val name: String,
-    val options: List<String>?
+    val options: List<Option>?
 )
 
 @Serializable

--- a/backend/src/main/kotlin/no/bekk/services/TableService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/TableService.kt
@@ -36,7 +36,7 @@ class TableService {
 
         val questions = metodeverkData.records.map { record ->
             record.mapToQuestion(
-                answers = answers.filter { it.questionId == record.fields.jsonObject["ID"]?.jsonPrimitive?.content},
+                answers = answers.filter { it.questionId == record.fields.jsonObject["ID"]?.jsonPrimitive?.content },
                 comments = comments.filter { it.questionId == record.fields.jsonObject["ID"]?.jsonPrimitive?.content },
                 metaDataFields = tableMetadata.fields,
             )
@@ -46,7 +46,9 @@ class TableService {
             Field(
                 type = mapAirTableFieldTypeToOptionalFieldType(AirTableFieldType.fromString(field.type)),
                 name = field.name,
-                options = field.options?.choices?.map { choice -> choice.name }
+                options = field.options?.choices?.map { choice ->
+                    Option(name = choice.name, color = choice.color)
+                }
             )
         }
 

--- a/frontend/beCompliant/src/api/types.ts
+++ b/frontend/beCompliant/src/api/types.ts
@@ -28,9 +28,14 @@ export type Comment = {
 };
 
 export type Field = {
-  options: string[] | null;
+  options: Option[] | null;
   name: string;
   type: OptionalFieldType;
+};
+
+export type Option = {
+  name: string;
+  color?: string;
 };
 
 export enum OptionalFieldType {

--- a/frontend/beCompliant/src/components/table/AnswerCell.tsx
+++ b/frontend/beCompliant/src/components/table/AnswerCell.tsx
@@ -1,10 +1,11 @@
-import { Box, Button, Input, Select, Stack, Textarea, Text } from '@kvib/react';
+import { Button, Input, Select, Stack, Textarea } from '@kvib/react';
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useSubmitAnswers } from '../../hooks/useSubmitAnswers';
 import { AnswerType } from '../../api/types';
-import { formatDateTime } from '../../utils/formatTime';
 import { LastUpdated } from './LastUpdated';
+import { Option } from '../../api/types';
+import colorUtils from '../../utils/colorUtils';
 
 type Props = {
   value: any;
@@ -14,6 +15,7 @@ type Props = {
   comment: string;
   updated?: Date;
   choices?: string[] | null;
+  options?: Option[] | null;
 };
 
 export function AnswerCell({
@@ -23,6 +25,7 @@ export function AnswerCell({
   questionName,
   updated,
   choices,
+  options,
 }: Props) {
   const params = useParams();
   const team = params.teamName;
@@ -84,6 +87,15 @@ export function AnswerCell({
         throw new Error(
           `Failed to fetch choices for single selection answer cell`
         );
+
+      const selectedColor = options?.find(
+        (option) => option.name === selectedAnswer
+      )?.color;
+
+      const selectedAnswerBackgroundColor = selectedColor
+        ? (colorUtils.getHexForColor(selectedColor) ?? undefined)
+        : undefined;
+
       return (
         <Stack spacing={1}>
           <Select
@@ -92,7 +104,7 @@ export function AnswerCell({
             onChange={handleSelectionAnswer}
             value={selectedAnswer}
             width="170px"
-            background="white"
+            background={selectedAnswerBackgroundColor}
           >
             {choices.map((choice) => (
               <option value={choice} key={choice}>

--- a/frontend/beCompliant/src/components/table/TableCell.tsx
+++ b/frontend/beCompliant/src/components/table/TableCell.tsx
@@ -2,6 +2,7 @@ import { Flex, Tag, Text } from '@kvib/react';
 import { Row } from '@tanstack/react-table';
 import { AnswerCell } from './AnswerCell';
 import { Field, OptionalFieldType, Question } from '../../api/types';
+import colorUtils from '../../utils/colorUtils';
 
 type Props = {
   value: any;
@@ -10,7 +11,12 @@ type Props = {
   answerable?: boolean;
 };
 
-export const TableCell = ({ value, row, answerable = false }: Props) => {
+export const TableCell = ({
+  value,
+  column,
+  row,
+  answerable = false,
+}: Props) => {
   if (answerable) {
     return (
       <AnswerCell
@@ -21,6 +27,7 @@ export const TableCell = ({ value, row, answerable = false }: Props) => {
         comment={row.original.comments?.at(0)?.comment ?? ''}
         updated={row.original.answers[0]?.updated}
         choices={row.original.metadata?.answerMetadata.options}
+        options={column.options}
       />
     );
   }
@@ -47,7 +54,25 @@ export const TableCell = ({ value, row, answerable = false }: Props) => {
       );
     }
     case OptionalFieldType.OPTION_SINGLE:
-      return <Tag backgroundColor={'#cccccc'}>{value.value}</Tag>;
+      const backgroundColor = column.options?.find(
+        (option) => option.name === value.value[0]
+      )?.color;
+
+      const backgroundColorHex = colorUtils.getHexForColor(
+        backgroundColor ?? 'grayLight1'
+      );
+      const useWhiteTextColor = colorUtils.shouldUseLightTextOnColor(
+        backgroundColor ?? 'grayLight1'
+      );
+
+      return (
+        <Tag
+          backgroundColor={backgroundColorHex ?? 'white'}
+          textColor={useWhiteTextColor ? 'white' : 'black'}
+        >
+          {value.value}
+        </Tag>
+      );
   }
   return (
     <Text whiteSpace="normal" fontSize="md">

--- a/frontend/beCompliant/src/components/tableActions/TableFilter.tsx
+++ b/frontend/beCompliant/src/components/tableActions/TableFilter.tsx
@@ -1,10 +1,11 @@
 import { Flex, Select, Text } from '@kvib/react';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { ActiveFilter } from '../../types/tableTypes';
+import { Option } from '../../api/types';
 
 export type TableFilters = {
   filterName: string;
-  filterOptions: string[] | null;
+  filterOptions: Option[] | null;
   activeFilters: ActiveFilter[];
   setActiveFilters: Dispatch<SetStateAction<ActiveFilter[]>>;
 };
@@ -32,9 +33,9 @@ export const TableFilter = ({
     event: React.ChangeEvent<HTMLSelectElement>
   ): void => {
     const filterValue = filterOptions?.find(
-      (choice) => choice === event.target.value
+      (choice) => choice.name === event.target.value
     );
-    setCurrentValue(filterValue);
+    setCurrentValue(filterValue?.name);
 
     const updatedFilters = activeFilters.filter(
       (filter) => filter.filterName !== filterName
@@ -43,7 +44,7 @@ export const TableFilter = ({
     if (filterValue) {
       updatedFilters.push({
         filterName: filterName,
-        filterValue: filterValue,
+        filterValue: filterValue.name,
       });
     }
 
@@ -68,8 +69,8 @@ export const TableFilter = ({
           whiteSpace="nowrap"
         >
           {filterOptions?.map((choice) => (
-            <option value={choice} key={choice}>
-              {choice}
+            <option value={choice.name} key={choice.name} color={choice.color}>
+              {choice.name}
             </option>
           ))}
         </Select>

--- a/frontend/beCompliant/src/pages/ActivityPage.tsx
+++ b/frontend/beCompliant/src/pages/ActivityPage.tsx
@@ -28,7 +28,10 @@ export const ActivityPage = () => {
   const { data, error, isFetching } = useFetchTable(tableId, team);
 
   const statusFilterOptions: Field = {
-    options: ['Utfylt', 'Ikke utfylt'],
+    options: [
+      { name: 'Utfylt', color: '' },
+      { name: 'Ikke utfylt', color: '' },
+    ],
     name: 'Status',
     type: OptionalFieldType.OPTION_SINGLE,
   };


### PR DESCRIPTION
## Background
Fargene på de ulike alternativene fra airtable var ikke tatt med og vist

## Solution
Endret til å sende med fargene når tabellen fetches i frontend
Mapper ut riktig farge til alternativet og displayer det

Resolves #issue-this-pr-resolves
#168 