### PR TITLE
Yaml stotte

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -59,6 +59,8 @@ dependencies {
     implementation("org.postgresql:postgresql:42.7.3")
     implementation("io.ktor:ktor-server-cors:$ktor_version")
     implementation("com.google.code.gson:gson:2.11.0")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.2")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.2")
     testImplementation("io.ktor:ktor-server-tests-jvm")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
 }

--- a/backend/src/main/kotlin/no/bekk/Application.kt
+++ b/backend/src/main/kotlin/no/bekk/Application.kt
@@ -27,8 +27,8 @@ private fun loadAppConfig(config: ApplicationConfig) {
 
     // Data source config
     AppConfig.data = DataConfig.apply {
-        url = config.propertyOrNull("data.source")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"data.dataSource\"")
-        source = config.propertyOrNull("data.type")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"data.type\"")
+        url = config.propertyOrNull("data.url")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"data.url\"")
+        source = config.propertyOrNull("data.source")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"data.source\"")
     }
 
     // MicrosoftGraph config

--- a/backend/src/main/kotlin/no/bekk/Application.kt
+++ b/backend/src/main/kotlin/no/bekk/Application.kt
@@ -17,7 +17,6 @@ private fun loadAppConfig(config: ApplicationConfig) {
     // AirTable config
     AppConfig.airTable = AirTableConfig.apply {
         accessToken = config.propertyOrNull("airTable.accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.accessToken\"")
-        baseUrl = config.propertyOrNull("airTable.baseUrl")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.baseUrl\"")
         metadataPath = config.propertyOrNull("airTable.metadataPath")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.metadataPath\"")
         metodeVerkPath = config.propertyOrNull("airTable.metodeVerkPath")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.metodeVerkPath\"")
         allePath = config.propertyOrNull("airTable.allePath")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.allePath\"")
@@ -28,8 +27,8 @@ private fun loadAppConfig(config: ApplicationConfig) {
 
     // Data source config
     AppConfig.data = DataConfig.apply {
-        dataSource = config.propertyOrNull("data.source")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"data.dataSource\"")
-        dataType = config.propertyOrNull("data.type")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"data.type\"")
+        url = config.propertyOrNull("data.source")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"data.dataSource\"")
+        source = config.propertyOrNull("data.type")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"data.type\"")
     }
 
     // MicrosoftGraph config

--- a/backend/src/main/kotlin/no/bekk/Application.kt
+++ b/backend/src/main/kotlin/no/bekk/Application.kt
@@ -21,6 +21,15 @@ private fun loadAppConfig(config: ApplicationConfig) {
         metadataPath = config.propertyOrNull("airTable.metadataPath")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.metadataPath\"")
         metodeVerkPath = config.propertyOrNull("airTable.metodeVerkPath")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.metodeVerkPath\"")
         allePath = config.propertyOrNull("airTable.allePath")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.allePath\"")
+        tableId = config.propertyOrNull("airTable.tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.tableId\"")
+        tableReference = config.propertyOrNull("airTable.tableReference")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.tableReference\"")
+
+    }
+
+    // Data source config
+    AppConfig.data = DataConfig.apply {
+        dataSource = config.propertyOrNull("data.source")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"data.dataSource\"")
+        dataType = config.propertyOrNull("data.type")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"data.type\"")
     }
 
     // MicrosoftGraph config

