### PR TITLE
Regelrett config

### DIFF
--- a/backend/src/main/kotlin/no/bekk/Application.kt
+++ b/backend/src/main/kotlin/no/bekk/Application.kt
@@ -1,5 +1,6 @@
 package no.bekk
 
+import io.ktor.client.*
 import no.bekk.plugins.*
 import io.ktor.server.application.*
 import io.ktor.server.plugins.contentnegotiation.*
@@ -22,9 +23,10 @@ private fun loadAppConfig(config: ApplicationConfig) {
         }
 
         tables = config.configList("tables").map { table ->
-            TableInstance(
+
+            when (table.propertyOrNull("type")?.getString()) {
+                "AIRTABLE" -> AirTableInstanceConfig(
                 id = table.propertyOrNull("id")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"id\""),
-                type = table.propertyOrNull("type")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"type\""),
                 accessToken = table.propertyOrNull("accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"accessToken\""),
                 baseId = table.propertyOrNull("baseId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"baseId\""),
                 tableId = table.propertyOrNull("tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"tableId\""),
@@ -32,28 +34,16 @@ private fun loadAppConfig(config: ApplicationConfig) {
                 webhookId = table.propertyOrNull("webhookId")?.getString(),
                 webhookSecret = table.propertyOrNull("webhookSecret")?.getString(),
             )
+                "YAML" -> YAMLInstanceConfig(
+                    id = table.propertyOrNull("id")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"id\""),
+                    endpoint = table.propertyOrNull("endpoint")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"baseId\""),
+                    resourcePath = table.propertyOrNull("resourcePath")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"tableId\""),
+                )
+                else -> throw IllegalStateException("Illegal type \"type\"")
+
+            }
+
         }
-
-
-
-
-//        sikkerhetskontroller = AirTableInstanceConfig(
-//            accessToken = config.propertyOrNull("airTable.sikkerhetskontroller.accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.accessToken\""),
-//            baseId = config.propertyOrNull("airTable.sikkerhetskontroller.baseId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.baseId\""),
-//            tableId = config.propertyOrNull("airTable.sikkerhetskontroller.tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.tableId\""),
-//            viewId = config.propertyOrNull("airTable.sikkerhetskontroller.viewId")?.getString(),
-//            webhookId = config.propertyOrNull("airTable.sikkerhetskontroller.webhookId")?.getString(),
-//            webhookSecret = config.propertyOrNull("airTable.sikkerhetskontroller.webhookSecret")?.getString(),
-//
-//        )
-//        driftskontinuitet = AirTableInstanceConfig(
-//            accessToken = config.propertyOrNull("airTable.driftskontinuitet.accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.accessToken\""),
-//            baseId = config.propertyOrNull("airTable.driftskontinuitet.baseId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.baseId\""),
-//            tableId = config.propertyOrNull("airTable.driftskontinuitet.tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.tableId\""),
-//            viewId = config.propertyOrNull("airTable.driftskontinuitet.viewId")?.getString(),
-//            webhookId = config.propertyOrNull("airTable.driftskontinuitet.webhookId")?.getString(),
-//            webhookSecret = config.propertyOrNull("airTable.driftskontinuitet.webhookSecret")?.getString(),
-//        )
     }
 
     // MicrosoftGraph config

--- a/backend/src/main/kotlin/no/bekk/Application.kt
+++ b/backend/src/main/kotlin/no/bekk/Application.kt
@@ -20,23 +20,40 @@ private fun loadAppConfig(config: ApplicationConfig) {
         airTable = AirTableConfig.apply {
             baseUrl = config.propertyOrNull("airTable.baseUrl")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.baseUrl\"")
         }
