### PR TITLE
make tables endpoint public and create tableId endpoint

### DIFF
--- a/backend/src/main/kotlin/no/bekk/database/ContextRepository.kt
+++ b/backend/src/main/kotlin/no/bekk/database/ContextRepository.kt
@@ -110,6 +110,21 @@ object ContextRepository {
         }
     }
 
+    fun getContextTableId(id: String): String {
+        val sqlStatement = "SELECT table_id FROM contexts WHERE id = ?"
+        Database.getConnection().use { conn ->
+            conn.prepareStatement(sqlStatement).use { statement ->
+                statement.setObject(1, UUID.fromString(id))
+                val result = statement.executeQuery()
+                if (result.next()) {
+                    return result.getString("table_id")
+                } else {
+                    throw RuntimeException("Error getting table_id for this context")
+                }
+            }
+        }
+    }
+
     fun deleteContext(id: String): Boolean {
         val sqlStatementContext = "DELETE FROM contexts WHERE id = ?"
         Database.getConnection().use { conn ->

--- a/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
@@ -2,7 +2,6 @@ package no.bekk.routes
 
 import io.ktor.http.*
 import io.ktor.server.application.*
-import io.ktor.server.plugins.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.bekk.services.TableService
@@ -10,14 +9,6 @@ import no.bekk.util.logger
 
 fun Route.tableRouting() {
     route("/tables") {
-
-        get {
-            val tables = TableService.getTableProviders().map {
-                it.getTable()
-            }
-            call.respond(tables)
-        }
-
         get("/{tableId}") {
             val tableId = call.parameters["tableId"]
             if (tableId == null) {


### PR DESCRIPTION
## Background
Flytte getTables endepunktet til Routing slik at den blir public så FRISK kan bruke den.
Lage endepunkt for å hente tableId basert på contextId for å muliggjøre migrering av skjema-metadata til ny metadata.

## Solution

Resolves #569 og #570 