### PR TITLE
fix linjeskift on comments in detailed view

### DIFF
--- a/frontend/beCompliant/src/components/questionPage/QuestionComment.tsx
+++ b/frontend/beCompliant/src/components/questionPage/QuestionComment.tsx
@@ -129,7 +129,7 @@ export function QuestionComment({
             <Text
               maxWidth="328px"
               overflow="hidden"
-              whiteSpace="normal"
+              whiteSpace="pre-wrap"
               fontSize="md"
             >
               {latestComment}


### PR DESCRIPTION
## Background
Doble linjeskift synes ikke på detaljsiden

## Solution
whitespace: normal -> pre-wrap

Resolves #560 