--- a/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
+++ b/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
@@ -2,6 +2,7 @@ package no.bekk.configuration
 
 object AppConfig {
     lateinit var airTable: AirTableConfig
+    lateinit var data: DataConfig
     lateinit var microsoftGraph: MicrosoftGraphConfig
     lateinit var oAuth: OAuthConfig
     lateinit var frontend: FrontendConfig
@@ -14,6 +15,13 @@ object AirTableConfig {
     lateinit var metadataPath: String
     lateinit var metodeVerkPath: String
     lateinit var allePath: String
+    lateinit var tableId: String
+    lateinit var tableReference: String
+}
+
+object DataConfig {
+    lateinit var dataSource: String
+    lateinit var dataType: String
 }
 
 object MicrosoftGraphConfig {

--- a/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
+++ b/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
@@ -11,7 +11,6 @@ object AppConfig {
 
 object AirTableConfig {
     lateinit var accessToken: String
-    lateinit var baseUrl: String
     lateinit var metadataPath: String
     lateinit var metodeVerkPath: String
     lateinit var allePath: String
@@ -20,8 +19,8 @@ object AirTableConfig {
 }
 
 object DataConfig {
-    lateinit var dataSource: String
-    lateinit var dataType: String
+    lateinit var url: String
+    lateinit var source: String
 }
 
 object MicrosoftGraphConfig {

--- a/backend/src/main/kotlin/no/bekk/model/internal/Question.kt
+++ b/backend/src/main/kotlin/no/bekk/model/internal/Question.kt
@@ -13,8 +13,8 @@ data class Question(
     val id: String,
     val question: String,
     val metadata: QuestionMetadata,
-    val answers: List<Answer>,
-    val comments: List<Comment>,
+    val answers: List<Answer> = emptyList(),
+    val comments: List<Comment> = emptyList(),
     val updated: String?,
 )
 
@@ -22,7 +22,7 @@ data class Question(
 data class OptionalField(
     val key: String,
     val value: List<String>,
-    val type: OptionalFieldType,
+    val type: OptionalFieldType?,
     val options: List<String>?,
 )
 

--- a/backend/src/main/kotlin/no/bekk/providers/AirTableProvider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/AirTableProvider.kt
@@ -34,7 +34,7 @@ class AirTableProvider: Provider {
         }
     }
 
-    override suspend fun fetchData(team: String?): Table? {
+    override suspend fun fetchData(team: String?): Table {
         val metodeverkData = fetchDataFromMetodeverk()
         val airTableMetadata = fetchDataFromMetadata()
         val tableReferenceId = AppConfig.airTable.tableReference

--- a/backend/src/main/kotlin/no/bekk/providers/AirTableProvider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/AirTableProvider.kt
@@ -1,4 +1,4 @@
-package no.bekk.services
+package no.bekk.providers
 
 import io.ktor.client.*
 import io.ktor.client.call.*

--- a/backend/src/main/kotlin/no/bekk/providers/AirTableProvider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/AirTableProvider.kt
@@ -15,7 +15,7 @@ import no.bekk.domain.Record
 import no.bekk.domain.mapToQuestion
 import no.bekk.model.airtable.AirTableFieldType
 import no.bekk.model.airtable.mapAirTableFieldTypeToOptionalFieldType
-import no.bekk.model.internal.Field
+import no.bekk.model.internal.Column
 import no.bekk.model.internal.Option
 import no.bekk.model.internal.Table
 
@@ -34,7 +34,7 @@ class AirTableProvider: Provider {
         }
     }
 
-    override suspend fun fetchData(team: String?): Table {
+    override suspend fun getTable(team: String?): Table {
         val metodeverkData = fetchDataFromMetodeverk()
         val airTableMetadata = fetchDataFromMetadata()
         val tableReferenceId = AppConfig.airTable.tableReference
@@ -53,8 +53,8 @@ class AirTableProvider: Provider {
             )
         }
 
-        val fields = tableMetadata.fields.map { field ->
-            Field(
+        val columns = tableMetadata.fields.map { field ->
+            Column(
                 type = mapAirTableFieldTypeToOptionalFieldType(AirTableFieldType.fromString(field.type)),
                 name = field.name,
                 options = field.options?.choices?.map { choice ->
@@ -66,7 +66,7 @@ class AirTableProvider: Provider {
         return Table(
             id = tableId,
             name = tableMetadata.name,
-            fields = fields,
+            columns = columns,
             records = questions
         )
     }

--- a/backend/src/main/kotlin/no/bekk/providers/AirTableProvider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/AirTableProvider.kt
@@ -34,64 +34,6 @@ class AirTableProvider: Provider {
         }
     }
 
-    private fun filterDataOnStop(metadataResponse: MetadataResponse): MetadataResponse {
-        val newTables = metadataResponse.tables.map { table ->
-            val fields = table.fields
-            if (!fields.isNullOrEmpty()) {
-                val stopIndex = fields.indexOfFirst { it.name == "STOP" }
-                if (stopIndex != -1) {
-                    val newFields = fields.slice(0..< stopIndex)
-                    table.copy(fields = newFields)
-                } else {
-                    table
-                }
-            } else {
-                table
-            }
-        }
-
-        return metadataResponse.copy(tables = newTables)
-    }
-
-    private suspend fun fetchDataFromMetadata(): MetadataResponse {
-        val response: HttpResponse = client.get(AppConfig.airTable.baseUrl + AppConfig.airTable.metadataPath)
-        val responseBody = response.body<String>()
-        val metadataResponse: MetadataResponse = json.decodeFromString(responseBody)
-        val filteredMetaData = filterDataOnStop(metadataResponse = metadataResponse)
-        return filteredMetaData
-
-    }
-
-    private suspend fun fetchDataFromMetodeverk(): AirtableResponse {
-        var offset: String? = null
-        val allRecords = mutableListOf<Record>()
-        do {
-            val response = fetchMetodeverkPage(offset)
-            val records = response.records
-            allRecords.addAll(records)
-            offset = response.offset
-        } while (offset != null)
-
-        return AirtableResponse(allRecords)
-    }
-
-
-    private suspend fun fetchMetodeverkPage(offset: String? = null): AirtableResponse {
-        val url = buildString {
-            append(AppConfig.airTable.baseUrl + AppConfig.airTable.metodeVerkPath)
-            if (offset != null) {
-                append("&offset=$offset")
-            }
-        }
-        val response: HttpResponse = client.get(url) {
-            headers {
-                append("Authorization", "Bearer ${AppConfig.airTable.accessToken}")
-            }
-        }
-        val responseBody = response.bodyAsText()
-        return json.decodeFromString(responseBody)
-    }
-
     override suspend fun fetchData(team: String?): Table? {
         val metodeverkData = fetchDataFromMetodeverk()
         val airTableMetadata = fetchDataFromMetadata()
@@ -127,5 +69,62 @@ class AirTableProvider: Provider {
             fields = fields,
             records = questions
         )
+    }
+
+    private suspend fun fetchDataFromMetadata(): MetadataResponse {
+        val response: HttpResponse = client.get(AppConfig.data.url + AppConfig.airTable.metadataPath)
+        val responseBody = response.body<String>()
+        val metadataResponse: MetadataResponse = json.decodeFromString(responseBody)
+        val filteredMetaData = filterDataOnStop(metadataResponse = metadataResponse)
+        return filteredMetaData
+
+    }
+
+    private fun filterDataOnStop(metadataResponse: MetadataResponse): MetadataResponse {
+        val newTables = metadataResponse.tables.map { table ->
+            val fields = table.fields
+            if (!fields.isNullOrEmpty()) {
+                val stopIndex = fields.indexOfFirst { it.name == "STOP" }
+                if (stopIndex != -1) {
+                    val newFields = fields.slice(0..< stopIndex)
+                    table.copy(fields = newFields)
+                } else {
+                    table
+                }
+            } else {
+                table
+            }
+        }
+
+        return metadataResponse.copy(tables = newTables)
+    }
+
+    private suspend fun fetchDataFromMetodeverk(): AirtableResponse {
+        var offset: String? = null
+        val allRecords = mutableListOf<Record>()
+        do {
+            val response = fetchMetodeverkPage(offset)
+            val records = response.records
+            allRecords.addAll(records)
+            offset = response.offset
+        } while (offset != null)
+
+        return AirtableResponse(allRecords)
+    }
+
+    private suspend fun fetchMetodeverkPage(offset: String? = null): AirtableResponse {
+        val url = buildString {
+            append(AppConfig.data.url + AppConfig.airTable.metodeVerkPath)
+            if (offset != null) {
+                append("&offset=$offset")
+            }
+        }
+        val response: HttpResponse = client.get(url) {
+            headers {
+                append("Authorization", "Bearer ${AppConfig.airTable.accessToken}")
+            }
+        }
+        val responseBody = response.bodyAsText()
+        return json.decodeFromString(responseBody)
     }
 }

--- a/backend/src/main/kotlin/no/bekk/providers/Provider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/Provider.kt
@@ -1,0 +1,7 @@
+package no.bekk.providers
+
+import no.bekk.model.internal.Table
+
+interface Provider {
+    suspend fun fetchData(): Table?
+}

--- a/backend/src/main/kotlin/no/bekk/providers/Provider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/Provider.kt
@@ -3,5 +3,5 @@ package no.bekk.providers
 import no.bekk.model.internal.Table
 
 interface Provider {
-    suspend fun fetchData(team: String? = null): Table
+    suspend fun getTable(team: String? = null): Table
 }

--- a/backend/src/main/kotlin/no/bekk/providers/Provider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/Provider.kt
@@ -3,5 +3,5 @@ package no.bekk.providers
 import no.bekk.model.internal.Table
 
 interface Provider {
-    suspend fun fetchData(team: String? = null): Table?
+    suspend fun fetchData(team: String? = null): Table
 }

--- a/backend/src/main/kotlin/no/bekk/providers/Provider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/Provider.kt
@@ -3,5 +3,5 @@ package no.bekk.providers
 import no.bekk.model.internal.Table
 
 interface Provider {
-    suspend fun fetchData(): Table?
+    suspend fun fetchData(team: String? = null): Table?
 }

--- a/backend/src/main/kotlin/no/bekk/providers/YamlProvider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/YamlProvider.kt
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import no.bekk.model.internal.Field
+import no.bekk.model.internal.Column
 import no.bekk.model.internal.OptionalFieldType
 import no.bekk.model.internal.Question
 import no.bekk.model.internal.Table
@@ -16,7 +16,7 @@ import no.bekk.model.internal.Table
 class YamlProvider: Provider {
 
     // Temporary code for reading in a static YAML file. In the future, this will be read from a URL
-    override suspend fun fetchData(team: String?): Table {
+    override suspend fun getTable(team: String?): Table {
         val yamlFile = this::class.java.classLoader.getResource(TEST_FILE)?.readText()
         return convertData(yamlFile!!)
     }
@@ -50,8 +50,8 @@ class YamlProvider: Provider {
             val name = node.get("name").asText()
 
             val columnsNode = node.get("columns")
-            val fields = columnsNode.map { columnNode ->
-                Field(
+            val columns = columnsNode.map { columnNode ->
+                Column(
                     type = OptionalFieldType.OPTION_SINGLE,
                     name = columnNode.asText(),
                     options = null
@@ -66,7 +66,7 @@ class YamlProvider: Provider {
             return Table(
                 id = id,
                 name = name,
-                fields = fields,
+                columns = columns,
                 records = records
             )
         }

--- a/backend/src/main/kotlin/no/bekk/providers/YamlProvider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/YamlProvider.kt
@@ -14,12 +14,18 @@ import no.bekk.model.internal.Question
 import no.bekk.model.internal.Table
 
 class YamlProvider: Provider {
-    override suspend fun fetchData(team: String?): Table? {
+
+    // Temporary code for reading in a static YAML file. In the future, this will be read from a URL
+    override suspend fun fetchData(team: String?): Table {
         val yamlFile = this::class.java.classLoader.getResource(TEST_FILE)?.readText()
-            return convertData(yamlFile!!)
+        return convertData(yamlFile!!)
     }
 
-    private fun convertData(yamlFile: String): Table? {
+    companion object {
+        const val TEST_FILE = "questions/testQuestions.yaml"
+    }
+
+    private fun convertData(yamlFile: String): Table{
         val module = SimpleModule().apply {
             addDeserializer(Table::class.java, YamlDeserializer)
         }
@@ -27,20 +33,12 @@ class YamlProvider: Provider {
             registerModule(module)
             registerKotlinModule()
         }
-        var table: Table? = null;
-        try {
-
-            table  = objectMapper.readValue(yamlFile, Table::class.java)
-            return table
+         try {
+             return objectMapper.readValue(yamlFile, Table::class.java)
         } catch (e: Exception) {
-           println(e.message)
             e.printStackTrace()
+            throw e
         }
-    return table
-    }
-
-    companion object {
-        const val TEST_FILE = "questions/testQuestions.yaml"
     }
 
     object YamlDeserializer : JsonDeserializer<Table>() {

--- a/backend/src/main/kotlin/no/bekk/providers/YamlProvider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/YamlProvider.kt
@@ -1,0 +1,76 @@
+package no.bekk.providers
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import no.bekk.model.internal.Field
+import no.bekk.model.internal.OptionalFieldType
+import no.bekk.model.internal.Question
+import no.bekk.model.internal.Table
+
+class YamlService: Provider {
+    override suspend fun fetchData(): Table? {
+        val yamlFile = this::class.java.classLoader.getResource(TEST_FILE)?.readText()
+            return convertData(yamlFile!!)
+    }
+
+    private fun convertData(yamlFile: String): Table? {
+        val module = SimpleModule().apply {
+            addDeserializer(Table::class.java, YamlDeserializer)
+        }
+        val objectMapper = ObjectMapper(YAMLFactory()).apply {
+            registerModule(module)
+            registerKotlinModule()
+        }
+        var table: Table? = null;
+        try {
+
+            table  = objectMapper.readValue(yamlFile, Table::class.java)
+            return table
+        } catch (e: Exception) {
+           println(e.message)
+            e.printStackTrace()
+        }
+    return table
+    }
+
+    companion object {
+        const val TEST_FILE = "questions/testQuestions.yaml"
+    }
+
+    object YamlDeserializer : JsonDeserializer<Table>() {
+        override fun deserialize(p0: JsonParser, p1: DeserializationContext): Table {
+            val node = p0.readValueAsTree<JsonNode>()
+            val objectMapper = p0.codec as ObjectMapper
+
+            val id = node.get("id").asText()
+            val name = node.get("name").asText()
+
+            val columnsNode = node.get("columns")
+            val fields = columnsNode.map { columnNode ->
+                Field(
+                    type = OptionalFieldType.OPTION_SINGLE,
+                    name = columnNode.asText(),
+                    options = null
+                )
+            }
+
+            val recordsNode = node.get("records")
+            val records: List<Question> = recordsNode.map { recordNode ->
+                objectMapper.treeToValue(recordNode, Question::class.java)
+            }
+
+            return Table(
+                id = id,
+                name = name,
+                fields = fields,
+                records = records
+            )
+        }
+    }
+}

--- a/backend/src/main/kotlin/no/bekk/providers/YamlProvider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/YamlProvider.kt
@@ -13,8 +13,8 @@ import no.bekk.model.internal.OptionalFieldType
 import no.bekk.model.internal.Question
 import no.bekk.model.internal.Table
 
-class YamlService: Provider {
-    override suspend fun fetchData(): Table? {
+class YamlProvider: Provider {
+    override suspend fun fetchData(team: String?): Table? {
         val yamlFile = this::class.java.classLoader.getResource(TEST_FILE)?.readText()
             return convertData(yamlFile!!)
     }

--- a/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
@@ -22,10 +22,7 @@ fun Route.tableRouting() {
             try {
                 val table = tableService.getTable(team)
                 logger.info("Successfully retrieved table for tableId: $tableId")
-                if (table != null) {
-
-                    call.respond(table)
-                }
+                call.respond(table)
             } catch (e: IllegalArgumentException) {
                 logger.error("Error occurred while retrieving table for tableId: $tableId", e)
                 call.respond(HttpStatusCode.InternalServerError, "An error occured: ${e.message}")

--- a/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
@@ -5,7 +5,6 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.bekk.services.TableService
-import no.bekk.providers.YamlService
 import no.bekk.util.logger
 
 fun Route.tableRouting() {
@@ -21,8 +20,7 @@ fun Route.tableRouting() {
             val team = call.request.queryParameters["team"]
 
             try {
-                //val table = tableService.getTable(tableId, team)
-                val table = YamlService().fetchData()
+                val table = tableService.getTable(team)
                 logger.info("Successfully retrieved table for tableId: $tableId")
                 if (table != null) {
 

--- a/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
@@ -5,6 +5,7 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.bekk.services.TableService
+import no.bekk.providers.YamlService
 import no.bekk.util.logger
 
 fun Route.tableRouting() {
@@ -20,9 +21,13 @@ fun Route.tableRouting() {
             val team = call.request.queryParameters["team"]
 
             try {
-                val table = tableService.getTable(tableId, team)
+                //val table = tableService.getTable(tableId, team)
+                val table = YamlService().fetchData()
                 logger.info("Successfully retrieved table for tableId: $tableId")
-                call.respond(table)
+                if (table != null) {
+
+                    call.respond(table)
+                }
             } catch (e: IllegalArgumentException) {
                 logger.error("Error occurred while retrieving table for tableId: $tableId", e)
                 call.respond(HttpStatusCode.InternalServerError, "An error occured: ${e.message}")

--- a/backend/src/main/kotlin/no/bekk/services/TableService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/TableService.kt
@@ -7,6 +7,7 @@ import no.bekk.domain.mapToQuestion
 import no.bekk.model.airtable.AirTableFieldType
 import no.bekk.model.airtable.mapAirTableFieldTypeToOptionalFieldType
 import no.bekk.model.internal.*
+import no.bekk.providers.AirTableService
 
 class TableService {
     private val airTableService = AirTableService()

--- a/backend/src/main/kotlin/no/bekk/services/TableService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/TableService.kt
@@ -12,12 +12,12 @@ class TableService {
     suspend fun getTable(team: String?): Table {
         return when (val dataType = AppConfig.data.source) {
             "AIRTABLE" ->
-                airTableProvider.fetchData(
+                airTableProvider.getTable(
                     team = team
                 )
 
             "YAML" ->
-                yamlProvider.fetchData()
+                yamlProvider.getTable()
 
             else -> throw IllegalArgumentException("Table source $dataType not supported")
         }

--- a/backend/src/main/kotlin/no/bekk/services/TableService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/TableService.kt
@@ -1,92 +1,25 @@
 package no.bekk.services
 
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
-import no.bekk.database.DatabaseRepository
-import no.bekk.domain.mapToQuestion
-import no.bekk.model.airtable.AirTableFieldType
-import no.bekk.model.airtable.mapAirTableFieldTypeToOptionalFieldType
+import no.bekk.configuration.AppConfig
 import no.bekk.model.internal.*
-import no.bekk.providers.AirTableService
+import no.bekk.providers.AirTableProvider
+import no.bekk.providers.YamlProvider
 
 class TableService {
-    private val airTableService = AirTableService()
-    private val databaseRepository = DatabaseRepository()
+    private val airTableProvider = AirTableProvider()
+    private val yamlProvider = YamlProvider()
 
-    private fun getAnswers(team: String?) = team?.let {
-        databaseRepository.getAnswersByTeamIdFromDatabase(team)
-    } ?: run {
-        databaseRepository.getAnswersFromDatabase()
-    }
-
-    private fun getComments(team: String?) = team?.let {
-        databaseRepository.getCommentsByTeamIdFromDatabase(it)
-    } ?: mutableListOf()
-
-    private suspend fun getTableFromAirTable(tableInternalId: String, tableReferenceId: String, team: String?): Table {
-        val metodeverkData = airTableService.fetchDataFromMetodeverk()
-        val airTableMetadata = airTableService.fetchDataFromMetadata()
-
-        val tableMetadata = airTableMetadata.tables.first { it.id == tableReferenceId }
-        if (tableMetadata.fields == null) {
-            throw IllegalArgumentException("Table $tableReferenceId has no fields")
-        }
-
-        val answers = getAnswers(team)
-        val comments = getComments(team)
-
-        val questions = metodeverkData.records.map { record ->
-            record.mapToQuestion(
-                answers = answers.filter { it.questionId == record.fields.jsonObject["ID"]?.jsonPrimitive?.content },
-                comments = comments.filter { it.questionId == record.fields.jsonObject["ID"]?.jsonPrimitive?.content },
-                metaDataFields = tableMetadata.fields,
-            )
-        }
-
-        val fields = tableMetadata.fields.map { field ->
-            Field(
-                type = mapAirTableFieldTypeToOptionalFieldType(AirTableFieldType.fromString(field.type)),
-                name = field.name,
-                options = field.options?.choices?.map { choice ->
-                    Option(name = choice.name, color = choice.color)
-                }
-            )
-        }
-
-        return Table(
-            id = tableInternalId,
-            name = tableMetadata.name,
-            fields = fields,
-            records = questions
-        )
-    }
-
-    suspend fun getTable(tableId: String, team: String?): Table {
-        val (tableReferenceId, tableSource) = tableMapping(tableId)
-        when (tableSource) {
-            TableSources.AIRTABLE ->
-                return getTableFromAirTable(
-                    tableInternalId = tableId,
-                    tableReferenceId = tableReferenceId,
+    suspend fun getTable(team: String?): Table? {
+        return when (val dataType = AppConfig.data.dataType) {
+            "AIRTABLE" ->
+                airTableProvider.fetchData(
                     team = team
                 )
-            else -> throw IllegalArgumentException("Table source $tableSource not supported")
+
+            "YAML" ->
+                yamlProvider.fetchData()
+
+            else -> throw IllegalArgumentException("Table source $dataType not supported")
         }
-    }
-}
-
-enum class TableSources {
-    AIRTABLE
-}
-
-data class TableReference(
-    val id: String,
-    val source: TableSources
-)
-
-fun tableMapping(tableId: String): TableReference {
-    return when (tableId) {
-        "570e9285-3228-4396-b82b-e9752e23cd73" -> TableReference("tblLZbUqA0XnUgC2v", TableSources.AIRTABLE)
-        else -> throw IllegalArgumentException("Table $tableId not found")
     }
 }

--- a/backend/src/main/kotlin/no/bekk/services/TableService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/TableService.kt
@@ -9,7 +9,7 @@ class TableService {
     private val airTableProvider = AirTableProvider()
     private val yamlProvider = YamlProvider()
 
-    suspend fun getTable(team: String?): Table? {
+    suspend fun getTable(team: String?): Table {
         return when (val dataType = AppConfig.data.source) {
             "AIRTABLE" ->
                 airTableProvider.fetchData(

--- a/backend/src/main/kotlin/no/bekk/services/TableService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/TableService.kt
@@ -10,7 +10,7 @@ class TableService {
     private val yamlProvider = YamlProvider()
 
     suspend fun getTable(team: String?): Table? {
-        return when (val dataType = AppConfig.data.dataType) {
+        return when (val dataType = AppConfig.data.source) {
             "AIRTABLE" ->
                 airTableProvider.fetchData(
                     team = team

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -11,10 +11,13 @@ airTable:
   metadataPath: "/v0/meta/bases/appzJQ8Tkmm8DobrJ/tables"
   metodeVerkPath: "/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v?view=viw2XliGUJu5448Hk"
   allePath: "/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v"
+  tableId: "$TABLE_ID:570e9285-3228-4396-b82b-e9752e23cd73"
+  tableReference: "$TABLE_REFERENCE:tblLZbUqA0XnUgC2v"
 
 data:
   source: "$DATA_SOURCE:https://api.airtable.com"
   type: "$DATA_SOURCE_TYPE:YAML"
+
 
 microsoftGraph:
   baseUrl: "https://graph.microsoft.com"

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -7,7 +7,6 @@ ktor:
 
 airTable:
   accessToken: $AIRTABLE_ACCESS_TOKEN
-  baseUrl: "https://api.airtable.com"
   metadataPath: "/v0/meta/bases/appzJQ8Tkmm8DobrJ/tables"
   metodeVerkPath: "/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v?view=viw2XliGUJu5448Hk"
   allePath: "/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v"
@@ -16,8 +15,7 @@ airTable:
 
 data:
   source: "$DATA_SOURCE:https://api.airtable.com"
-  type: "$DATA_SOURCE_TYPE:YAML"
-
+  type: "$DATA_SOURCE_TYPE:AIRTABLE"
 
 microsoftGraph:
   baseUrl: "https://graph.microsoft.com"

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -12,6 +12,10 @@ airTable:
   metodeVerkPath: "/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v?view=viw2XliGUJu5448Hk"
   allePath: "/v0/appzJQ8Tkmm8DobrJ/tblLZbUqA0XnUgC2v"
 
+data:
+  source: "$DATA_SOURCE:https://api.airtable.com"
+  type: "$DATA_SOURCE_TYPE:YAML"
+
 microsoftGraph:
   baseUrl: "https://graph.microsoft.com"
   memberOfPath: "/v1.0/me/memberOf/microsoft.graph.group"

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -14,8 +14,8 @@ airTable:
   tableReference: "$TABLE_REFERENCE:tblLZbUqA0XnUgC2v"
 
 data:
-  source: "$DATA_SOURCE:https://api.airtable.com"
-  type: "$DATA_SOURCE_TYPE:AIRTABLE"
+  url: "$DATA_SOURCE:https://api.airtable.com"
+  source: "$DATA_SOURCE_TYPE:AIRTABLE"
 
 microsoftGraph:
   baseUrl: "https://graph.microsoft.com"

--- a/backend/src/main/resources/questions/testQuestions.yaml
+++ b/backend/src/main/resources/questions/testQuestions.yaml
@@ -1,0 +1,64 @@
+id: "hehe"
+name: "YAML-data"
+columns:
+  - Kortnavn
+  - Kontroller
+  - Priority
+  - Svar
+records:
+  - id: "Z-420"
+    question: "How many countries are there in the world?"
+    metadata:
+      answerMetadata:
+        type: "SELECT_SINGLE"
+        options:
+          - "180"
+          - "190"
+          - "195"
+          - "205"
+      optionalFields:
+        - key: "Kontroller"
+          value:
+            - "How many countries are there in the world?"
+        - key: "Kortnavn"
+          value:
+            - "Antall land"
+        - key: "Priority"
+          value:
+            - "High"
+  - id: "Z-421"
+    question: "What is the capital of France?"
+    metadata:
+      answerMetadata:
+        type: "TEXT_SINGLE_LINE"
+      optionalFields:
+        - key: "Kontroller"
+          value:
+            - "What is the capital of France?"
+        - key: "Priority"
+          value:
+            - "High"
+        - key: "Subject"
+          value:
+            - "Geography"
+            - "History"
+          type: "OPTION_MULTIPLE"
+          options:
+            - "Geography"
+            - "History"
+            - "Science"
+  - id: "Z-422"
+    question: "What is the capital of Spain?"
+    metadata:
+      answerMetadata:
+        type: "TEXT_SINGLE_LINE"
+      optionalFields:
+        - key: "Kontroller"
+          value:
+            - "What is the capital of Spain?"
+        - key: "Kortnavn"
+          value:
+            - "Antall land"
+        - key: "Priority"
+          value:
+            - "High"


### PR DESCRIPTION
## Background
Nå har vi kun støtte for å bruke Airtable som datakilde. For å gjøre produktet mer generelt og versatilt, vil vi åpne opp for å bruke andre kilder, som statiske filer.

## Solution
Har laget en egen provider for å lese og omgjøre YAML-filer til et Table-objekt. Har også omstrukturert den eksisterende AirtableServicen til å være en provider.

Det er flere ting som burde endres, men velger å bryte det ned i andre oppgaver. Som for eksempel burde datastrukturen trolig omgjøres noe, da den nå er litt uoversiktlig. Gjenstår også å inkorporere endringene fra #250 

Resolves #237 
