### PR TITLE
Fikser at kommentarfeltet lukker seg om man endrer svaralternativ

### DIFF
--- a/backend/resources/.gitignore
+++ b/backend/resources/.gitignore
@@ -1,0 +1,1 @@
+*.private.env.json

--- a/backend/resources/airtable.http
+++ b/backend/resources/airtable.http
@@ -4,11 +4,6 @@ Authorization: Bearer {{AIRTABLE_TOKEN}}
 
 ###
 
-GET https://api.airtable.com/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v
-Authorization: Bearer {{AIRTABLE_TOKEN}}
-
-###
-
 GET https://api.airtable.com/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v?offset=itrEBNYNjNHE6o6gX/recc7IE7PBvvkrcHN
 Authorization: Bearer {{AIRTABLE_TOKEN}}
 

--- a/backend/resources/airtable.http
+++ b/backend/resources/airtable.http
@@ -1,0 +1,78 @@
+### Metodeverk for deling
+GET https://api.airtable.com/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v
+Authorization: Bearer {{AIRTABLE_TOKEN}}
+
+###
+
+GET https://api.airtable.com/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v
+Authorization: Bearer {{AIRTABLE_TOKEN}}
+
+###
+
+GET https://api.airtable.com/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v?offset=itrEBNYNjNHE6o6gX/recc7IE7PBvvkrcHN
+Authorization: Bearer {{AIRTABLE_TOKEN}}
+
+###
+
+GET https://api.airtable.com/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v?view=viw2XliGUJu5448Hk
+Authorization: Bearer {{AIRTABLE_TOKEN}}
+
+###
+
+GET https://api.airtable.com/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v?view=viw2XliGUJu5448Hk&
+    offset=itrudhieToHuw2ZEt/recXVaggbJhBIsTTe
+Authorization: Bearer {{AIRTABLE_TOKEN}}
+
+
+### Hente ut informasjon fra ulike records
+
+GET https://api.airtable.com/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v/recoLfk5vlyM96vd6
+Authorization: Bearer {{AIRTABLE_TOKEN}}
+
+###
+
+GET https://api.airtable.com/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v/recdOhcX8zVd1sfZy
+Authorization: Bearer {{AIRTABLE_TOKEN}}
+
+
+### Alle
+
+GET https://api.airtable.com/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v?view=viw2XliGUJu5448Hk
+Authorization: Bearer {{AIRTABLE_TOKEN}}
+
+###
+
+GET https://api.airtable.com/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v?fields=ID&fields=Aktivitiet&fields=Pri&
+    fields=Kortnavn
+Authorization: Bearer {{AIRTABLE_TOKEN}}
+
+###
+
+GET https://api.airtable.com/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v?view=viwCjOnfZlhMBNVJj
+Authorization: Bearer {{AIRTABLE_TOKEN}}
+
+###
+
+GET https://api.airtable.com/v0/meta/bases/appzJQ8Tkmm8DobrJ/views
+Authorization: Bearer {{AIRTABLE_TOKEN}}
+
+###
+
+GET https://api.airtable.com/v0/meta/bases
+Authorization: Bearer {{AIRTABLE_TOKEN}}
+
+###
+
+GET https://api.airtable.com/v0/meta/bases/appzJQ8Tkmm8DobrJ/tables
+Authorization: Bearer {{AIRTABLE_TOKEN}}
+
+###
+
+
+
+
+
+
+
+
+

--- a/frontend/beCompliant/src/components/Table.tsx
+++ b/frontend/beCompliant/src/components/Table.tsx
@@ -16,12 +16,7 @@ import { DataTable } from './table/DataTable';
 import { DataTableCell } from './table/DataTableCell';
 import { DataTableHeader } from './table/DataTableHeader';
 import { TableCell } from './table/TableCell';
