### PR TITLE
change border to outline and increase size

### DIFF
--- a/frontend/beCompliant/src/components/table/DataTable.tsx
+++ b/frontend/beCompliant/src/components/table/DataTable.tsx
@@ -180,7 +180,7 @@ export function DataTable<TData>({
                       `${(row.original as { recordId: string }).recordId}`
                     )
                   }
-                  _hover={{ border: '1.5px solid', borderColor: 'blue.400' }}
+                  _hover={{ outline: '2px solid', outlineColor: 'blue.400' }}
                   style={{ cursor: 'pointer' }}
                 >
                   {row.getVisibleCells().map((cell) => (


### PR DESCRIPTION
## Background
Borderen rundt radene synes ikke på stor skjerm

## Solution
Økte størrelsen til 2px slik at den synes uansett skjermstørrelse
Endret fra border til outline slik at radene ikke "hopper" når man hovrer

Resolves #522 
