### PR TITLE
remove unit when no answer in history

### DIFF
--- a/frontend/beCompliant/src/components/questionPage/QuestionHistory.tsx
+++ b/frontend/beCompliant/src/components/questionPage/QuestionHistory.tsx
@@ -104,8 +104,9 @@ function QuestionHistoryStep({
         <Stack flexDirection="row" opacity={opacity}>
           <Icon icon="trip_origin" color={theme.colors.green[500]} />
           <Text color={theme.colors.green[500]}>
-            {answer.answer}{' '}
-            {answer.answerType === 'PERCENT' ? '%' : answer.answerUnit || ''}
+            {answer.answer ? answer.answer : '-'}{' '}
+            {answer.answer &&
+              (answer.answerType === 'PERCENT' ? '%' : answer.answerUnit || '')}
           </Text>
         </Stack>
         <Stack flexDirection="row" opacity={opacity}>


### PR DESCRIPTION
## Background
Når svaret er tomt, vises uniten (%, min osv) fortsatt i historikk-komponenten. 

## Solution
La til at uniten kun vises hvis svaret eksisterer

Resolves #461 