### PR TITLE
[Sikkerhet] Oppdaterer med catalog-info.yaml til versjon 3.0

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 3.0
 organisasjon: Eiendom
 product: sikkerhetsmetrikker
 repo_types: [InternalApi,InternalClient]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,56 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "regelrett"
+  tags:
+  - "internal"
+spec:
+  type: "service"
+  lifecycle: "production"
+  owner: "skvis"
+  system: "sikkerhetsmetrikker"
+  providesApis:
+  - "regelrett-api"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_regelrett"
+  title: "Security Champion regelrett"
+spec:
+  type: "security_champion"
+  parent: "eiendom_security_champions"
+  members:
+  - "jorn-ola-birkeland"
+  children:
+  - "resource:regelrett"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "regelrett"
+  links:
+  - url: "https://github.com/kartverket/regelrett"
+    title: "regelrett på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_regelrett"
+  dependencyOf:
+  - "component:regelrett"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "API"
+metadata:
+  name: "regelrett-api"
+  tags:
+  - "internal"
+spec:
+  type: "openapi"
+  lifecycle: "production"
+  owner: "skvis"
+  definition: |
+    openapi: "3.0.0"
+    info:
+        title: regelrett API
+    paths:


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage, samtidig som `beskrivelse.yaml` nå går til `version: 3.0`.
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.