### PR TITLE
add get schemas endpoint, fix cors frisk, fix redirect for new metadata

### DIFF
--- a/.github/workflows/build-deploy-backend-gcp.yml
+++ b/.github/workflows/build-deploy-backend-gcp.yml
@@ -30,6 +30,7 @@ env:
   FRONTEND_URL_HOST: regelrett-frontend-1024826672490.europe-north1.run.app
   SIKKERHETSKONTROLLER_WEBHOOK_ID: "ach2vlnWcdxY8Cl3k"
   DRIFTSKONTINUITET_WEBHOOK_ID: "achCxVfK6DaWMhchX"
+  FRISK_FRONTEND_URL_HOST: https://frisk-frontend.fly.dev
 
 jobs:
   build-and-push:
@@ -145,6 +146,7 @@ jobs:
             sudo docker stop '${{ env.IMAGE_NAME }}' || true &&
             sudo docker rm '${{ env.IMAGE_NAME }}' || true &&
             sudo docker run -d --name '${{ env.IMAGE_NAME }}' --network container_network -p 8080:8080 \
+              -e FRISK_FRONTEND_URL_HOST=${{ env.FRISK_FRONTEND_URL_HOST }} \
               -e AIRTABLE_ACCESS_TOKEN=${{ secrets.AIRTABLE_ACCESS_TOKEN }} \
               -e CLIENT_ID=${{ secrets.ENTRA_CLIENT_ID }} \
               -e TENANT_ID=${{ secrets.ENTRA_TENANT_ID }} \

--- a/backend/src/main/kotlin/no/bekk/Application.kt
+++ b/backend/src/main/kotlin/no/bekk/Application.kt
@@ -74,6 +74,10 @@ private fun loadAppConfig(config: ApplicationConfig) {
         username = config.propertyOrNull("db.username")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"db.username\"")
         password = config.propertyOrNull("db.password")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"db.password\"")
     }
