### PR TITLE
Remove sorting when column is hidden

### DIFF
--- a/frontend/beCompliant/src/components/table/DataTable.tsx
+++ b/frontend/beCompliant/src/components/table/DataTable.tsx
@@ -48,16 +48,17 @@ export function DataTable<TData>({
   const headerNames = table.getAllColumns().map((column) => column.id);
 
   const handleOnChange = () => {
-    if (
-      JSON.stringify(getShownColumns(columnVisibility, headerNames)) ===
-      JSON.stringify(FILLMODE_COLUMNS)
-    ) {
+    const currentShownColumns = JSON.stringify(
+      getShownColumns(columnVisibility, headerNames)
+    );
+    const isFillMode = currentShownColumns === JSON.stringify(FILLMODE_COLUMNS);
+
+    if (isFillMode) {
       unHideColumns();
     } else {
       showOnlyFillModeColumns(headerNames);
-      FILLMODE_COLUMNS.forEach((column) => {
-        unHideColumn(column);
-      });
+      headerNames.forEach((header) => table.getColumn(header)?.clearSorting());
+      FILLMODE_COLUMNS.forEach(unHideColumn);
     }
   };
 

--- a/frontend/beCompliant/src/components/table/DataTableHeader.tsx
+++ b/frontend/beCompliant/src/components/table/DataTableHeader.tsx
@@ -29,6 +29,7 @@ export function DataTableHeader<TData, TValue>({
 }: Props<TData, TValue>) {
   const theme = useTheme();
   const hideColumn = (name: string) => {
+    column.clearSorting();
     setColumnVisibility((prev) => ({
       ...prev,
       [name]: false,


### PR DESCRIPTION
## Background
Når det er sortert på en kolonne og den kolonnen blir skjult, er dataen fortsatt sortert på den kolonnen

## Solution
Fjerner sortering på kolonnen når kolonnen skjules.

Resolves #issue-this-pr-resolves
#227 