-import {
-  OptionalField,
-  OptionalFieldType,
-  Question,
-  Table,
-} from '../api/types';
+import { OptionalField, Question, Table } from '../api/types';
 
 type Props = {
   data: Question[];

--- a/frontend/beCompliant/src/components/table/Comment.tsx
+++ b/frontend/beCompliant/src/components/table/Comment.tsx
@@ -17,9 +17,6 @@ export function Comment({ comment, questionId, updated, team }: Props) {
   const [editedComment, setEditedComment] = useState<string | undefined>(
     comment
   );
-  const [submittedComment, setSubmittedComment] = useState<
-    string | undefined
-  >();
   const [commentDeleted, setCommentDeleted] = useState(false);
   const [editMode, setEditMode] = useState<boolean>(false);
   const {
@@ -44,12 +41,6 @@ export function Comment({ comment, questionId, updated, team }: Props) {
       });
     }
   };
-
-  useEffect(() => {
-    if (data?.data) {
-      setSubmittedComment(data.data.comment);
-    }
-  }, [data]);
 
   const handleDiscardChanges = () => {
     setEditedComment(comment);
@@ -115,7 +106,7 @@ export function Comment({ comment, questionId, updated, team }: Props) {
   }
 
   // change this when the new data model is implemented. Because this should not be an empty string
-  if ((comment === '' && !submittedComment) || commentDeleted) {
+  if ((comment === '' && data?.data.comment == null) || commentDeleted) {
     return (
       <IconButton
         aria-label="Legg til kommentar"
@@ -141,7 +132,7 @@ export function Comment({ comment, questionId, updated, team }: Props) {
           whiteSpace="normal"
           fontSize="md"
         >
-          {submittedComment ?? comment}
+          {data?.data.comment ?? comment}
         </Text>
         <Flex flexDirection="column" gap="2">
           <IconButton

--- a/frontend/beCompliant/src/components/table/Comment.tsx
+++ b/frontend/beCompliant/src/components/table/Comment.tsx
@@ -40,7 +40,6 @@ export function Comment({ comment, questionId, updated, team }: Props) {
         updated: '',
       });
     }
-    setIsEditing(false);
   };
 
   const handleDiscardChanges = () => {

--- a/frontend/beCompliant/src/components/table/DataTable.tsx
+++ b/frontend/beCompliant/src/components/table/DataTable.tsx
@@ -20,6 +20,7 @@ import React from 'react';
 import { FILLMODE_COLUMNS } from '../../utils/fillmodeColumns';
 import { DataTableSearch } from './DataTableSearch';
 import { PaginationButtonContainer } from './pagination/PaginationButtonContainer';
+import { TableStateProvider } from './TableState';
 
 interface Props<TData> {
   table: TanstackTable<TData>;
@@ -63,108 +64,118 @@ export function DataTable<TData>({
   };
 
   return (
-    <Flex flexDirection="column" width="100%" gap="4">
-      <Flex
-        justifyContent={hasHiddenColumns ? 'space-between' : 'flex-end'}
-        alignItems="end"
-        width="100%"
-        paddingX="10"
-      >
-        {hasHiddenColumns && (
-          <Flex direction="column" gap="2">
-            <Heading size="xs" fontWeight="semibold">
-              Skjulte kolonner
-            </Heading>
-            <Flex gap="1" alignItems="center" flexWrap="wrap">
-              <Button
-                aria-label={'Show all columns'}
-                onClick={() => unHideColumns()}
-                colorScheme="blue"
-                size="xs"
-              >
-                <Text size="md" variant="solid" colorScheme="blue">
-                  Vis alle kolonner
-                </Text>
-              </Button>
-              <Divider height="5" orientation="vertical" />
-              {Object.entries(columnVisibility)
-                .filter(([_, visible]) => !visible)
-                .map(([name, _]) => (
-                  <Tag colorScheme="blue" variant="subtle" size="md" key={name}>
-                    <TagLabel>{name}</TagLabel>
-                    <TagCloseButton onClick={() => unHideColumn(name)} />
-                  </Tag>
-                ))}
+    <TableStateProvider>
+      <Flex flexDirection="column" width="100%" gap="4">
+        <Flex
+          justifyContent={hasHiddenColumns ? 'space-between' : 'flex-end'}
+          alignItems="end"
+          width="100%"
+          paddingX="10"
+        >
+          {hasHiddenColumns && (
+            <Flex direction="column" gap="2">
+              <Heading size="xs" fontWeight="semibold">
+                Skjulte kolonner
+              </Heading>
+              <Flex gap="1" alignItems="center" flexWrap="wrap">
+                <Button
+                  aria-label={'Show all columns'}
+                  onClick={() => unHideColumns()}
+                  colorScheme="blue"
+                  size="xs"
+                >
+                  <Text size="md" variant="solid" colorScheme="blue">
+                    Vis alle kolonner
+                  </Text>
+                </Button>
+                <Divider height="5" orientation="vertical" />
+                {Object.entries(columnVisibility)
+                  .filter(([_, visible]) => !visible)
+                  .map(([name, _]) => (
+                    <Tag
+                      colorScheme="blue"
+                      variant="subtle"
+                      size="md"
+                      key={name}
+                    >
+                      <TagLabel>{name}</TagLabel>
+                      <TagCloseButton onClick={() => unHideColumn(name)} />
+                    </Tag>
+                  ))}
+              </Flex>
             </Flex>
-          </Flex>
-        )}
-        <Flex alignItems="center" gap={3}>
-          <Flex
-            alignItems="center"
-            flexDirection="row"
-            backgroundColor={theme.colors.blue[50]}
-            padding={4}
-            borderRadius="5px"
-            maxHeight="28px"
-          >
-            <Text
-              fontWeight="bold"
-              marginRight="15px"
-              color={theme.colors.gray[700]}
+          )}
+          <Flex alignItems="center" gap={3}>
+            <Flex
+              alignItems="center"
+              flexDirection="row"
+              backgroundColor={theme.colors.blue[50]}
+              padding={4}
+              borderRadius="5px"
+              maxHeight="28px"
             >
-              Utfyllingsmodus
+              <Text
+                fontWeight="bold"
+                marginRight="15px"
+                color={theme.colors.gray[700]}
+              >
+                Utfyllingsmodus
+              </Text>
+              <Switch
+                onChange={handleOnChange}
+                colorScheme="blue"
+                isChecked={
+                  JSON.stringify(
+                    getShownColumns(columnVisibility, headerNames)
+                  ) === JSON.stringify(FILLMODE_COLUMNS)
+                }
+              />
+            </Flex>
+            <Text
+              maxWidth="350px"
+              fontSize="small"
+              color={theme.colors.gray[500]}
+            >
+              Viser kun essensielle kolonner slik at det blir mer oversiktlig å
+              fylle inn data.
             </Text>
-            <Switch
-              onChange={handleOnChange}
-              colorScheme="blue"
-              isChecked={
-                JSON.stringify(
-                  getShownColumns(columnVisibility, headerNames)
-                ) === JSON.stringify(FILLMODE_COLUMNS)
-              }
-            />
+            {showSearch && <DataTableSearch table={table} />}
           </Flex>
-          <Text
-            maxWidth="350px"
-            fontSize="small"
-            color={theme.colors.gray[500]}
-          >
-            Viser kun essensielle kolonner slik at det blir mer oversiktlig å
-            fylle inn data.
-          </Text>
-          {showSearch && <DataTableSearch table={table} />}
         </Flex>
+        <TableContainer background="white" paddingX="3">
+          <Table variant="striped">
+            <Thead>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <Tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <React.Fragment key={header.id}>
+                      {flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                    </React.Fragment>
+                  ))}
+                </Tr>
+              ))}
+            </Thead>
+            <Tbody>
+              {table.getRowModel().rows.map((row) => (
+                <Tr key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <React.Fragment key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </React.Fragment>
+                  ))}
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        </TableContainer>
+        <PaginationButtonContainer table={table} />
       </Flex>
-      <TableContainer background="white" paddingX="3">
-        <Table variant="striped">
-          <Thead>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <Tr key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <React.Fragment key={header.id}>
-                    {flexRender(
-                      header.column.columnDef.header,
-                      header.getContext()
-                    )}
-                  </React.Fragment>
-                ))}
-              </Tr>
-            ))}
-          </Thead>
-          <Tbody>
-            {table.getRowModel().rows.map((row) => (
-              <Tr key={row.id}>
-                {row.getVisibleCells().map((cell) => (
-                  <React.Fragment key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </React.Fragment>
-                ))}
-              </Tr>
-            ))}
-          </Tbody>
-        </Table>
-      </TableContainer>
-      <PaginationButtonContainer table={table} />
-    </Flex>
+    </TableStateProvider>
   );
 }

