### PR TITLE
requent cache updates while webhooks dont work

### DIFF
--- a/backend/src/main/kotlin/no/bekk/util/RefreshWebhookBackgroundTask.kt
+++ b/backend/src/main/kotlin/no/bekk/util/RefreshWebhookBackgroundTask.kt
@@ -22,10 +22,11 @@ fun Application.configureBackgroundTasks() {
                     } else {
                         logger.warn("Failed to refresh webhook for table ${provider.id}")
                     }
+                    provider.updateCaches() // temp solution while webhooks don't work at SKIP
                 }
 
                 // Delay for 24 hours
-                delay(24 * 60 * 60 * 1000L)
+                delay(1 * 60 * 60 * 1000L) // changed to 1 hour while webhooks are not working as intended
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {


### PR DESCRIPTION
## Background
Webhooks blir ikke mottatt på SKIP. Temp løsning som regelmessing fetcher data fra AirTable og oppdaterer caches uavhengig av at det blir gjort faktiske endringer i Airtable

Resolves #issue-this-pr-resolves
#512 

