### PR TITLE
handle line breaks and fix question page layout

### DIFF
--- a/frontend/beCompliant/src/components/answers/CheckboxAnswer.tsx
+++ b/frontend/beCompliant/src/components/answers/CheckboxAnswer.tsx
@@ -1,12 +1,13 @@
 import { Checkbox, Stack } from '@kvib/react';
 import { LastUpdated } from '../table/LastUpdated';
+import { LastUpdatedQuestionPage } from '../questionPage/LastUpdatedQuestionPage';
 
 type Props = {
   value: string | undefined;
   updated?: Date;
   setAnswerInput: React.Dispatch<React.SetStateAction<string | undefined>>;
   submitAnswer: (newAnswer: string) => void;
-  showLastUpdated?: boolean;
+  isActivityPageView?: boolean;
 };
 
 export function CheckboxAnswer({
@@ -14,7 +15,7 @@ export function CheckboxAnswer({
   updated,
   setAnswerInput,
   submitAnswer,
-  showLastUpdated = false,
+  isActivityPageView = false,
 }: Props) {
   const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.checked ? 'checked' : 'unchecked';
@@ -32,7 +33,11 @@ export function CheckboxAnswer({
       >
         {value ? (value === 'checked' ? 'Enig' : 'Uenig') : ''}
       </Checkbox>
-      {showLastUpdated && <LastUpdated updated={updated} />}
+      {isActivityPageView ? (
+        <LastUpdated updated={updated} />
+      ) : (
+        <LastUpdatedQuestionPage lastUpdated={updated} />
+      )}
     </Stack>
   );
 }

--- a/frontend/beCompliant/src/components/answers/PercentAnswer.tsx
+++ b/frontend/beCompliant/src/components/answers/PercentAnswer.tsx
@@ -7,13 +7,14 @@ import {
 } from '@kvib/react';
 import { LastUpdated } from '../table/LastUpdated';
 import { useRef } from 'react';
+import { LastUpdatedQuestionPage } from '../questionPage/LastUpdatedQuestionPage';
 
 type Props = {
   value: string | undefined;
   updated?: Date;
   setAnswerInput: React.Dispatch<React.SetStateAction<string | undefined>>;
   submitAnswer: (newAnswer: string) => void;
-  showLastUpdated?: boolean;
+  isActivityPageView?: boolean;
 };
 
 export function PercentAnswer({
@@ -21,7 +22,7 @@ export function PercentAnswer({
   updated,
   setAnswerInput,
   submitAnswer,
-  showLastUpdated = false,
+  isActivityPageView = false,
 }: Props) {
   const initialValue = useRef(value).current;
 
@@ -69,7 +70,11 @@ export function PercentAnswer({
           />
         </InputGroup>
       </Stack>
-      {showLastUpdated && <LastUpdated updated={updated} />}
+      {isActivityPageView ? (
+        <LastUpdated updated={updated} />
+      ) : (
+        <LastUpdatedQuestionPage lastUpdated={updated} />
+      )}
     </Stack>
   );
 }

--- a/frontend/beCompliant/src/components/answers/TimeAnswer.tsx
+++ b/frontend/beCompliant/src/components/answers/TimeAnswer.tsx
@@ -8,6 +8,7 @@ import {
 } from '@kvib/react';
 import { LastUpdated } from '../table/LastUpdated';
 import { useEffect, useRef } from 'react';
+import { LastUpdatedQuestionPage } from '../questionPage/LastUpdatedQuestionPage';
 
 type Props = {
   value: string | undefined;
@@ -17,7 +18,7 @@ type Props = {
   setAnswerInput: React.Dispatch<React.SetStateAction<string | undefined>>;
   setAnswerUnit: React.Dispatch<React.SetStateAction<string | undefined>>;
   submitAnswer: (newAnswer: string, unit?: string) => void;
-  showLastUpdated?: boolean;
+  isActivityPageView?: boolean;
 };
 
 export function TimeAnswer({
@@ -28,7 +29,7 @@ export function TimeAnswer({
   setAnswerInput,
   setAnswerUnit,
   submitAnswer,
-  showLastUpdated = false,
+  isActivityPageView = false,
 }: Props) {
   const initialValue = useRef(value).current;
   const initialUnit = useRef(unit).current;
@@ -85,7 +86,11 @@ export function TimeAnswer({
           </NumberInput>
         </InputGroup>
       </Stack>
-      {showLastUpdated && <LastUpdated updated={updated} />}
+      {isActivityPageView ? (
+        <LastUpdated updated={updated} />
+      ) : (
+        <LastUpdatedQuestionPage lastUpdated={updated} />
+      )}
     </Stack>
   );
 }

--- a/frontend/beCompliant/src/components/questionPage/LastUpdatedQuestionPage.tsx
+++ b/frontend/beCompliant/src/components/questionPage/LastUpdatedQuestionPage.tsx
@@ -1,0 +1,15 @@
+import { Text } from '@kvib/react';
+import { formatDateTime } from '../../utils/formatTime';
+
+export function LastUpdatedQuestionPage({
+  lastUpdated,
+}: {
+  lastUpdated?: Date;
+}) {
+  if (!lastUpdated) return null;
+  return (
+    <Text fontSize="md" fontWeight="semibold">
+      {'Svar sist endret ' + formatDateTime(lastUpdated)}
+    </Text>
+  );
+}

--- a/frontend/beCompliant/src/components/questionPage/QuestionAnswer.tsx
+++ b/frontend/beCompliant/src/components/questionPage/QuestionAnswer.tsx
@@ -47,6 +47,7 @@ export function QuestionAnswer({ question, answers, contextId, user }: Props) {
           latestAnswer={answers.at(-1)?.answer ?? ''}
           contextId={contextId}
           user={user}
+          lastUpdated={answers.at(-1)?.updated}
         />
       );
     case AnswerType.TEXT_MULTI_LINE:
@@ -56,6 +57,7 @@ export function QuestionAnswer({ question, answers, contextId, user }: Props) {
           latestAnswer={answers.at(-1)?.answer ?? ''}
           contextId={contextId}
           user={user}
+          lastUpdated={answers.at(-1)?.updated}
         />
       );
     case AnswerType.PERCENT:

--- a/frontend/beCompliant/src/components/questionPage/QuestionDetails.tsx
+++ b/frontend/beCompliant/src/components/questionPage/QuestionDetails.tsx
@@ -1,5 +1,4 @@
 import { Text, Stack, StackProps } from '@kvib/react';
-import { formatDateTime } from '../../utils/formatTime';
 import { Question } from '../../api/types';
 
 type Props = StackProps & {
@@ -14,15 +13,16 @@ export function QuestionDetails({ question, answerUpdated, ...rest }: Props) {
 
   const description =
     findFieldValue('Sikkerhetskontroller') || findFieldValue('Beskrivelse');
+  const name = findFieldValue('Kortnavn') || findFieldValue('Navn');
 
   return (
     <Stack gap="1" {...rest}>
       <Text>{question.id}</Text>
       <Text fontSize="lg" as="b">
-        {description}
+        {name}
       </Text>
-      <Text fontSize="lg">
-        {'Svar sist endret ' + formatDateTime(answerUpdated)}
+      <Text fontSize="md" whiteSpace="pre-line" maxW="600px">
+        {description}
       </Text>
     </Stack>
   );

--- a/frontend/beCompliant/src/components/questionPage/RadioAnswer.tsx
+++ b/frontend/beCompliant/src/components/questionPage/RadioAnswer.tsx
@@ -1,12 +1,14 @@
 import { Text, RadioGroup, Radio, Stack, Flex } from '@kvib/react';
 import { useSubmitAnswers } from '../../hooks/useSubmitAnswers';
 import { Question, User } from '../../api/types';
+import { LastUpdatedQuestionPage } from './LastUpdatedQuestionPage';
 
 type Props = {
   question: Question;
   latestAnswer: string;
   contextId: string;
   user: User;
+  lastUpdated?: Date;
 };
 
 export function RadioAnswer({
@@ -14,6 +16,7 @@ export function RadioAnswer({
   latestAnswer,
   contextId,
   user,
+  lastUpdated,
 }: Props) {
   const { mutate: submitAnswer } = useSubmitAnswers(
     contextId,
@@ -51,6 +54,7 @@ export function RadioAnswer({
           ))}
         </Stack>
       </RadioGroup>
+      <LastUpdatedQuestionPage lastUpdated={lastUpdated} />
     </Flex>
   );
 }

--- a/frontend/beCompliant/src/components/questionPage/TextAreaAnswer.tsx
+++ b/frontend/beCompliant/src/components/questionPage/TextAreaAnswer.tsx
@@ -2,12 +2,14 @@ import { Text, Textarea, Stack, Flex } from '@kvib/react';
 import { useSubmitAnswers } from '../../hooks/useSubmitAnswers';
 import { Question, User } from '../../api/types';
 import { useEffect, useState } from 'react';
+import { LastUpdatedQuestionPage } from './LastUpdatedQuestionPage';
 
 type Props = {
   question: Question;
   latestAnswer: string;
   contextId: string;
   user: User;
+  lastUpdated?: Date;
 };
 
 export function TextAreaAnswer({
@@ -15,6 +17,7 @@ export function TextAreaAnswer({
   latestAnswer,
   contextId,
   user,
+  lastUpdated,
 }: Props) {
   const [answerInput, setAnswerInput] = useState<string | undefined>(
     latestAnswer
@@ -59,6 +62,7 @@ export function TextAreaAnswer({
           onBlur={submitTextAnswer}
         />
       </Stack>
+      <LastUpdatedQuestionPage lastUpdated={lastUpdated} />
     </Flex>
   );
 }

--- a/frontend/beCompliant/src/components/table/AnswerCell.tsx
+++ b/frontend/beCompliant/src/components/table/AnswerCell.tsx
@@ -84,7 +84,7 @@ export function AnswerCell({
           updated={updated}
           setAnswerInput={setAnswerInput}
           submitAnswer={submitAnswer}
-          showLastUpdated
+          isActivityPageView
         />
       );
     case AnswerType.TIME:
@@ -97,7 +97,7 @@ export function AnswerCell({
           setAnswerInput={setAnswerInput}
           setAnswerUnit={setAnswerUnit}
           submitAnswer={submitAnswer}
-          showLastUpdated
+          isActivityPageView
         />
       );
     case AnswerType.CHECKBOX:
@@ -107,7 +107,7 @@ export function AnswerCell({
           updated={updated}
           setAnswerInput={setAnswerInput}
           submitAnswer={submitAnswer}
-          showLastUpdated
+          isActivityPageView
         />
       );
     default:

--- a/frontend/beCompliant/src/components/table/TableCell.tsx
+++ b/frontend/beCompliant/src/components/table/TableCell.tsx
@@ -98,7 +98,7 @@ export const TableCell = ({
   }
   return (
     <Text whiteSpace="normal" fontSize="md">
-      {value.value}
+      {value.value[0].split('\n\n')[0]}
     </Text>
   );
 };

--- a/frontend/beCompliant/src/pages/QuestionPage.tsx
+++ b/frontend/beCompliant/src/pages/QuestionPage.tsx
@@ -120,7 +120,7 @@ export const QuestionPage = () => {
         <QuestionDetails
           question={question}
           answerUpdated={answers.at(-1)?.updated ?? new Date()}
-          marginBottom={{ base: '30', md: '120' }}
+          marginBottom={{ base: '30', md: '20' }}
         />
         <Flex
           justifyContent="space-between"


### PR DESCRIPTION
## Background
Dersom tekstfelter har dobbel linjeskift skal kun teksten fra til linjeskift vises i tabellen, men hele teksten skal vises på spørsmålssiden.

## Solution
- La til håndtering av linjeskift. Testet med testskjemaet. La til linjeskift og tekst i beskrivelsen til AR-001 hvis dere vil teste
- Måtte endre litt på spørsmålssiden slik at det ser noenlunde greit ut

Resolves #488 
