### PR TITLE
Update backend to send response instead of text, and to update timest…

### DIFF
--- a/backend/src/main/kotlin/no/bekk/routes/AnswerRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/AnswerRouting.kt
@@ -33,8 +33,8 @@ fun Route.answerRouting() {
             updated = "",
             team = answerRequest.team,
         )
-        databaseRepository.getAnswerFromDatabase(answer)
-        call.respondText("Answer was successfully submitted.")
+        val insertedAnswer = databaseRepository.insertAnswer(answer)
+        call.respond(HttpStatusCode.OK, Json.encodeToString(insertedAnswer))
     }
 
     get("/answers") {

--- a/frontend/beCompliant/src/components/Table.tsx
+++ b/frontend/beCompliant/src/components/Table.tsx
@@ -105,7 +105,7 @@ export function TableComponent({ data, tableData }: Props) {
         <Comment
           comment={getValue()}
           questionId={row.original.id}
-          updated={row.original.comments[0]?.updated}
+          updated={row.original.comments.at(-1)?.updated}
           team={team}
         />
       </DataTableCell>

--- a/frontend/beCompliant/src/components/table/AnswerCell.tsx
+++ b/frontend/beCompliant/src/components/table/AnswerCell.tsx
@@ -34,7 +34,13 @@ export function AnswerCell({
     value
   );
 
-  const { mutate: submitAnswer } = useSubmitAnswers(team);
+  const { mutate: submitAnswer, data: submitAnswerResponse } =
+    useSubmitAnswers(team);
+
+  const updatedDate =
+    submitAnswerResponse?.data != null
+      ? new Date(submitAnswerResponse.data.updated)
+      : updated;
 
   const handleInputAnswer = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
@@ -112,7 +118,7 @@ export function AnswerCell({
               </option>
             ))}
           </Select>
-          {updated && <LastUpdated updated={updated} />}
+          {updatedDate && <LastUpdated updated={updatedDate} />}
         </Stack>
       );
   }

--- a/frontend/beCompliant/src/components/table/Comment.tsx
+++ b/frontend/beCompliant/src/components/table/Comment.tsx
@@ -30,6 +30,9 @@ export function Comment({ comment, questionId, updated, team }: Props) {
     onClose: onDeleteClose,
   } = useDisclosure();
 
+  const updatedDate =
+    data?.data != null ? new Date(data.data.updated) : updated;
+
   const handleCommentSubmit = () => {
     if (editedComment !== comment && editedComment != null) {
       submitComment({
@@ -153,7 +156,7 @@ export function Comment({ comment, questionId, updated, team }: Props) {
           />
         </Flex>
       </Flex>
-      {updated && <LastUpdated updated={updated} />}
+      {updatedDate && <LastUpdated updated={updatedDate} />}
       <DeleteCommentModal
         onOpen={onDeleteOpen}
         onClose={onDeleteClose}

--- a/frontend/beCompliant/src/components/table/TableCell.tsx
+++ b/frontend/beCompliant/src/components/table/TableCell.tsx
@@ -25,7 +25,7 @@ export const TableCell = ({
         questionId={row.original.id}
         questionName={row.original.question}
         comment={row.original.comments?.at(0)?.comment ?? ''}
-        updated={row.original.answers[0]?.updated}
+        updated={row.original.answers.at(-1)?.updated}
         choices={row.original.metadata?.answerMetadata.options}
         options={column.options}
       />

--- a/frontend/beCompliant/src/hooks/useSubmitAnswers.ts
+++ b/frontend/beCompliant/src/hooks/useSubmitAnswers.ts
@@ -20,10 +20,10 @@ export function useSubmitAnswers(team?: string) {
   return useMutation({
     mutationKey: apiConfig.answer.queryKey,
     mutationFn: (body: SubmitAnswerRequest) => {
-      return axiosFetch({
+      return axiosFetch<SubmitAnswerRequest>({
         url: URL,
         method: 'POST',
-        data: body,
+        data: JSON.stringify(body),
       });
     },
     onSuccess: () => {


### PR DESCRIPTION
Update backend to send response instead of text, and to update timestamps in UI

## Background
Endring av svar og kommentarer bare vises når siden refreshes. 

## Solution
Endepunktet sender nå det nye svaret som respons i stedet for bare tekst
Displayer den nye timestampen med en gang svaret eller kommentaren endres

Tar gjerne imot hjelp med:
Når svaret eller kommentaren oppdateres, displayes det nye svaret eller kommentaren med oppdatert tidspunkt. Likevel, når man gjør noe på siden som f.eks. å filtrere eller trykke på utfyllingsmodus, vises det "gamle" svaret/kommentaren og tidspunktet. Bare når siden refreshes kan man se den "nye" dataen. Anders og jeg tror at det er fordi komponenten da blir laget på nytt og tar verdien fra props som ikke har blitt endret. Prøvde litt forskjellig, men kom ikke fram til noe fornuftig løsning.

Resolves #issue-this-pr-resolves
#222 