+
+    AppConfig.friskFrontend = FRISKFrontendConfig.apply {
+        host = config.propertyOrNull("friskFrontend.host")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"friskFrontend.host\"")
+    }
 }
 
 fun Application.module() {

--- a/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
+++ b/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
@@ -7,6 +7,7 @@ object AppConfig {
     lateinit var frontend: FrontendConfig
     lateinit var backend: BackendConfig
     lateinit var db: DbConfig
+    lateinit var friskFrontend: FRISKFrontendConfig
 }
 
 object TableConfig {
@@ -63,4 +64,8 @@ object DbConfig {
     lateinit var url: String
     lateinit var username: String
     lateinit var password: String
+}
+
+object FRISKFrontendConfig {
+    lateinit var host: String
 }

--- a/backend/src/main/kotlin/no/bekk/model/internal/Table.kt
+++ b/backend/src/main/kotlin/no/bekk/model/internal/Table.kt
@@ -29,3 +29,9 @@ data class Table(
     val columns: List<Column>,
     val records: List<Question>,
 )
+
+@Serializable
+data class Schema(
+    val id: String,
+    val name: String
+)

--- a/backend/src/main/kotlin/no/bekk/plugins/Cors.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/Cors.kt
@@ -8,6 +8,7 @@ import no.bekk.configuration.AppConfig
 fun Application.configureCors() {
     install(CORS) {
         allowHost(AppConfig.frontend.host)
+        allowHost(AppConfig.friskFrontend.host)
         allowCredentials = true
         allowSameOrigin = true
         allowHeader(HttpHeaders.ContentType)

--- a/backend/src/main/kotlin/no/bekk/plugins/Routing.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/Routing.kt
@@ -22,11 +22,11 @@ fun Application.configureRouting() {
             call.respondText("Health OK", ContentType.Text.Plain)
         }
 
-        get("/tables") {
-            val tables = TableService.getTableProviders().map {
-                it.getTable()
+        get("/schemas") {
+            val schemas = TableService.getTableProviders().map {
+                it.getSchema()
             }
-            call.respond(tables)
+            call.respond(schemas)
         }
 
         //This endpoint can be removed after schemas in frisk are migrated to new metadata

--- a/backend/src/main/kotlin/no/bekk/providers/TableProvider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/TableProvider.kt
@@ -1,6 +1,5 @@
 package no.bekk.providers
 
-import com.github.benmanes.caffeine.cache.Cache
 import no.bekk.model.internal.*
 
 interface TableProvider {
@@ -8,4 +7,5 @@ interface TableProvider {
     suspend fun getTable(): Table
     suspend fun getQuestion(recordId: String): Question
     suspend fun getColumns(): List<Column>
+    suspend fun getSchema(): Schema
 }

--- a/backend/src/main/kotlin/no/bekk/providers/YamlProvider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/YamlProvider.kt
@@ -1,6 +1,5 @@
 package no.bekk.providers
 
-import com.github.benmanes.caffeine.cache.Cache
 import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -26,6 +25,22 @@ class YamlProvider(
             return getTableFromYamlEndpoint()
         } else {
             return getTableFromResourcePath()
+        }
+    }
+
+    override suspend fun getSchema(): Schema {
+        if (endpoint != null) {
+            val table = getTableFromYamlEndpoint()
+            return Schema(
+                id = table.id,
+                name = table.name,
+            )
+        } else {
+            val table = getTableFromResourcePath()
+            return Schema(
+                id = table.id,
+                name = table.name,
+            )
         }
     }
 

--- a/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
@@ -9,6 +9,14 @@ import no.bekk.util.logger
 
 fun Route.tableRouting() {
     route("/tables") {
+
+        get {
+            val tables = TableService.getTableProviders().map {
+                it.getTable()
+            }
+            call.respond(tables)
+        }
+
         get("/{tableId}") {
             val tableId = call.parameters["tableId"]
             if (tableId == null) {

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -47,3 +47,6 @@ db:
   url: "$DB_URL:jdbc:postgresql://localhost:5432/regelrett"
   username: "$DB_NAME:postgres"
   password: "$DB_PASSWORD:pwd"
+
+friskFrontend:
+  host: "$FRISK_FRONTEND_URL_HOST:localhost:5173"

--- a/frontend/beCompliant/src/pages/CreateContextPage.tsx
+++ b/frontend/beCompliant/src/pages/CreateContextPage.tsx
@@ -55,12 +55,7 @@ export const CreateContextPage = () => {
             if (redirect) {
               const incomingRedirect = decodeURIComponent(redirect)
                 .replace('{contextId}', data.data.id)
-                .replace('{contextName}', data.data.name)
-                .replace(
-                  '{tableName}',
-                  tablesData?.find((table) => table.id === data.data.tableId)
-                    ?.name ?? tableId
-                );
+                .replace('{tableId}', tableId);
               const fullRedirect = new URL(incomingRedirect);
               const newRedirect = new URL(
                 `${window.location.origin}/context/${data.data.id}`

--- a/frontend/beCompliant/src/pages/CreateContextPage.tsx
+++ b/frontend/beCompliant/src/pages/CreateContextPage.tsx
@@ -55,7 +55,13 @@ export const CreateContextPage = () => {
             if (redirect) {
               const incomingRedirect = decodeURIComponent(redirect)
                 .replace('{contextId}', data.data.id)
-                .replace('{tableId}', tableId);
+                .replace('{tableId}', tableId)
+                .replace('{contextName}', data.data.name)
+                .replace(
+                  '{tableName}',
+                  tablesData?.find((table) => table.id === data.data.tableId)
+                    ?.name ?? tableId
+                );
               const fullRedirect = new URL(incomingRedirect);
               const newRedirect = new URL(
                 `${window.location.origin}/context/${data.data.id}`


### PR DESCRIPTION
## Background
- lagde /schemas endepunkt for å ikke få med unødvendig data fra /tables endepunktet
- flyttet /tables endepunktet tilbake til TableRouting
- endret på "redirect" i frontend for at det skal matche med ny skjema-metadata
- la til frisk frontend url i config slik at endepunktene kan kalles på fra frisk


Resolves 191 i frisk