### PR TITLE
fix comma in string bug csv export

### DIFF
--- a/backend/src/main/kotlin/no/bekk/routes/UploadCSVRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/UploadCSVRouting.kt
@@ -88,11 +88,11 @@ fun List<AnswersCSVDump>.toCsv(): String {
     val stringWriter = StringWriter()
     stringWriter.append("questionId,answer,answer_type,answer_unit,answer_updated,answer_actor,comment,comment_updated,comment_actor,context_id,context_name,table_id,team_id\n")
     this.forEach {
-        stringWriter.append("${it.questionId},${it.answer},${it.answerType},${it.answerUnit},${it.answerUpdated},${it.answerActor},${it.comment},${it.commentUpdated},${it.commentActor},${it.contextId},${it.contextName},${it.tableName},${it.teamId}\n")
+        stringWriter.append("\"${it.questionId}\",\"${it.answer}\",\"${it.answerType}\",\"${it.answerUnit}\",\"${it.answerUpdated}\",\"${it.answerActor}\",\"${it.comment}\",\"${it.commentUpdated}\",\"${it.commentActor}\",\"${it.contextId}\",\"${it.contextName}\",\"${it.tableName}\",\"${it.teamId}\"\n")
     }
+
     return stringWriter.toString()
 }
-
 
 fun mapRowToAnswersCSVDump(rs: ResultSet): AnswersCSVDump {
     return AnswersCSVDump(


### PR DESCRIPTION
## Background
Hvis det var komma i et av feltene tolket csv filen det som en ny kolonne. Endret til at hvert felt blir wrappet i double quotes.


Resolves #issue-this-pr-resolves
#533 
