### PR TITLE
Fix updating statistics

### DIFF
--- a/frontend/beCompliant/src/components/table/TableStatistics.tsx
+++ b/frontend/beCompliant/src/components/table/TableStatistics.tsx
@@ -8,7 +8,7 @@ interface Props {
 export const TableStatistics = ({ filteredData }: Props) => {
   const numberOfQuestions = filteredData?.length;
   const numberOfAnswers = filteredData.reduce((count, data) => {
-    if (data.answers[0]?.answer) {
+    if (data.answers[0]?.answer && data.answers.at(-1)?.answer !== '') {
       count++;
     }
     return count;


### PR DESCRIPTION
## Background
Dersom man legger til et svar og deretter fjerner det, står det på statistikkhjulet at spørsmålet er besvart. Det er fordi at det kun sjekkes om det blir lagt til et nytt object i answers.

## Solution
La til en sjekk for å sjekke om det siste svaret som har blitt lagt til er en tom streng og har dermed egentlig ikke noe svar. Nå funker det hvis man f.eks endrer fra "ok" til "velg alternativ" så blir det -1 på statistikkhjulet. Samme for fritekstfelt.

Resolves #issue-this-pr-resolves
#295 
