### PR TITLE
use localstorage to save filters for tables

### DIFF
--- a/frontend/beCompliant/src/components/tableActions/TableActions.tsx
+++ b/frontend/beCompliant/src/components/tableActions/TableActions.tsx
@@ -1,5 +1,4 @@
 import { Flex, Heading, Icon } from '@kvib/react';
-import { useEffect } from 'react';
 import { Column } from '../../api/types';
 import { TableFilter, TableFilters } from './TableFilter';
 
@@ -12,20 +11,6 @@ export const TableActions = ({
   filters: { filterOptions, activeFilters, setActiveFilters },
   tableMetadata,
 }: Props) => {
-  useEffect(() => {
-    const storedFilter = localStorage.getItem('filters');
-    const parsedFilter = storedFilter ? JSON.parse(storedFilter) : {};
-    if (parsedFilter && Object.keys(parsedFilter).length > 0) {
-      setActiveFilters(parsedFilter);
-    }
-  }, [setActiveFilters]);
-
-  useEffect(() => {
-    if (activeFilters) {
-      localStorage.setItem('filters', JSON.stringify(activeFilters));
-    }
-  }, [activeFilters]);
-
   return (
     <Flex flexDirection="column" gap="2" marginX="10">
       <Flex gap="2" alignItems="center">

--- a/frontend/beCompliant/src/components/tableActions/TableFilter.tsx
+++ b/frontend/beCompliant/src/components/tableActions/TableFilter.tsx
@@ -1,5 +1,5 @@
 import { Flex, Select, Text } from '@kvib/react';
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ActiveFilter } from '../../types/tableTypes';
 import { Option } from '../../api/types';
 
@@ -7,7 +7,7 @@ export type TableFilters = {
   filterName: string;
   filterOptions: Option[] | null;
   activeFilters: ActiveFilter[];
-  setActiveFilters: Dispatch<SetStateAction<ActiveFilter[]>>;
+  setActiveFilters: (activeFilters: ActiveFilter[]) => void;
 };
 
 export const TableFilter = ({

--- a/frontend/beCompliant/src/hooks/useLocalstorageState.ts
+++ b/frontend/beCompliant/src/hooks/useLocalstorageState.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 export const useLocalstorageState = <T>(key: string, initialValue: T) => {
-  const [value, setValue] = useState(() => {
+  const [value, setValue] = useState<T>(() => {
     const storedValue = window.localStorage.getItem(key);
     return storedValue ? JSON.parse(storedValue) : initialValue;
   });
@@ -10,5 +10,5 @@ export const useLocalstorageState = <T>(key: string, initialValue: T) => {
     window.localStorage.setItem(key, JSON.stringify(value));
   }, [value, setValue]);
 
-  return [value, setValue];
+  return [value, setValue] as const;
 };

--- a/frontend/beCompliant/src/pages/ActivityPage.tsx
+++ b/frontend/beCompliant/src/pages/ActivityPage.tsx
@@ -16,12 +16,15 @@ import { ErrorState } from '../components/ErrorState';
 import { filterData } from '../utils/tablePageUtil';
 import { useFetchContext } from '../hooks/useFetchContext';
 import { useFetchUserinfo } from '../hooks/useFetchUserinfo';
+import { useLocalstorageState } from '../hooks/useLocalstorageState';
 
 export const ActivityPage = () => {
   const params = useParams();
   const contextId = params.contextId;
 
-  const [activeFilters, setActiveFilters] = useState<ActiveFilter[]>([]);
+  const [activeFilters, setActiveFilters] = useLocalstorageState<
+    Record<string, ActiveFilter[]>
+  >('filters', {});
 
   const {
     data: context,
@@ -79,12 +82,16 @@ export const ActivityPage = () => {
   }
 
   tableData.records = mapTableDataRecords(tableData, comments, answers);
-  const filteredData = filterData(tableData.records, activeFilters);
+  const filteredData = filterData(
+    tableData.records,
+    activeFilters[tableData.id] ?? []
+  );
   const filters = {
     filterOptions: statusFilterOptions.options,
     filterName: '',
-    activeFilters: activeFilters,
-    setActiveFilters: setActiveFilters,
+    activeFilters: activeFilters[tableData.id] ?? [],
+    setActiveFilters: (activeFilters: ActiveFilter[]) =>
+      setActiveFilters((prev) => ({ ...prev, [tableData.id]: activeFilters })),
   };
 
   return (


### PR DESCRIPTION
## Background
Filterne blir lagret og overført selv om man bytter tabell. Det fører til at ingen spm vises i f.eks. i SLA når man setter filtere på sikkerhetskontroller-skjema

## Solution
Endre til å lagre et map med key tableId og value med filtre i stedet for å kun lagre filtrene. Da blir filtrene satt for en type skjema kun dukke opp på det skjemaet

Resolves #401 
