### PR TITLE
Special sort for some columns

### DIFF
--- a/frontend/beCompliant/src/components/Table.tsx
+++ b/frontend/beCompliant/src/components/Table.tsx
@@ -17,6 +17,7 @@ import { DataTableCell } from './table/DataTableCell';
 import { DataTableHeader } from './table/DataTableHeader';
 import { TableCell } from './table/TableCell';
 import { OptionalField, Question, Table } from '../api/types';
+import { getSortFuncForColumn } from './table/TableSort';
 
 type Props = {
   data: Question[];
@@ -72,18 +73,14 @@ export function TableComponent({ data, tableData }: Props) {
           (
             a.getValue(columnId) as OptionalField | null
           )?.value?.[0]?.toLowerCase() || '';
+
         const valueB =
           (
             b.getValue(columnId) as OptionalField | null
           )?.value?.[0]?.toLowerCase() || '';
 
-        if (valueA < valueB) {
-          return -1;
-        }
-        if (valueA > valueB) {
-          return 1;
-        }
-        return 0;
+        const sortFunc = getSortFuncForColumn(columnId);
+        return sortFunc(valueA, valueB);
       },
     })
   );

--- a/frontend/beCompliant/src/components/table/TableSort.ts
+++ b/frontend/beCompliant/src/components/table/TableSort.ts
@@ -1,0 +1,43 @@
+type SortFunc = (a: string, b: string) => number;
+
+export const standardColumnSort: SortFunc = (a, b) => {
+  return a.localeCompare(b);
+};
+
+const customSort = (a: string, b: string, priorityOrder: string[]): number => {
+  const priValueA = priorityOrder.indexOf(a);
+  const priValueB = priorityOrder.indexOf(b);
+
+  // If for some reason both values are not in the priority order list, lets use standard-sort
+  if (priValueA < 0 && priValueB < 0) {
+    return standardColumnSort(a, b);
+  }
+
+  return priValueA - priValueB;
+};
+
+export const prirorityColumnSort: SortFunc = (a, b) => {
+  const priorityOrder = ['kan', 'bør', '(må)', 'må'];
+  return customSort(a, b, priorityOrder);
+};
+
+export const ledetidColumnSort: SortFunc = (a, b) => {
+  const priorityOrder = [
+    'kort (< 1 mnd)',
+    'middels (1-3 mnd)',
+    'lang (> 3 mnd)',
+  ];
+  return customSort(a, b, priorityOrder);
+};
+
+export const getSortFuncForColumn = (columnId: string): SortFunc => {
+  console.log('Column id', columnId);
+  switch (columnId.toLowerCase()) {
+    case 'pri':
+      return prirorityColumnSort;
+    case 'ledetid':
+      return ledetidColumnSort;
+    default:
+      return standardColumnSort;
+  }
+};

--- a/frontend/beCompliant/src/components/table/TableSort.ts
+++ b/frontend/beCompliant/src/components/table/TableSort.ts
@@ -31,7 +31,6 @@ export const ledetidColumnSort: SortFunc = (a, b) => {
 };
 
 export const getSortFuncForColumn = (columnId: string): SortFunc => {
-  console.log('Column id', columnId);
   switch (columnId.toLowerCase()) {
     case 'pri':
       return prirorityColumnSort;


### PR DESCRIPTION
## Background

Sortering for enkelte kolonner blir litt merkelig om man sorterer alfabetisk. F.eks. for ledetid burde det sorteres kort -> middels -> lang (men alfabetisk blir det kort -> lang -> middels). Samme utfordring for prioritet.

## Solution

Jeg legger til spesialhåndtering av sortering for enkelte kolonner. Dette er desverre ikke veldig fleksibel løsning, men en veldig enkel løsning. På sikt kan man vurdere om man skal gå for noe mer fleksibelt hvor man kan gi en "sortValue" eller noe fra backend, slik at sorteringen kan styres i airtable. Men gjør det enkelt i første omgang med å bare ha spesialhåndtering.

Resolves #165 
