### PR TITLE
fix pagination

### DIFF
--- a/frontend/beCompliant/src/components/table/pagination/PaginationButtonContainer.tsx
+++ b/frontend/beCompliant/src/components/table/pagination/PaginationButtonContainer.tsx
@@ -16,7 +16,7 @@ export function PaginationButtonContainer<TData>({ table }: Props<TData>) {
   const numberOfPages = Math.ceil(numberOfRows / pageSize);
   const ref = useRef<HTMLDivElement>(null);
 
-  const scrollToPagination = () => {
+  useEffect(() => {
     if (ref.current) {
       const currentScrollPosition =
         window.scrollY || document.documentElement.scrollTop;
@@ -25,9 +25,7 @@ export function PaginationButtonContainer<TData>({ table }: Props<TData>) {
         (currentScrollPosition + window.innerHeight);
       window.scrollBy({ top: distanceToBottom, behavior: 'auto' });
     }
-  };
-
-  useEffect(scrollToPagination, [index]);
+  }, [index]);
 
   return (
     <Flex

--- a/frontend/beCompliant/src/components/table/pagination/PaginationButtonContainer.tsx
+++ b/frontend/beCompliant/src/components/table/pagination/PaginationButtonContainer.tsx
@@ -2,7 +2,7 @@ import { Flex, Icon } from '@kvib/react';
 import { Table, Updater } from '@tanstack/react-table';
 import { PaginationActionButton } from './PaginationActionButton';
 import { PaginationRelativeButtons } from './PaginationRelativeButtons';
-import { useRef } from 'react';
+import { useRef, useEffect } from 'react';
 
 interface Props<TData> {
   table: Table<TData>;
@@ -17,10 +17,17 @@ export function PaginationButtonContainer<TData>({ table }: Props<TData>) {
   const ref = useRef<HTMLDivElement>(null);
 
   const scrollToPagination = () => {
-    if (ref.current !== null) {
-      ref.current.scrollIntoView({ behavior: 'auto', block: 'start' });
+    if (ref.current) {
+      const currentScrollPosition =
+        window.scrollY || document.documentElement.scrollTop;
+      const distanceToBottom =
+        document.documentElement.scrollHeight -
+        (currentScrollPosition + window.innerHeight);
+      window.scrollBy({ top: distanceToBottom, behavior: 'auto' });
     }
   };
+
+  useEffect(scrollToPagination, [index]);
 
   return (
     <Flex
@@ -36,7 +43,6 @@ export function PaginationButtonContainer<TData>({ table }: Props<TData>) {
         isDisplayed={table.getCanPreviousPage()}
         onClick={() => {
           table.previousPage();
-          scrollToPagination();
         }}
       >
         <Icon size={30} icon="chevron_left" />
@@ -44,7 +50,6 @@ export function PaginationButtonContainer<TData>({ table }: Props<TData>) {
       <PaginationActionButton
         onClick={() => {
           table.setPageIndex(0);
-          scrollToPagination();
         }}
         ariaLabel={'Gå til side 1'}
         isCurrent={index === 0}
@@ -56,7 +61,6 @@ export function PaginationButtonContainer<TData>({ table }: Props<TData>) {
         currentIndex={index}
         setIndex={(index: Updater<number>) => {
           table.setPageIndex(index);
-          scrollToPagination();
         }}
       />
 
@@ -64,7 +68,6 @@ export function PaginationButtonContainer<TData>({ table }: Props<TData>) {
         <PaginationActionButton
           onClick={() => {
             table.setPageIndex(numberOfPages - 1);
-            scrollToPagination();
           }}
           ariaLabel={'Gå til siste side'}
           isCurrent={index === numberOfPages - 1}
@@ -75,7 +78,6 @@ export function PaginationButtonContainer<TData>({ table }: Props<TData>) {
       <PaginationActionButton
         onClick={() => {
           table.nextPage();
-          scrollToPagination();
         }}
         ariaLabel={'Gå til neste side'}
         isDisplayed={table.getCanNextPage()}


### PR DESCRIPTION
## Background
Viewen hoppet når man byttet sider

## Solution
Viewen på siden "låses" til nederst i siden uavhengig av lengden på sikkerhetskontrollere. Man kan nå enkelt trykke seg gjennom sidene uten å måtte flytte på pekeren. 

Resolves #issue-this-pr-resolves
#220 