-        sikkerhetskontroller = AirTableInstanceConfig(
-            accessToken = config.propertyOrNull("airTable.sikkerhetskontroller.accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.accessToken\""),
-            baseId = config.propertyOrNull("airTable.sikkerhetskontroller.baseId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.baseId\""),
-            tableId = config.propertyOrNull("airTable.sikkerhetskontroller.tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.tableId\""),
-            viewId = config.propertyOrNull("airTable.sikkerhetskontroller.viewId")?.getString(),
-            webhookId = config.propertyOrNull("airTable.sikkerhetskontroller.webhookId")?.getString(),
-            webhookSecret = config.propertyOrNull("airTable.sikkerhetskontroller.webhookSecret")?.getString(),
 
-        )
-        driftskontinuitet = AirTableInstanceConfig(
-            accessToken = config.propertyOrNull("airTable.driftskontinuitet.accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.accessToken\""),
-            baseId = config.propertyOrNull("airTable.driftskontinuitet.baseId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.baseId\""),
-            tableId = config.propertyOrNull("airTable.driftskontinuitet.tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.tableId\""),
-            viewId = config.propertyOrNull("airTable.driftskontinuitet.viewId")?.getString(),
-            webhookId = config.propertyOrNull("airTable.driftskontinuitet.webhookId")?.getString(),
-            webhookSecret = config.propertyOrNull("airTable.driftskontinuitet.webhookSecret")?.getString(),
-        )
+        tables = config.configList("tables").map { table ->
+            TableInstance(
+                id = table.propertyOrNull("id")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"id\""),
+                type = table.propertyOrNull("type")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"type\""),
+                accessToken = table.propertyOrNull("accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"accessToken\""),
+                baseId = table.propertyOrNull("baseId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"baseId\""),
+                tableId = table.propertyOrNull("tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"tableId\""),
+                viewId = table.propertyOrNull("viewId")?.getString(),
+                webhookId = table.propertyOrNull("webhookId")?.getString(),
+                webhookSecret = table.propertyOrNull("webhookSecret")?.getString(),
+            )
+        }
+
+
+
+
+//        sikkerhetskontroller = AirTableInstanceConfig(
+//            accessToken = config.propertyOrNull("airTable.sikkerhetskontroller.accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.accessToken\""),
+//            baseId = config.propertyOrNull("airTable.sikkerhetskontroller.baseId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.baseId\""),
+//            tableId = config.propertyOrNull("airTable.sikkerhetskontroller.tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.tableId\""),
+//            viewId = config.propertyOrNull("airTable.sikkerhetskontroller.viewId")?.getString(),
+//            webhookId = config.propertyOrNull("airTable.sikkerhetskontroller.webhookId")?.getString(),
+//            webhookSecret = config.propertyOrNull("airTable.sikkerhetskontroller.webhookSecret")?.getString(),
+//
+//        )
+//        driftskontinuitet = AirTableInstanceConfig(
+//            accessToken = config.propertyOrNull("airTable.driftskontinuitet.accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.accessToken\""),
+//            baseId = config.propertyOrNull("airTable.driftskontinuitet.baseId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.baseId\""),
+//            tableId = config.propertyOrNull("airTable.driftskontinuitet.tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.tableId\""),
+//            viewId = config.propertyOrNull("airTable.driftskontinuitet.viewId")?.getString(),
+//            webhookId = config.propertyOrNull("airTable.driftskontinuitet.webhookId")?.getString(),
+//            webhookSecret = config.propertyOrNull("airTable.driftskontinuitet.webhookSecret")?.getString(),
+//        )
     }
 
     // MicrosoftGraph config

--- a/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
+++ b/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
@@ -1,5 +1,7 @@
 package no.bekk.configuration
 
