### PR TITLE
Rename field to column

### DIFF
--- a/backend/src/main/kotlin/no/bekk/model/internal/Table.kt
+++ b/backend/src/main/kotlin/no/bekk/model/internal/Table.kt
@@ -9,7 +9,7 @@ data class Option(
 )
 
 @Serializable
-data class Field(
+data class Column(
     val type: OptionalFieldType,
     val name: String,
     val options: List<Option>?
@@ -19,6 +19,6 @@ data class Field(
 data class Table(
     val id: String,
     val name: String,
-    val fields: List<Field>,
+    val columns: List<Column>,
     val records: List<Question>,
 )

--- a/backend/src/main/kotlin/no/bekk/services/AirTableService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/AirTableService.kt
@@ -14,7 +14,6 @@ import no.bekk.domain.MetadataResponse
 import no.bekk.domain.Record
 
 
-
 class AirTableService {
 
     val json = Json { ignoreUnknownKeys = true }

--- a/backend/src/main/kotlin/no/bekk/services/TableService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/TableService.kt
@@ -42,8 +42,8 @@ class TableService {
             )
         }
 
-        val fields = tableMetadata.fields.map { field ->
-            Field(
+        val columns = tableMetadata.fields.map { field ->
+            Column(
                 type = mapAirTableFieldTypeToOptionalFieldType(AirTableFieldType.fromString(field.type)),
                 name = field.name,
                 options = field.options?.choices?.map { choice ->
@@ -55,7 +55,7 @@ class TableService {
         return Table(
             id = tableInternalId,
             name = tableMetadata.name,
-            fields = fields,
+            columns = columns,
             records = questions
         )
     }

--- a/frontend/beCompliant/src/api/types.ts
+++ b/frontend/beCompliant/src/api/types.ts
@@ -27,7 +27,7 @@ export type Comment = {
   updated: Date;
 };
 
-export type Field = {
+export type Column = {
   options: Option[] | null;
   name: string;
   type: OptionalFieldType;
@@ -68,7 +68,7 @@ export type QuestionMetadata = {
 
 export type Table = {
   id: string;
-  fields: Field[];
+  columns: Column[];
   name: string;
   records: Question[];
 };

--- a/frontend/beCompliant/src/components/Table.tsx
+++ b/frontend/beCompliant/src/components/Table.tsx
@@ -38,7 +38,7 @@ export function TableComponent({ data, tableData }: Props) {
     getShownColumns,
   ] = useColumnVisibility();
 
-  const columns: ColumnDef<any, any>[] = tableData.fields.map(
+  const columns: ColumnDef<any, any>[] = tableData.columns.map(
     (field, index) => ({
       header: ({ column }) => (
         <DataTableHeader

--- a/frontend/beCompliant/src/components/table/TableCell.tsx
+++ b/frontend/beCompliant/src/components/table/TableCell.tsx
@@ -1,12 +1,12 @@
 import { Flex, Tag, Text } from '@kvib/react';
 import { Row } from '@tanstack/react-table';
 import { AnswerCell } from './AnswerCell';
-import { Field, OptionalFieldType, Question } from '../../api/types';
+import { Column, OptionalFieldType, Question } from '../../api/types';
 import colorUtils from '../../utils/colorUtils';
 
 type Props = {
   value: any;
-  column: Field;
+  column: Column;
   row: Row<Question>;
   answerable?: boolean;
 };

--- a/frontend/beCompliant/src/components/tableActions/TableActions.tsx
+++ b/frontend/beCompliant/src/components/tableActions/TableActions.tsx
@@ -1,11 +1,11 @@
 import { Flex, Heading, Icon } from '@kvib/react';
 import { TableFilter, TableFilters } from './TableFilter';
-import { Field } from '../../api/types';
+import { Column } from '../../api/types';
 import { useEffect } from 'react';
 
 interface Props {
   filters: TableFilters;
-  tableMetadata: Field[];
+  tableMetadata: Column[];
 }
 
 export const TableActions = ({

--- a/frontend/beCompliant/src/pages/ActivityPage.tsx
+++ b/frontend/beCompliant/src/pages/ActivityPage.tsx
@@ -16,7 +16,7 @@ import { TableStatistics } from '../components/table/TableStatistics';
 import { Page } from '../components/layout/Page';
 import { TableComponent } from '../components/Table';
 import { useFetchTable } from '../hooks/useFetchTable';
-import { Field, OptionalFieldType } from '../api/types';
+import { Column, OptionalFieldType } from '../api/types';
 
 export const ActivityPage = () => {
   const params = useParams();
@@ -27,7 +27,7 @@ export const ActivityPage = () => {
 
   const { data, error, isPending } = useFetchTable(tableId, team);
 
-  const statusFilterOptions: Field = {
+  const statusFilterOptions: Column = {
     options: [
       { name: 'Utfylt', color: '' },
       { name: 'Ikke utfylt', color: '' },
@@ -71,7 +71,7 @@ export const ActivityPage = () => {
         <Divider borderColor="gray.400" />
       </Box>
 
-      <TableActions filters={filters} tableMetadata={data.fields} />
+      <TableActions filters={filters} tableMetadata={data.columns} />
       <TableComponent data={filteredData} tableData={data} />
     </Page>
   );


### PR DESCRIPTION
## Background
Navnet `Field` kan være litt tvetydig, og kan gjøre det vanskeligere å forstå hva det skal representere.

## Solution
Velger å rename den til `Column`, da det mer presist beskriver hva det faktisk er

Resolves #issue-this-pr-resolves
