### PR TITLE
bug: .at() exception when refreshing

### DIFF
--- a/frontend/beCompliant/src/utils/tablePageUtil.ts
+++ b/frontend/beCompliant/src/utils/tablePageUtil.ts
@@ -17,12 +17,16 @@ export const filterData = (
 
     return filteredData.filter((record: Question) => {
       if (fieldName === 'Svar') {
-        const lastAnswer = record.answers.at(-1)?.answer;
+        const lastAnswer = Array.isArray(record.answers)
+          ? record.answers.at(-1)?.answer
+          : undefined;
         return lastAnswer?.toLowerCase() === filterValue;
       }
 
       if (fieldName === 'Status') {
-        const lastAnswerExists = record.answers.at(-1) != null;
+        const lastAnswerExists = Array.isArray(record.answers)
+          ? record.answers.at(-1) != null
+          : false;
 
         if (filterValue === 'utfylt') {
           return lastAnswerExists;


### PR DESCRIPTION
## Background
Hvis man filterer på svar, går til front page, refresher, og prøver å gå inn på skjemaet inn kastes det en exception.

## Solution
Fant ut at record.answers kan være undefined i noen tilfeller når data filtreres, og at det er derfor feilmeldingen om .at() kastes.
La til en sjekk som sjekker at det faktisk er en array.

Resolves #530 
