### PR TITLE
Updating readme with info about where to find secrets

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -42,6 +42,11 @@ CLIENT_ID
 CLIENT_SECRET
 TENANT_ID
 ```
+
+To get access to the secrets ask someone on the team to give you access to the 1password vault.
+`AIRTABLE_ACCESS_TOKEN` is stored under the name `AirTable` in the vault and `CLIENT_ID`, `CLIENT_SECRET`
+and `TENANT_ID` is stored under `EntraId`.
+
 You can do this in IntelliJ under `Run -> Edit configurations`. Most of the values can be found in 1Password. You should be given access by another team member.
 
 ## Build with Gradle

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -31,6 +31,6 @@ frontend:
   host: "$FRONTEND_URL_HOST:localhost:3000"
 
 db:
-  url: "jdbc:postgresql://localhost:5432/regelrett"
+  url: "$DB_URL:jdbc:postgresql://localhost:5432/regelrett"
   username: "$DB_NAME:postgres"
   password: "$DB_PASSWORD:pwd"


### PR DESCRIPTION
Oppdaterer readme med info om hvor man finner secretene man må sette som miljøvariabler.

Gjorde det og mulig å overstyre DB_URL på samme måte som brukernavn og passord, dette for å støtte at man kan kjøre opp databasen lokalt på en annen port enn default (og unngå konflikt med andre postgres-instanser man kan ha kjørende)
