### PR TITLE
Redirect user to login if not authenticated

### DIFF
--- a/frontend/beCompliant/src/App.tsx
+++ b/frontend/beCompliant/src/App.tsx
@@ -1,7 +1,10 @@
 import { RouterProvider } from 'react-router-dom';
 import router from './routes';
+import { useIsLoggedIn } from './hooks/useIsLoggedIn';
 
 function App() {
+  useIsLoggedIn();
+
   return <RouterProvider router={router} />;
 }
 

--- a/frontend/beCompliant/src/hooks/useIsLoggedIn.ts
+++ b/frontend/beCompliant/src/hooks/useIsLoggedIn.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+import { axiosFetch } from '../api/Fetch';
+import { API_URL_AUTH_STATUS, API_URL_LOGIN } from '../api/apiConfig';
+import { useEffect, useState } from 'react';
+
+type AuthStatus = {
+  authenticated: boolean;
+};
+
+export const useIsLoggedIn = () => {
+  const [isLoggedIn, setIsLoggedIn] = useState(true);
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      window.location.href = API_URL_LOGIN;
+    }
+  }, [isLoggedIn]);
+
+  return useQuery({
+    queryKey: ['isLoggedIn'],
+    refetchOnWindowFocus: true,
+    refetchOnMount: true,
+    staleTime: 0,
+    queryFn: () =>
+      axiosFetch<AuthStatus>({ url: API_URL_AUTH_STATUS })
+        .then((response) => {
+          if (!response.data.authenticated) {
+            setIsLoggedIn(false);
+          }
+        })
+        .catch(() => setIsLoggedIn(false)),
+  });
+};

--- a/frontend/beCompliant/src/hooks/useIsLoggedIn.ts
+++ b/frontend/beCompliant/src/hooks/useIsLoggedIn.ts
@@ -1,21 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { axiosFetch } from '../api/Fetch';
 import { API_URL_AUTH_STATUS, API_URL_LOGIN } from '../api/apiConfig';
-import { useEffect, useState } from 'react';
 
 type AuthStatus = {
   authenticated: boolean;
 };
 
 export const useIsLoggedIn = () => {
-  const [isLoggedIn, setIsLoggedIn] = useState(true);
-
-  useEffect(() => {
-    if (!isLoggedIn) {
-      window.location.href = API_URL_LOGIN;
-    }
-  }, [isLoggedIn]);
-
   return useQuery({
     queryKey: ['isLoggedIn'],
     refetchOnWindowFocus: true,
@@ -25,9 +16,11 @@ export const useIsLoggedIn = () => {
       axiosFetch<AuthStatus>({ url: API_URL_AUTH_STATUS })
         .then((response) => {
           if (!response.data.authenticated) {
-            setIsLoggedIn(false);
+            window.location.href = API_URL_LOGIN;
           }
         })
-        .catch(() => setIsLoggedIn(false)),
+        .catch(() => {
+          window.location.href = API_URL_LOGIN;
+        }),
   });
 };


### PR DESCRIPTION
## Background
Hvis tokenet til brukeren utløper, så får man ingen respons på det med mindre man laster in siden på nytt. Da kan man avgi svar eller skrive en kommentar, og bare få feilmelding uten å vite at det er fordi man ikke lenger er logget inn.

## Solution
Har laget en hook som querier `/auth-status` hver gang vinduet får fokus eller komponenten mounter. Da vil man bli redirected til login hvis man har blitt logget ut.

Resolves #225 