--- a/frontend/beCompliant/src/components/table/DeleteCommentModal.tsx
+++ b/frontend/beCompliant/src/components/table/DeleteCommentModal.tsx
@@ -11,7 +11,6 @@ import {
   Text,
 } from '@kvib/react';
 import { useDeleteComment } from '../../hooks/useDeleteComment';
-import { useEffect } from 'react';
 
 type Props = {
   onOpen: () => void;
@@ -32,28 +31,24 @@ export function DeleteCommentModal({
   setEditMode,
   setCommentDeleted,
 }: Props) {
-  const {
-    mutate: deleteComment,
-    isPending: isLoading,
-    isSuccess,
-  } = useDeleteComment(setEditMode, team);
-  const handleCommentDelete = () => {
-    deleteComment({
+  const { mutateAsync: deleteComment, isPending: isLoading } = useDeleteComment(
+    setEditMode,
+    team
+  );
+  const handleCommentDelete = async () => {
+    const result = await deleteComment({
       actor: 'Unknown',
       questionId: questionId,
       team: team,
       comment: comment,
       updated: new Date(),
     });
-    setEditMode(false);
-  };
-
-  useEffect(() => {
-    if (isSuccess) {
+    if (result.status >= 200 && result.status < 300) {
       setCommentDeleted(true);
+      setEditMode(false);
       onClose();
     }
-  }, [isSuccess]);
+  };
 
   return (
     <Modal onClose={onClose} isOpen={isOpen} isCentered>

--- a/frontend/beCompliant/src/components/table/DeleteCommentModal.tsx
+++ b/frontend/beCompliant/src/components/table/DeleteCommentModal.tsx
@@ -31,23 +31,25 @@ export function DeleteCommentModal({
   setEditMode,
   setCommentDeleted,
 }: Props) {
-  const { mutateAsync: deleteComment, isPending: isLoading } = useDeleteComment(
-    setEditMode,
+  const handleDeleteSuccess = () => {
+    setEditMode(false);
+    setCommentDeleted(true);
+    onClose();
+  };
+
+  const { mutate: deleteComment, isPending: isLoading } = useDeleteComment(
+    handleDeleteSuccess,
     team
   );
+
   const handleCommentDelete = async () => {
-    const result = await deleteComment({
+    deleteComment({
       actor: 'Unknown',
       questionId: questionId,
       team: team,
       comment: comment,
       updated: new Date(),
     });
-    if (result.status >= 200 && result.status < 300) {
-      setCommentDeleted(true);
-      setEditMode(false);
-      onClose();
-    }
   };
 
   return (

--- a/frontend/beCompliant/src/components/table/TableState.tsx
+++ b/frontend/beCompliant/src/components/table/TableState.tsx
@@ -1,0 +1,91 @@
+import { createContext, PropsWithChildren, useContext, useState } from 'react';
+
+export type KommentarCellState = {
+  isEditMode: boolean;
+  editedComment: string | null;
+};
+
+export type RowState = {
+  kommentar: KommentarCellState;
+};
+
+export type TableState = {
+  [rowId: string]: RowState;
+};
+
+type TableStateContextType = {
+  tableState: TableState;
+  getRowState: (rowId: string) => RowState;
+  setRowState: (rowId: string, state: RowState) => void;
+};
+
+const initialRowState: RowState = {
+  kommentar: {
+    isEditMode: false,
+    editedComment: null,
+  },
+};
+
+const initialValue: TableStateContextType = {
+  tableState: {},
+  getRowState: () => initialRowState,
+  setRowState: () => {},
+};
+
+const TableStateContext = createContext<TableStateContextType>(initialValue);
+
+export const TableStateProvider = ({ children }: PropsWithChildren) => {
+  const [tableState, setTableState] = useState<TableState>({});
+
+  const getRowState = (rowId: string) => {
+    if (tableState[rowId] != null) {
+      return tableState[rowId];
+    }
+    return initialRowState;
+  };
+
+  const setRowState = (rowId: string, rowState: RowState) => {
+    setTableState({ ...tableState, [rowId]: rowState });
+  };
+
+  const value = {
+    tableState,
+    getRowState,
+    setRowState,
+  };
+
+  return (
+    <TableStateContext.Provider value={value}>
+      {children}
+    </TableStateContext.Provider>
+  );
+};
+
+export const useTableState = () => {
+  return useContext<TableStateContextType>(TableStateContext);
+};
+
+export const useKommentarCellState = (rowId: string) => {
+  const { getRowState, setRowState } = useTableState();
+  const rowState = getRowState(rowId);
+
+  const setIsEditing = (isEditMode: boolean) => {
+    setRowState(rowId, {
+      ...rowState,
+      kommentar: { editedComment: null, isEditMode },
+    });
+  };
+
+  const setEditedComment = (editedComment: string | null) => {
+    setRowState(rowId, {
+      ...rowState,
+      kommentar: { ...rowState.kommentar, editedComment },
+    });
+  };
+
+  return {
+    ...rowState.kommentar,
+    setIsEditing,
+    setEditedComment,
+  };
+};

--- a/frontend/beCompliant/src/hooks/useDeleteComment.ts
+++ b/frontend/beCompliant/src/hooks/useDeleteComment.ts
@@ -4,10 +4,7 @@ import { axiosFetch } from '../api/Fetch';
 import { PATH_TABLE, apiConfig } from '../api/apiConfig';
 import { Comment } from '../api/types';
 
-export function useDeleteComment(
-  setEditMode: (editMode: boolean) => void,
-  team?: string
-) {
+export function useDeleteComment(onSuccess: () => void, team?: string) {
   const URL = apiConfig.comments.url;
   const queryClient = useQueryClient();
   const toast = useToast();
@@ -35,7 +32,7 @@ export function useDeleteComment(
       await queryClient.invalidateQueries({
         queryKey: apiConfig.comments.queryKey,
       });
-      setEditMode(false);
+      onSuccess();
       queryClient.refetchQueries({
         queryKey: [PATH_TABLE, team],
       });


### PR DESCRIPTION
## Background

Om man åpnet en eller flere kontrollere for å skrive kommentar og så endret svaralternativ i en av dropdownene så ble kommentarfeltet lukket. Årsaken til at dette skjedde var at Reac-table er litt teit å mounter komponentene på nytt når data i tabelen endrer seg. Dette betyr at all intern state for en komponent blir glemt. 

## Solution

For å løse dette er den enkleste løsninge og rett og slett gjøre denne type state mer global. For å ha en form for abstraksjon innførte jeg derfor en `TableStateContext` som kan brukes til å holde på alt av intern state for tabellen. Og så lagrer jeg intern-state i denne contexten slik at man kan bruke `useTableState` eller `useKommentarCellState` for å hente ut staten og eventuelt endre på den. Siden dette ligger globalt utenfor selve tabellen vil den ikke resettes selv om react-table remounter de ulike komponentene.

Tanken er at denne også skal kunne utvides til å holde på annen intern state men kunne trenge i tabellen på sikt. React-context har en del boilerplate så jeg håper at det jeg har gjort er forstålig. Men hvis ikke er det bare å spørre eller komme med tilbakemeldinger på ting som kunne være mer tydelig.

## Ekstra stuff

* Jeg la til en `airtable.http` fil. Dette skrev jeg om på slack, men er bare et alternativ til `curl.txt` for de som skulle ønske å bare kjøre HTTP-kallene direkte fra intelliJ i stede for å bruke cURL i terminalen. Jeg synes i hvertfall det er ganske mye diggere.
* Jeg skrev om 2 steder jeg så 2 useEffecter som var brukt litt feil, til å ikke bruke `useEffect` i det hele tatt.

Resolves #244 
