### PR TITLE
Dont autoreset all table-setting on datachange

### DIFF
--- a/frontend/beCompliant/src/components/Table.tsx
+++ b/frontend/beCompliant/src/components/Table.tsx
@@ -151,6 +151,7 @@ export function TableComponent({ data, tableData }: Props) {
     state: {
       columnVisibility,
     },
+    autoResetAll: false,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),


### PR DESCRIPTION
## Background

Om data i tanellen endret seg ble paginering og andre slikt valg reset, som er defaultoppførsel i react-table. Men det skapte litt rar opplevelse slik vi brukte tabellen.

## Solution

Setter `autoResetAll: false` for å skru av denne defaultoppførselen.

Resolves #247 