+import io.ktor.client.*
+
 object AppConfig {
     lateinit var tables: TableConfig
     lateinit var microsoftGraph: MicrosoftGraphConfig
@@ -12,34 +14,33 @@ object AppConfig {
 object TableConfig {
     lateinit var airTable: AirTableConfig
     lateinit var tables: List<TableInstance>
-    //lateinit var sikkerhetskontroller: AirTableInstanceConfig
-    //lateinit var driftskontinuitet: AirTableInstanceConfig
 }
 
 object AirTableConfig {
     lateinit var baseUrl: String
 }
 
-
-data class TableInstance (
-    val id: String,
-    val type: String,
-    val accessToken: String,
-    val baseId: String,
-    val tableId: String,
-    var viewId: String? = null,
-    var webhookId: String? = null,
-    var webhookSecret: String? = null,
-)
+interface TableInstance {
+    val id: String
+}
 
 data class AirTableInstanceConfig (
+    override val id: String,
     val accessToken: String,
     val baseId: String,
     val tableId: String,
     var viewId: String? = null,
     var webhookId: String? = null,
     var webhookSecret: String? = null,
-)
+) : TableInstance
+
+data class YAMLInstanceConfig (
+    override val id: String,
+    val endpoint: String? = null,
+    val resourcePath: String? = null
+) : TableInstance
+
+
 
 object MicrosoftGraphConfig {
     lateinit var baseUrl: String

--- a/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
+++ b/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
@@ -11,13 +11,26 @@ object AppConfig {
 
 object TableConfig {
     lateinit var airTable: AirTableConfig
-    lateinit var sikkerhetskontroller: AirTableInstanceConfig
-    lateinit var driftskontinuitet: AirTableInstanceConfig
+    lateinit var tables: List<TableInstance>
+    //lateinit var sikkerhetskontroller: AirTableInstanceConfig
+    //lateinit var driftskontinuitet: AirTableInstanceConfig
 }
 
 object AirTableConfig {
     lateinit var baseUrl: String
 }
+
+
+data class TableInstance (
+    val id: String,
+    val type: String,
+    val accessToken: String,
+    val baseId: String,
+    val tableId: String,
+    var viewId: String? = null,
+    var webhookId: String? = null,
+    var webhookSecret: String? = null,
+)
 
 data class AirTableInstanceConfig (
     val accessToken: String,

--- a/backend/src/main/kotlin/no/bekk/services/TableService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/TableService.kt
@@ -6,29 +6,50 @@ import no.bekk.providers.TableProvider
 import no.bekk.providers.clients.AirTableClient
 
 object TableService {
-    private val providers: List<TableProvider> = listOf<TableProvider>(
-        AirTableProvider(
-            id = "570e9285-3228-4396-b82b-e9752e23cd73",
-            airtableClient = AirTableClient(
-                AppConfig.tables.sikkerhetskontroller.accessToken
-            ),
-            baseId = AppConfig.tables.sikkerhetskontroller.baseId,
-            tableId = AppConfig.tables.sikkerhetskontroller.tableId,
-            viewId = AppConfig.tables.sikkerhetskontroller.viewId,
-            webhookId = AppConfig.tables.sikkerhetskontroller.webhookId,
-            webhookSecret = AppConfig.tables.sikkerhetskontroller.webhookSecret,
-        ),
-        AirTableProvider(
-            id = "816cc808-9188-44a9-8f4b-5642fc2932c4",
-            airtableClient = AirTableClient(
-                AppConfig.tables.driftskontinuitet.accessToken
-            ),
-            baseId = AppConfig.tables.driftskontinuitet.baseId,
-            tableId = AppConfig.tables.driftskontinuitet.tableId,
-            viewId = AppConfig.tables.driftskontinuitet.viewId,
-            webhookId = AppConfig.tables.driftskontinuitet.webhookId,
-            webhookSecret = AppConfig.tables.driftskontinuitet.webhookSecret,
-        ),
+
+
+  private val providers: List<TableProvider> = AppConfig.tables.tables.map { table ->
+        if (table.type == "AIRTABLE") {
+            AirTableProvider(
+                id = table.id,
+                airtableClient = AirTableClient(
+                    table.accessToken
+                ),
+                baseId = table.baseId,
+                tableId =   table.tableId,
+                viewId = table.viewId,
+                webhookId = table.webhookId,
+                webhookSecret = table.webhookSecret,
+            )
+        } else {
+            throw Exception("Table ${table.type} not found")
+        }
+    }
+
+
+//    private val providers: List<TableProvider> = listOf<TableProvider>(
+//        AirTableProvider(
+//            id = "570e9285-3228-4396-b82b-e9752e23cd73",
+//            airtableClient = AirTableClient(
+//                AppConfig.tables.sikkerhetskontroller.accessToken
+//            ),
+//            baseId = AppConfig.tables.sikkerhetskontroller.baseId,
+//            tableId = AppConfig.tables.sikkerhetskontroller.tableId,
+//            viewId = AppConfig.tables.sikkerhetskontroller.viewId,
+//            webhookId = AppConfig.tables.sikkerhetskontroller.webhookId,
+//            webhookSecret = AppConfig.tables.sikkerhetskontroller.webhookSecret,
+//        ),
+//        AirTableProvider(
+//            id = "816cc808-9188-44a9-8f4b-5642fc2932c4",
+//            airtableClient = AirTableClient(
+//                AppConfig.tables.driftskontinuitet.accessToken
+//            ),
+//            baseId = AppConfig.tables.driftskontinuitet.baseId,
+//            tableId = AppConfig.tables.driftskontinuitet.tableId,
+//            viewId = AppConfig.tables.driftskontinuitet.viewId,
+//            webhookId = AppConfig.tables.driftskontinuitet.webhookId,
+//            webhookSecret = AppConfig.tables.driftskontinuitet.webhookSecret,
+//        ),
 //        AirTableProvider(
 //            id = "test-table",
 //            airtableClient = AirTableClient(
@@ -40,7 +61,7 @@ object TableService {
 //            webhookId = "achpY1AcPW93B9ucr",
 //            webhookSecret = System.getenv("AIRTABLE_WEBHOOK_SECRET")
 //        ),
-    )
+ //   )
 
 
     fun getTableProvider(tableId: String): TableProvider {

--- a/backend/src/main/kotlin/no/bekk/services/TableService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/TableService.kt
@@ -1,16 +1,20 @@
 package no.bekk.services
 
+import io.ktor.client.*
+import no.bekk.configuration.AirTableInstanceConfig
 import no.bekk.configuration.AppConfig
+import no.bekk.configuration.YAMLInstanceConfig
 import no.bekk.providers.AirTableProvider
 import no.bekk.providers.TableProvider
+import no.bekk.providers.YamlProvider
 import no.bekk.providers.clients.AirTableClient
 
 object TableService {
 
 
   private val providers: List<TableProvider> = AppConfig.tables.tables.map { table ->
-        if (table.type == "AIRTABLE") {
-            AirTableProvider(
+        when (table) {
+            is AirTableInstanceConfig -> AirTableProvider(
                 id = table.id,
                 airtableClient = AirTableClient(
                     table.accessToken
@@ -21,47 +25,15 @@ object TableService {
                 webhookId = table.webhookId,
                 webhookSecret = table.webhookSecret,
             )
-        } else {
-            throw Exception("Table ${table.type} not found")
+            is YAMLInstanceConfig -> YamlProvider(
+                id = table.id,
+                endpoint = table.endpoint,
+                resourcePath =   table.resourcePath,
+            )
+            else ->  throw Exception("Valid tabletype not found")
+
         }
     }
-
-
-//    private val providers: List<TableProvider> = listOf<TableProvider>(
-//        AirTableProvider(
-//            id = "570e9285-3228-4396-b82b-e9752e23cd73",
-//            airtableClient = AirTableClient(
-//                AppConfig.tables.sikkerhetskontroller.accessToken
-//            ),
-//            baseId = AppConfig.tables.sikkerhetskontroller.baseId,
-//            tableId = AppConfig.tables.sikkerhetskontroller.tableId,
-//            viewId = AppConfig.tables.sikkerhetskontroller.viewId,
-//            webhookId = AppConfig.tables.sikkerhetskontroller.webhookId,
-//            webhookSecret = AppConfig.tables.sikkerhetskontroller.webhookSecret,
-//        ),
-//        AirTableProvider(
-//            id = "816cc808-9188-44a9-8f4b-5642fc2932c4",
-//            airtableClient = AirTableClient(
-//                AppConfig.tables.driftskontinuitet.accessToken
-//            ),
-//            baseId = AppConfig.tables.driftskontinuitet.baseId,
-//            tableId = AppConfig.tables.driftskontinuitet.tableId,
-//            viewId = AppConfig.tables.driftskontinuitet.viewId,
-//            webhookId = AppConfig.tables.driftskontinuitet.webhookId,
-//            webhookSecret = AppConfig.tables.driftskontinuitet.webhookSecret,
-//        ),
-//        AirTableProvider(
-//            id = "test-table",
-//            airtableClient = AirTableClient(
-//                System.getenv("AIRTABLE_TEST_TOKEN")
-//            ),
-//            baseId = "appJFzRzW8GmaKuz3",
-//            tableId = "tblbiZLh6qn3k7wdt",
-//            viewId = "",
-//            webhookId = "achpY1AcPW93B9ucr",
-//            webhookSecret = System.getenv("AIRTABLE_WEBHOOK_SECRET")
-//        ),
- //   )
 
 
     fun getTableProvider(tableId: String): TableProvider {

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -21,6 +21,23 @@ airTable:
     webhookId: "$DRIFTSKONTINUITET_WEBHOOK_ID:"
     webhookSecret: "$DRIFTSKONTINUITET_WEBHOOK_SECRET:"
 
+tables:
+- id: "570e9285-3228-4396-b82b-e9752e23cd73"
+  type : "AIRTABLE"
+  accessToken: $AIRTABLE_ACCESS_TOKEN
+  baseId: "appzJQ8Tkmm8DobrJ"
+  tableId: "tblLZbUqA0XnUgC2v"
+  viewId: "viw2XliGUJu5448Hk"
+  webhookId: "$SIKKERHETSKONTROLLER_WEBHOOK_ID:"
+  webhookSecret: "$SIKKERHETSKONTROLLER_WEBHOOK_SECRET:"
+- id: "816cc808-9188-44a9-8f4b-5642fc2932c4"
+  type: "AIRTABLE"
+  accessToken: $AIRTABLE_ACCESS_TOKEN
+  baseId: "appsIiBWlCCSsMmRB"
+  tableId: "tbl4pNqNp2wLyI6iv"
+  webhookId: "$DRIFTSKONTINUITET_WEBHOOK_ID:"
+  webhookSecret: "$DRIFTSKONTINUITET_WEBHOOK_SECRET:"
+
 microsoftGraph:
   baseUrl: "https://graph.microsoft.com"
   memberOfPath: "/v1.0/me/memberOf/microsoft.graph.group"


### PR DESCRIPTION

## Background

Ønske om å kunne konfigurere opp tables

## Solution

Tables i `application.yaml` har en liste `tables` som `Application.kt` iterer igjennom og gjør om til en liste med `AirTableInstanceConfig` og `YAMLInstanceConfig`. Så iterer `TableService.kt` igjennom tables.tables for å opprette providers. 


Resolves [547](https://github.com/orgs/kartverket/projects/16/views/1?pane=issue&itemId=90652606&issue=kartverket%7Cregelrett%7C547)
