### PR TITLE
separated answers and comments from table data

### DIFF
--- a/backend/src/main/kotlin/no/bekk/domain/AirtableResponseMapper.kt
+++ b/backend/src/main/kotlin/no/bekk/domain/AirtableResponseMapper.kt
@@ -2,13 +2,11 @@ package no.bekk.domain
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*
-import no.bekk.database.DatabaseAnswer
-import no.bekk.database.DatabaseComment
 import no.bekk.model.airtable.AirTableFieldType
-import no.bekk.model.airtable.mapAirTableFieldTypeToAnswerType
 import no.bekk.model.airtable.mapAirTableFieldTypeToOptionalFieldType
 import no.bekk.model.internal.*
 import java.util.*
+
 
 @Serializable
 data class AirtableResponse(
@@ -24,8 +22,6 @@ data class Record(
 )
 
 fun Record.mapToQuestion(
-    answers: List<DatabaseAnswer>,
-    comments: List<DatabaseComment>,
     metaDataFields: List<Field>,
     answerType: AnswerType,
     answerOptions: List<String>?,
@@ -33,25 +29,6 @@ fun Record.mapToQuestion(
         id = fields.jsonObject["ID"]?.jsonPrimitive?.content ?: UUID.randomUUID().toString(),
         question = fields.jsonObject["Aktivitet"]?.jsonPrimitive?.content ?: "",
         updated = createdTime,
-        answers = answers.map {
-            Answer(
-                actor = it.actor,
-                questionId = it.questionId,
-                question = it.question,
-                answer = it.Svar ?: "",
-                team = it.team,
-                updated = it.updated
-            )
-        },
-        comments = comments.map {
-            Comment(
-                questionId = it.questionId,
-                comment = it.comment,
-                team = it.team,
-                updated = it.updated,
-                actor = it.actor
-            )
-        },
         metadata = QuestionMetadata(
             answerMetadata = AnswerMetadata(
                 type = answerType,

--- a/backend/src/main/kotlin/no/bekk/model/internal/Question.kt
+++ b/backend/src/main/kotlin/no/bekk/model/internal/Question.kt
@@ -13,8 +13,6 @@ data class Question(
     val id: String,
     val question: String,
     val metadata: QuestionMetadata,
-    val answers: List<Answer>,
-    val comments: List<Comment>,
     val updated: String?,
 )
 

--- a/frontend/beCompliant/src/api/apiConfig.ts
+++ b/frontend/beCompliant/src/api/apiConfig.ts
@@ -24,6 +24,10 @@ export const apiConfig = {
   answers: {
     queryKey: [PATH_ANSWERS],
     url: API_URL_ANSWERS,
+    withTeam: {
+      queryKey: (team: string) => [PATH_ANSWERS, team],
+      url: (team: string) => `${API_URL_ANSWERS}/${team}`,
+    },
   },
   answer: {
     queryKey: [PATH_ANSWER],
@@ -32,6 +36,10 @@ export const apiConfig = {
   comments: {
     queryKey: [PATH_COMMENTS],
     url: API_URL_COMMENTS,
+    withTeam: {
+      queryKey: (team: string) => [PATH_COMMENTS, team],
+      url: (team: string) => `${API_URL_COMMENTS}/${team}`,
+    },
   },
   table: {
     queryKey: () => [PATH_TABLE],

--- a/frontend/beCompliant/src/api/types.ts
+++ b/frontend/beCompliant/src/api/types.ts
@@ -7,7 +7,7 @@ export enum AnswerType {
 
 export type Answer = {
   actor: string;
-  answer: string;
+  Svar: string;
   quesiton: string;
   questionId: string;
   team: string | null;

--- a/frontend/beCompliant/src/components/table/TableCell.tsx
+++ b/frontend/beCompliant/src/components/table/TableCell.tsx
@@ -20,7 +20,7 @@ export const TableCell = ({
   if (answerable) {
     return (
       <AnswerCell
-        value={row.original.answers.at(-1)?.answer}
+        value={row.original.answers.at(-1)?.Svar}
         answerType={row.original.metadata?.answerMetadata.type}
         questionId={row.original.id}
         questionName={row.original.question}

--- a/frontend/beCompliant/src/components/table/TableStatistics.tsx
+++ b/frontend/beCompliant/src/components/table/TableStatistics.tsx
@@ -8,7 +8,7 @@ interface Props {
 export const TableStatistics = ({ filteredData }: Props) => {
   const numberOfQuestions = filteredData?.length;
   const numberOfAnswers = filteredData.reduce((count, data) => {
-    if (data.answers[0]?.answer) {
+    if (data.answers[0]?.Svar) {
       count++;
     }
     return count;

--- a/frontend/beCompliant/src/hooks/useFetchAnswers.ts
+++ b/frontend/beCompliant/src/hooks/useFetchAnswers.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiConfig } from '../api/apiConfig';
+import { Answer } from '../api/types';
+import { axiosFetch } from '../api/Fetch';
+
+export function useFetchAnswers(team?: string) {
+  const queryKeys = team
+    ? apiConfig.answers.withTeam.queryKey(team)
+    : apiConfig.answers.queryKey;
+  const url = team
+    ? apiConfig.answers.withTeam.url(team)
+    : apiConfig.answers.url;
+
+  return useQuery({
+    queryKey: queryKeys,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    notifyOnChangeProps: ['data', 'error'],
+    queryFn: () =>
+      axiosFetch<Answer[]>({ url: url }).then((response) => response.data),
+  });
+}

--- a/frontend/beCompliant/src/hooks/useFetchComments.ts
+++ b/frontend/beCompliant/src/hooks/useFetchComments.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiConfig } from '../api/apiConfig';
+import { Comment } from '../api/types';
+import { axiosFetch } from '../api/Fetch';
+
+export function useFetchComments(team: string) {
+  return useQuery({
+    queryKey: apiConfig.comments.withTeam.queryKey(team),
+    queryFn: () =>
+      axiosFetch<Comment[]>({
+        url: apiConfig.comments.withTeam.url(team),
+      }).then((response) => response.data),
+  });
+}

--- a/frontend/beCompliant/src/hooks/useSubmitAnswers.ts
+++ b/frontend/beCompliant/src/hooks/useSubmitAnswers.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { axiosFetch } from '../api/Fetch';
-import { PATH_TABLE, apiConfig } from '../api/apiConfig';
+import { apiConfig } from '../api/apiConfig';
 import { useToast } from '@kvib/react';
 
 type SubmitAnswerRequest = {
@@ -38,7 +38,11 @@ export function useSubmitAnswers(team?: string) {
         });
       }
       queryClient.refetchQueries({
-        queryKey: [PATH_TABLE, team],
+        queryKey: [
+          team
+            ? apiConfig.answers.withTeam.queryKey(team)
+            : apiConfig.answers.queryKey,
+        ],
       });
       return queryClient.invalidateQueries({
         queryKey: apiConfig.answers.queryKey,

--- a/frontend/beCompliant/src/pages/ActivityPage.tsx
+++ b/frontend/beCompliant/src/pages/ActivityPage.tsx
@@ -16,6 +16,9 @@ import { TableStatistics } from '../components/table/TableStatistics';
 import { Page } from '../components/layout/Page';
 import { TableComponent } from '../components/Table';
 import { useFetchTable } from '../hooks/useFetchTable';
+import { useFetchComments } from '../hooks/useFetchComments';
+import { useFetchAnswers } from '../hooks/useFetchAnswers';
+import { mapTableDataRecords } from '../utils/mapperUtil';
 import { Column, OptionalFieldType } from '../api/types';
 
 export const ActivityPage = () => {
@@ -25,7 +28,24 @@ export const ActivityPage = () => {
 
   const [activeFilters, setActiveFilters] = useState<ActiveFilter[]>([]);
 
-  const { data, error, isPending } = useFetchTable(tableId, team);
+  const {
+    data: tableData,
+    error: tableError,
+    isPending: tableIsPending,
+  } = useFetchTable(tableId, team);
+  const {
+    data: commentData,
+    error: commentError,
+    isPending: commentIsPending,
+  } = useFetchComments(team ?? '');
+  const {
+    data: answerData,
+    error: answerError,
+    isPending: answerIsPending,
+  } = useFetchAnswers(team);
+
+  const error = tableError || commentError || answerError;
+  const isPending = tableIsPending || commentIsPending || answerIsPending;
 
   const statusFilterOptions: Column = {
     options: [
@@ -44,7 +64,7 @@ export const ActivityPage = () => {
     );
   }
 
-  if (error || !data) {
+  if (error || !tableData || !commentData || !answerData) {
     return (
       <Center height="70svh" flexDirection="column" gap="4">
         <Icon icon="error" size={64} weight={600} />
@@ -53,7 +73,8 @@ export const ActivityPage = () => {
     );
   }
 
-  const filteredData = filterData(data.records, activeFilters);
+  tableData.records = mapTableDataRecords(tableData, commentData, answerData);
+  const filteredData = filterData(tableData.records, activeFilters);
   const filters = {
     filterOptions: statusFilterOptions.options,
     filterName: '',
@@ -71,8 +92,8 @@ export const ActivityPage = () => {
         <Divider borderColor="gray.400" />
       </Box>
 
-      <TableActions filters={filters} tableMetadata={data.columns} />
-      <TableComponent data={filteredData} tableData={data} />
+      <TableActions filters={filters} tableMetadata={tableData.columns} />
+      <TableComponent data={filteredData} tableData={tableData} />
     </Page>
   );
 };

--- a/frontend/beCompliant/src/pages/ActivityPage.tsx
+++ b/frontend/beCompliant/src/pages/ActivityPage.tsx
@@ -34,12 +34,12 @@ export const ActivityPage = () => {
     isPending: tableIsPending,
   } = useFetchTable(tableId, team);
   const {
-    data: commentData,
+    data: comments,
     error: commentError,
     isPending: commentIsPending,
   } = useFetchComments(team ?? '');
   const {
-    data: answerData,
+    data: answers,
     error: answerError,
     isPending: answerIsPending,
   } = useFetchAnswers(team);
@@ -64,7 +64,7 @@ export const ActivityPage = () => {
     );
   }
 
-  if (error || !tableData || !commentData || !answerData) {
+  if (error || !tableData || !comments || !answers) {
     return (
       <Center height="70svh" flexDirection="column" gap="4">
         <Icon icon="error" size={64} weight={600} />
@@ -73,7 +73,7 @@ export const ActivityPage = () => {
     );
   }
 
-  tableData.records = mapTableDataRecords(tableData, commentData, answerData);
+  tableData.records = mapTableDataRecords(tableData, comments, answers);
   const filteredData = filterData(tableData.records, activeFilters);
   const filters = {
     filterOptions: statusFilterOptions.options,

--- a/frontend/beCompliant/src/utils/mapperUtil.ts
+++ b/frontend/beCompliant/src/utils/mapperUtil.ts
@@ -1,0 +1,39 @@
+import { Answer, Comment, Table } from '../api/types';
+
+export const mapTableDataRecords = (
+  tableData: Table,
+  commentData: Comment[],
+  answerData: Answer[]
+) => {
+  return tableData.records.map((question) => ({
+    ...question,
+    comments: createCommentMap(commentData)[question.id] || [],
+    answers: createAnswerMap(answerData)[question.id] || [],
+  }));
+};
+
+const createCommentMap = (commentData: Comment[]) => {
+  return commentData?.reduce(
+    (map, comment) => {
+      if (!map[comment.questionId]) {
+        map[comment.questionId] = [];
+      }
+      map[comment.questionId].push(comment);
+      return map;
+    },
+    {} as { [key: string]: Comment[] }
+  );
+};
+
+const createAnswerMap = (answerData: Answer[]) => {
+  return answerData?.reduce(
+    (map, answer) => {
+      if (!map[answer.questionId]) {
+        map[answer.questionId] = [];
+      }
+      map[answer.questionId].push(answer);
+      return map;
+    },
+    {} as { [key: string]: Answer[] }
+  );
+};

--- a/frontend/beCompliant/src/utils/tablePageUtil.ts
+++ b/frontend/beCompliant/src/utils/tablePageUtil.ts
@@ -22,7 +22,7 @@ export const filterData = (
 
     return filteredData.filter((record: Question) => {
       if (fieldName === 'Svar') {
-        const lastAnswer = record.answers.at(-1)?.answer;
+        const lastAnswer = record.answers.at(-1)?.Svar;
         return lastAnswer?.toLowerCase() === filterValue;
       }
 


### PR DESCRIPTION
## Background
Kommentarer og svar fetches sammen med tabellen i frontend. Dette gjør det er vanskelig med caching og oppdatering av states.

## Solution
Kommentarer og svar fetches fra egne endepunkter. Dataen settes deretter sammen når tabellen skal vises.

Fikk det til å funke ved å endre fra answer til Svar i Answer-typen. Tenker å heller lage en annen task til å rename fra Svar til answer, blir fort mye kluss her.

Resolves #issue-this-pr-resolves
#243 