### PR TITLE
add row with empty comment when deleting comment

### DIFF
--- a/backend/src/main/kotlin/no/bekk/database/CommentRepository.kt
+++ b/backend/src/main/kotlin/no/bekk/database/CommentRepository.kt
@@ -265,26 +265,24 @@ class CommentRepository {
 
     fun deleteCommentFromDatabase(comment: DatabaseComment) {
         logger.debug("Deleting comment from database: {}", comment)
+        println(comment)
         val connection = getDatabaseConnection()
         try {
             connection.use { conn ->
-                if (comment.team != null) {
                     val statement = conn.prepareStatement(
-                        "DELETE FROM comments WHERE question_id = ? AND team = ?"
+                        "INSERT INTO comments (actor, record_id, question_id, comment, team, function_id) VALUES (?, ?, ?, ?, ?, ?)"
                     )
-                    statement.setString(1, comment.questionId)
-                    statement.setString(2, comment.team)
+                    statement.setString(1, comment.actor)
+                    statement.setString(2, comment.recordId)
+                    statement.setString(3, comment.questionId)
+                    statement.setString(4, "")
+                    statement.setString(5, comment.team)
+                    if (comment.functionId != null) {
+                        statement.setInt(6, comment.functionId)
+                    } else {
+                        statement.setNull(6, Types.INTEGER)
+                    }
                     statement.executeUpdate()
-                } else if (comment.functionId != null) {
-                    val statement = conn.prepareStatement(
-                        "DELETE FROM comments WHERE question_id = ? AND function_id = ?"
-                    )
-                    statement.setString(1, comment.questionId)
-                    statement.setInt(2, comment.functionId)
-                    statement.executeUpdate()
-                } else {
-                    throw RuntimeException("Error deleting comment from database")
-                }
             }
         } catch (e: SQLException) {
             logger.error("Error deleting comment from database ${e.message}")


### PR DESCRIPTION
## Background
Alle kommentarene til spørsmålet har blitt slettet når man sletter en kommentar i UI

## Solution
Endret til å heller legge til en rad med en tom kommentar for å beholde historikken

Resolves #323 
