### PR TITLE
588 rename tables til form

### DIFF
--- a/backend/src/main/kotlin/no/bekk/Application.kt
+++ b/backend/src/main/kotlin/no/bekk/Application.kt
@@ -1,5 +1,6 @@
 package no.bekk
 
+import io.ktor.client.*
 import no.bekk.plugins.*
 import io.ktor.server.application.*
 import io.ktor.server.plugins.contentnegotiation.*
@@ -22,9 +23,10 @@ private fun loadAppConfig(config: ApplicationConfig) {
         }
 
         tables = config.configList("tables").map { table ->
-            TableInstance(
+
+            when (table.propertyOrNull("type")?.getString()) {
+                "AIRTABLE" -> AirTableInstanceConfig(
                 id = table.propertyOrNull("id")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"id\""),
-                type = table.propertyOrNull("type")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"type\""),
                 accessToken = table.propertyOrNull("accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"accessToken\""),
                 baseId = table.propertyOrNull("baseId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"baseId\""),
                 tableId = table.propertyOrNull("tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"tableId\""),
@@ -32,28 +34,16 @@ private fun loadAppConfig(config: ApplicationConfig) {
                 webhookId = table.propertyOrNull("webhookId")?.getString(),
                 webhookSecret = table.propertyOrNull("webhookSecret")?.getString(),
             )
+                "YAML" -> YAMLInstanceConfig(
+                    id = table.propertyOrNull("id")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"id\""),
+                    endpoint = table.propertyOrNull("endpoint")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"baseId\""),
+                    resourcePath = table.propertyOrNull("resourcePath")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"tableId\""),
+                )
+                else -> throw IllegalStateException("Illegal type \"type\"")
+
+            }
+
         }
-
-
-
-
-//        sikkerhetskontroller = AirTableInstanceConfig(
-//            accessToken = config.propertyOrNull("airTable.sikkerhetskontroller.accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.accessToken\""),
-//            baseId = config.propertyOrNull("airTable.sikkerhetskontroller.baseId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.baseId\""),
-//            tableId = config.propertyOrNull("airTable.sikkerhetskontroller.tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.tableId\""),
-//            viewId = config.propertyOrNull("airTable.sikkerhetskontroller.viewId")?.getString(),
-//            webhookId = config.propertyOrNull("airTable.sikkerhetskontroller.webhookId")?.getString(),
-//            webhookSecret = config.propertyOrNull("airTable.sikkerhetskontroller.webhookSecret")?.getString(),
-//
-//        )
-//        driftskontinuitet = AirTableInstanceConfig(
-//            accessToken = config.propertyOrNull("airTable.driftskontinuitet.accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.accessToken\""),
-//            baseId = config.propertyOrNull("airTable.driftskontinuitet.baseId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.baseId\""),
-//            tableId = config.propertyOrNull("airTable.driftskontinuitet.tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.tableId\""),
-//            viewId = config.propertyOrNull("airTable.driftskontinuitet.viewId")?.getString(),
-//            webhookId = config.propertyOrNull("airTable.driftskontinuitet.webhookId")?.getString(),
-//            webhookSecret = config.propertyOrNull("airTable.driftskontinuitet.webhookSecret")?.getString(),
-//        )
     }
 
     // MicrosoftGraph config

--- a/backend/src/main/kotlin/no/bekk/Application.kt
+++ b/backend/src/main/kotlin/no/bekk/Application.kt
@@ -21,7 +21,7 @@ private fun loadAppConfig(config: ApplicationConfig) {
             baseUrl = config.propertyOrNull("airTable.baseUrl")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.baseUrl\"")
         }
 
-        forms = config.configList("tables").map { table ->
+        forms = config.configList("forms").map { table ->
 
             when (table.propertyOrNull("type")?.getString()) {
                 "AIRTABLE" -> AirTableInstanceConfig(

--- a/backend/src/main/kotlin/no/bekk/Application.kt
+++ b/backend/src/main/kotlin/no/bekk/Application.kt
@@ -1,6 +1,5 @@
 package no.bekk
 
-import io.ktor.client.*
 import no.bekk.plugins.*
 import io.ktor.server.application.*
 import io.ktor.server.plugins.contentnegotiation.*
@@ -17,12 +16,12 @@ fun main(args: Array<String>) {
 
 private fun loadAppConfig(config: ApplicationConfig) {
 
-    AppConfig.tables = TableConfig.apply {
+    AppConfig.formConfig = FormConfig.apply {
         airTable = AirTableConfig.apply {
             baseUrl = config.propertyOrNull("airTable.baseUrl")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.baseUrl\"")
         }
 
-        tables = config.configList("tables").map { table ->
+        forms = config.configList("tables").map { table ->
 
             when (table.propertyOrNull("type")?.getString()) {
                 "AIRTABLE" -> AirTableInstanceConfig(

--- a/backend/src/main/kotlin/no/bekk/Application.kt
+++ b/backend/src/main/kotlin/no/bekk/Application.kt
@@ -20,23 +20,40 @@ private fun loadAppConfig(config: ApplicationConfig) {
         airTable = AirTableConfig.apply {
             baseUrl = config.propertyOrNull("airTable.baseUrl")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.baseUrl\"")
         }
-        sikkerhetskontroller = AirTableInstanceConfig(
-            accessToken = config.propertyOrNull("airTable.sikkerhetskontroller.accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.accessToken\""),
-            baseId = config.propertyOrNull("airTable.sikkerhetskontroller.baseId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.baseId\""),
-            tableId = config.propertyOrNull("airTable.sikkerhetskontroller.tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.tableId\""),
-            viewId = config.propertyOrNull("airTable.sikkerhetskontroller.viewId")?.getString(),
-            webhookId = config.propertyOrNull("airTable.sikkerhetskontroller.webhookId")?.getString(),
-            webhookSecret = config.propertyOrNull("airTable.sikkerhetskontroller.webhookSecret")?.getString(),
 
-        )
-        driftskontinuitet = AirTableInstanceConfig(
-            accessToken = config.propertyOrNull("airTable.driftskontinuitet.accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.accessToken\""),
-            baseId = config.propertyOrNull("airTable.driftskontinuitet.baseId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.baseId\""),
-            tableId = config.propertyOrNull("airTable.driftskontinuitet.tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.tableId\""),
-            viewId = config.propertyOrNull("airTable.driftskontinuitet.viewId")?.getString(),
-            webhookId = config.propertyOrNull("airTable.driftskontinuitet.webhookId")?.getString(),
-            webhookSecret = config.propertyOrNull("airTable.driftskontinuitet.webhookSecret")?.getString(),
-        )
+        tables = config.configList("tables").map { table ->
+            TableInstance(
+                id = table.propertyOrNull("id")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"id\""),
+                type = table.propertyOrNull("type")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"type\""),
+                accessToken = table.propertyOrNull("accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"accessToken\""),
+                baseId = table.propertyOrNull("baseId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"baseId\""),
+                tableId = table.propertyOrNull("tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"tableId\""),
+                viewId = table.propertyOrNull("viewId")?.getString(),
+                webhookId = table.propertyOrNull("webhookId")?.getString(),
+                webhookSecret = table.propertyOrNull("webhookSecret")?.getString(),
+            )
+        }
+
+
+
+
+//        sikkerhetskontroller = AirTableInstanceConfig(
+//            accessToken = config.propertyOrNull("airTable.sikkerhetskontroller.accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.accessToken\""),
+//            baseId = config.propertyOrNull("airTable.sikkerhetskontroller.baseId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.baseId\""),
+//            tableId = config.propertyOrNull("airTable.sikkerhetskontroller.tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.sikkerhetskontroller.tableId\""),
+//            viewId = config.propertyOrNull("airTable.sikkerhetskontroller.viewId")?.getString(),
+//            webhookId = config.propertyOrNull("airTable.sikkerhetskontroller.webhookId")?.getString(),
+//            webhookSecret = config.propertyOrNull("airTable.sikkerhetskontroller.webhookSecret")?.getString(),
+//
+//        )
+//        driftskontinuitet = AirTableInstanceConfig(
+//            accessToken = config.propertyOrNull("airTable.driftskontinuitet.accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.accessToken\""),
+//            baseId = config.propertyOrNull("airTable.driftskontinuitet.baseId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.baseId\""),
+//            tableId = config.propertyOrNull("airTable.driftskontinuitet.tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.driftskontinuitet.tableId\""),
+//            viewId = config.propertyOrNull("airTable.driftskontinuitet.viewId")?.getString(),
+//            webhookId = config.propertyOrNull("airTable.driftskontinuitet.webhookId")?.getString(),
+//            webhookSecret = config.propertyOrNull("airTable.driftskontinuitet.webhookSecret")?.getString(),
+//        )
     }
 
     // MicrosoftGraph config

--- a/backend/src/main/kotlin/no/bekk/authentication/Authentication.kt
+++ b/backend/src/main/kotlin/no/bekk/authentication/Authentication.kt
@@ -15,9 +15,9 @@ import java.net.URI
 import java.util.concurrent.TimeUnit
 
 fun Application.initializeAuthentication() {
-    val issuer = AppConfig.oAuth.getIssuer()
+    val issuer = getIssuer()
     val clientId = AppConfig.oAuth.clientId
-    val jwksUri = AppConfig.oAuth.getJwksUrl()
+    val jwksUri = getJwksUrl()
 
     val jwkProvider = JwkProviderBuilder(URI(jwksUri).toURL())
         .cached(10, 24, TimeUnit.HOURS)

--- a/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
+++ b/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
@@ -59,6 +59,11 @@ object OAuthConfig {
     lateinit var superUserMail: String
 }
 
+fun getIssuer() = AppConfig.oAuth.baseUrl + "/" + AppConfig.oAuth.tenantId + AppConfig.oAuth.issuerPath
+fun getTokenUrl() = AppConfig.oAuth.baseUrl + "/" + AppConfig.oAuth.tenantId + AppConfig.oAuth.tokenPath
+fun getJwksUrl() = AppConfig.oAuth.baseUrl + "/" + AppConfig.oAuth.tenantId + AppConfig.oAuth.jwksPath
+
+
 object FrontendConfig {
     lateinit var host: String
 }

--- a/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
+++ b/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
@@ -1,5 +1,7 @@
 package no.bekk.configuration
 
+import io.ktor.client.*
+
 object AppConfig {
     lateinit var tables: TableConfig
     lateinit var microsoftGraph: MicrosoftGraphConfig
@@ -12,34 +14,33 @@ object AppConfig {
 object TableConfig {
     lateinit var airTable: AirTableConfig
     lateinit var tables: List<TableInstance>
-    //lateinit var sikkerhetskontroller: AirTableInstanceConfig
-    //lateinit var driftskontinuitet: AirTableInstanceConfig
 }
 
 object AirTableConfig {
     lateinit var baseUrl: String
 }
 
-
-data class TableInstance (
-    val id: String,
-    val type: String,
-    val accessToken: String,
-    val baseId: String,
-    val tableId: String,
-    var viewId: String? = null,
-    var webhookId: String? = null,
-    var webhookSecret: String? = null,
-)
+interface TableInstance {
+    val id: String
+}
 
 data class AirTableInstanceConfig (
+    override val id: String,
     val accessToken: String,
     val baseId: String,
     val tableId: String,
     var viewId: String? = null,
     var webhookId: String? = null,
     var webhookSecret: String? = null,
-)
+) : TableInstance
+
+data class YAMLInstanceConfig (
+    override val id: String,
+    val endpoint: String? = null,
+    val resourcePath: String? = null
+) : TableInstance
+
+
 
 object MicrosoftGraphConfig {
     lateinit var baseUrl: String

--- a/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
+++ b/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
@@ -1,9 +1,7 @@
 package no.bekk.configuration
 
-import io.ktor.client.*
-
 object AppConfig {
-    lateinit var tables: TableConfig
+    lateinit var formConfig: FormConfig
     lateinit var microsoftGraph: MicrosoftGraphConfig
     lateinit var oAuth: OAuthConfig
     lateinit var frontend: FrontendConfig
@@ -11,16 +9,16 @@ object AppConfig {
     lateinit var db: DbConfig
 }
 
-object TableConfig {
+object FormConfig {
     lateinit var airTable: AirTableConfig
-    lateinit var tables: List<TableInstance>
+    lateinit var forms: List<FormInstances>
 }
 
 object AirTableConfig {
     lateinit var baseUrl: String
 }
 
-interface TableInstance {
+interface FormInstances {
     val id: String
 }
 
@@ -32,13 +30,13 @@ data class AirTableInstanceConfig (
     var viewId: String? = null,
     var webhookId: String? = null,
     var webhookSecret: String? = null,
-) : TableInstance
+) : FormInstances
 
 data class YAMLInstanceConfig (
     override val id: String,
     val endpoint: String? = null,
     val resourcePath: String? = null
-) : TableInstance
+) : FormInstances
 
 
 

--- a/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
+++ b/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
@@ -11,13 +11,26 @@ object AppConfig {
 
 object TableConfig {
     lateinit var airTable: AirTableConfig
-    lateinit var sikkerhetskontroller: AirTableInstanceConfig
-    lateinit var driftskontinuitet: AirTableInstanceConfig
+    lateinit var tables: List<TableInstance>
+    //lateinit var sikkerhetskontroller: AirTableInstanceConfig
+    //lateinit var driftskontinuitet: AirTableInstanceConfig
 }
 
 object AirTableConfig {
     lateinit var baseUrl: String
 }
+
+
+data class TableInstance (
+    val id: String,
+    val type: String,
+    val accessToken: String,
+    val baseId: String,
+    val tableId: String,
+    var viewId: String? = null,
+    var webhookId: String? = null,
+    var webhookSecret: String? = null,
+)
 
 data class AirTableInstanceConfig (
     val accessToken: String,

--- a/backend/src/main/kotlin/no/bekk/database/ContextRepository.kt
+++ b/backend/src/main/kotlin/no/bekk/database/ContextRepository.kt
@@ -66,7 +66,7 @@ object ContextRepository {
         }
     }
 
-    fun getContextByTeamIdAndTableId(teamId: String, formId: String): List<DatabaseContext> {
+    fun getContextByTeamIdAndFormId(teamId: String, formId: String): List<DatabaseContext> {
         val sqlStatement = "SELECT * FROM contexts WHERE team_id = ? AND table_id = ?"
 
         Database.getConnection().use { conn ->

--- a/backend/src/main/kotlin/no/bekk/database/ContextRepository.kt
+++ b/backend/src/main/kotlin/no/bekk/database/ContextRepository.kt
@@ -14,7 +14,7 @@ object ContextRepository {
             Database.getConnection().use { conn ->
                 conn.prepareStatement(sqlStatement).use { statement ->
                     statement.setString(1, context.teamId)
-                    statement.setString(2, context.tableId)
+                    statement.setString(2, context.formId)
                     statement.setString(3, context.name)
 
                     val result = statement.executeQuery()
@@ -22,7 +22,7 @@ object ContextRepository {
                         return DatabaseContext(
                             id = result.getString("id"),
                             teamId = result.getString("team_id"),
-                            tableId = result.getString("table_id"),
+                            formId = result.getString("table_id"),
                             name = result.getString("name"),
                         )
                     } else {
@@ -54,7 +54,7 @@ object ContextRepository {
                         DatabaseContext(
                             id = result.getString("id"),
                             teamId = result.getString("team_id"),
-                            tableId = result.getString("table_id"),
+                            formId = result.getString("table_id"),
                             name = result.getString("name")
                         )
                     )
@@ -80,7 +80,7 @@ object ContextRepository {
                         DatabaseContext(
                             id = result.getString("id"),
                             teamId = result.getString("team_id"),
-                            tableId = result.getString("table_id"),
+                            formId = result.getString("table_id"),
                             name = result.getString("name")
                         )
                     )
@@ -100,7 +100,7 @@ object ContextRepository {
                     return DatabaseContext(
                         id = result.getString("id"),
                         teamId = result.getString("team_id"),
-                        tableId = result.getString("table_id"),
+                        formId = result.getString("table_id"),
                         name = result.getString("name")
                     )
                 } else {

--- a/backend/src/main/kotlin/no/bekk/database/ContextRepository.kt
+++ b/backend/src/main/kotlin/no/bekk/database/ContextRepository.kt
@@ -39,6 +39,8 @@ object ContextRepository {
         }
     }
 
+
+
     fun getContextsByTeamId(teamId: String): List<DatabaseContext> {
         val sqlStatement = "SELECT * FROM contexts WHERE team_id = ?"
 
@@ -64,13 +66,13 @@ object ContextRepository {
         }
     }
 
-    fun getContextByTeamIdAndTableId(teamId: String, tableId: String): List<DatabaseContext> {
+    fun getContextByTeamIdAndTableId(teamId: String, formId: String): List<DatabaseContext> {
         val sqlStatement = "SELECT * FROM contexts WHERE team_id = ? AND table_id = ?"
 
         Database.getConnection().use { conn ->
             conn.prepareStatement(sqlStatement).use { statement ->
                 statement.setString(1, teamId)
-                statement.setString(2, tableId)
+                statement.setString(2, formId)
 
                 val result = statement.executeQuery()
                 val contexts = mutableListOf<DatabaseContext>()
@@ -81,7 +83,7 @@ object ContextRepository {
                             id = result.getString("id"),
                             teamId = result.getString("team_id"),
                             formId = result.getString("table_id"),
-                            name = result.getString("name")
+                            name = result.getString("name"),
                         )
                     )
                 }
@@ -110,6 +112,7 @@ object ContextRepository {
         }
     }
 
+    //This can be removed after schemas in frisk are migrated to new metadata
     fun getContextTableId(id: String): String {
         val sqlStatement = "SELECT table_id FROM contexts WHERE id = ?"
         Database.getConnection().use { conn ->

--- a/backend/src/main/kotlin/no/bekk/database/DatabaseContext.kt
+++ b/backend/src/main/kotlin/no/bekk/database/DatabaseContext.kt
@@ -3,14 +3,6 @@ package no.bekk.database
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class OldDatabaseContext(
-    val id: String,
-    val teamId: String,
-    val tableId: String,
-    val name: String,
-)
-
-@Serializable
 data class OldDatabaseContextRequest(
     val teamId: String,
     val tableId: String,

--- a/backend/src/main/kotlin/no/bekk/database/DatabaseContext.kt
+++ b/backend/src/main/kotlin/no/bekk/database/DatabaseContext.kt
@@ -6,14 +6,14 @@ import kotlinx.serialization.Serializable
 data class DatabaseContext(
     val id: String,
     val teamId: String,
-    val tableId: String,
+    val formId: String,
     val name: String,
 )
 
 @Serializable
 data class DatabaseContextRequest(
     val teamId: String,
-    val tableId: String,
+    val formId: String,
     val name: String,
     val copyContext: String? = null,
 )

--- a/backend/src/main/kotlin/no/bekk/database/OldDatabaseContext.kt
+++ b/backend/src/main/kotlin/no/bekk/database/OldDatabaseContext.kt
@@ -3,6 +3,23 @@ package no.bekk.database
 import kotlinx.serialization.Serializable
 
 @Serializable
+data class OldDatabaseContext(
+    val id: String,
+    val teamId: String,
+    val tableId: String,
+    val name: String,
+)
+
+@Serializable
+data class OldDatabaseContextRequest(
+    val teamId: String,
+    val tableId: String,
+    val name: String,
+    val copyContext: String? = null,
+)
+
+
+@Serializable
 data class DatabaseContext(
     val id: String,
     val teamId: String,

--- a/backend/src/main/kotlin/no/bekk/model/internal/Form.kt
+++ b/backend/src/main/kotlin/no/bekk/model/internal/Form.kt
@@ -16,14 +16,14 @@ data class Column(
 )
 
 @Serializable
-data class TableWithoutId(
+data class FormWithoutId(
     val name: String,
     val columns: List<Column>,
     val records: List<Question>,
 )
 
 @Serializable
-data class Table(
+data class Form(
     val id: String,
     val name: String,
     val columns: List<Column>,

--- a/backend/src/main/kotlin/no/bekk/plugins/Routing.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/Routing.kt
@@ -43,7 +43,7 @@ fun Application.configureRouting() {
             commentRouting()
             contextRouting()
             questionRouting()
-            tableRouting()
+            formRouting()
             userInfoRouting()
             uploadCSVRouting()
         }

--- a/backend/src/main/kotlin/no/bekk/plugins/Routing.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/Routing.kt
@@ -8,7 +8,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.bekk.database.ContextRepository
 import no.bekk.routes.*
-import no.bekk.services.TableService
+import no.bekk.services.FormService
 import no.bekk.util.logger
 
 fun Application.configureRouting() {
@@ -23,7 +23,7 @@ fun Application.configureRouting() {
         }
 
         get("/schemas") {
-            val schemas = TableService.getTableProviders().map {
+            val schemas = FormService.getTableProviders().map {
                 it.getSchema()
             }
             call.respond(schemas)

--- a/backend/src/main/kotlin/no/bekk/plugins/Routing.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/Routing.kt
@@ -23,7 +23,7 @@ fun Application.configureRouting() {
         }
 
         get("/schemas") {
-            val schemas = FormService.getTableProviders().map {
+            val schemas = FormService.getFormProviders().map {
                 it.getSchema()
             }
             call.respond(schemas)

--- a/backend/src/main/kotlin/no/bekk/providers/AirTableProvider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/AirTableProvider.kt
@@ -33,7 +33,7 @@ class AirTableProvider(
             .build()
     }
 
-    private val tableCache: Cache<String, Table> = createCache()
+    private val tableCache: Cache<String, Form> = createCache()
     private val questionCache: Cache<String, Question> = createCache()
     private val columnCache: Cache<String, List<Column>> = createCache()
 
@@ -44,7 +44,7 @@ class AirTableProvider(
     private val SVARENHET = "Svarenhet"
     private val SVARVARIGHET = "Svarvarighet"
 
-    override suspend fun getForm(): Table {
+    override suspend fun getForm(): Form {
         val cachedTable = tableCache.getIfPresent(id)
         if (cachedTable != null) {
             logger.info("Successfully retrieved table: $tableId from cache")
@@ -97,7 +97,7 @@ class AirTableProvider(
         return freshColumns
     }
 
-    private suspend fun getTableFromAirTable(): Table {
+    private suspend fun getTableFromAirTable(): Form {
         val allRecords = fetchAllRecordsFromTable()
         val airTableMetadata = fetchMetadataFromBase()
 
@@ -154,7 +154,7 @@ class AirTableProvider(
             refreshWebhook()
         }
 
-        return Table(
+        return Form(
             id = id,
             name = airtableClient.getBases().bases.find { it.id == baseId }?.name ?: tableMetadata.name,
             columns = columns,

--- a/backend/src/main/kotlin/no/bekk/providers/AirTableProvider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/AirTableProvider.kt
@@ -24,7 +24,7 @@ class AirTableProvider(
     val webhookSecret: String? = null,
     val webhookId: String? = null,
 
-) : TableProvider {
+) : FormProvider {
 
     private fun <K, V> createCache(): Cache<K, V> {
         val expirationDuration = if (webhookId != null) (24L * 6) else 1L
@@ -44,7 +44,7 @@ class AirTableProvider(
     private val SVARENHET = "Svarenhet"
     private val SVARVARIGHET = "Svarvarighet"
 
-    override suspend fun getTable(): Table {
+    override suspend fun getForm(): Table {
         val cachedTable = tableCache.getIfPresent(id)
         if (cachedTable != null) {
             logger.info("Successfully retrieved table: $tableId from cache")

--- a/backend/src/main/kotlin/no/bekk/providers/FormProvider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/FormProvider.kt
@@ -4,7 +4,7 @@ import no.bekk.model.internal.*
 
 interface FormProvider {
     val id: String
-    suspend fun getForm(): Table
+    suspend fun getForm(): Form
     suspend fun getQuestion(recordId: String): Question
     suspend fun getColumns(): List<Column>
     suspend fun getSchema(): Schema

--- a/backend/src/main/kotlin/no/bekk/providers/FormProvider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/FormProvider.kt
@@ -2,9 +2,9 @@ package no.bekk.providers
 
 import no.bekk.model.internal.*
 
-interface TableProvider {
+interface FormProvider {
     val id: String
-    suspend fun getTable(): Table
+    suspend fun getForm(): Table
     suspend fun getQuestion(recordId: String): Question
     suspend fun getColumns(): List<Column>
     suspend fun getSchema(): Schema

--- a/backend/src/main/kotlin/no/bekk/providers/YamlProvider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/YamlProvider.kt
@@ -12,7 +12,7 @@ class YamlProvider(
     private val httpClient: HttpClient? = null,
     private val endpoint: String? = null,
     private val resourcePath: String? = null
-) : TableProvider {
+) : FormProvider {
 
     init {
         require((endpoint != null && httpClient != null) || resourcePath != null) {
@@ -20,7 +20,7 @@ class YamlProvider(
         }
     }
 
-    override suspend fun getTable(): Table {
+    override suspend fun getForm(): Table {
         if (endpoint != null) {
             return getTableFromYamlEndpoint()
         } else {

--- a/backend/src/main/kotlin/no/bekk/providers/YamlProvider.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/YamlProvider.kt
@@ -20,74 +20,74 @@ class YamlProvider(
         }
     }
 
-    override suspend fun getForm(): Table {
+    override suspend fun getForm(): Form {
         if (endpoint != null) {
-            return getTableFromYamlEndpoint()
+            return getFormFromYamlEndpoint()
         } else {
-            return getTableFromResourcePath()
+            return getFormFromResourcePath()
         }
     }
 
     override suspend fun getSchema(): Schema {
         if (endpoint != null) {
-            val table = getTableFromYamlEndpoint()
+            val form = getFormFromYamlEndpoint()
             return Schema(
-                id = table.id,
-                name = table.name,
+                id = form.id,
+                name = form.name,
             )
         } else {
-            val table = getTableFromResourcePath()
+            val form = getFormFromResourcePath()
             return Schema(
-                id = table.id,
-                name = table.name,
+                id = form.id,
+                name = form.name,
             )
         }
     }
 
     override suspend fun getColumns(): List<Column> {
         if (endpoint != null) {
-            return getTableFromYamlEndpoint().columns
+            return getFormFromYamlEndpoint().columns
         } else {
-            return getTableFromResourcePath().columns
+            return getFormFromResourcePath().columns
         }
     }
 
     override suspend fun getQuestion(recordId: String): Question {
         if (endpoint != null) {
-            return getTableFromYamlEndpoint().records.find { it.id == recordId } ?: run {
+            return getFormFromYamlEndpoint().records.find { it.id == recordId } ?: run {
                 throw NotFoundException("Question $recordId not found")
             }
 
         } else {
-            return getTableFromResourcePath().records.find { it.id == recordId } ?: run {
+            return getFormFromResourcePath().records.find { it.id == recordId } ?: run {
                 throw NotFoundException("Question $recordId not found")
             }
         }
     }
 
-    private suspend fun getTableFromYamlEndpoint(): Table {
+    private suspend fun getFormFromYamlEndpoint(): Form {
         require(endpoint != null && httpClient != null) { "endpoint and httpClient must not be null" }
         val response = httpClient.get(endpoint)
         val responseBody = response.bodyAsText()
-        return parseAndConvertToTable(responseBody)
+        return parseAndConvertToForm(responseBody)
     }
 
-    private fun getTableFromResourcePath(): Table {
+    private fun getFormFromResourcePath(): Form {
         require(resourcePath != null) { "Resource path not set" }
         val body = this::class.java.classLoader.getResource(resourcePath)?.readText()
             ?: throw NotFoundException("Resource not found: $resourcePath")
-        return parseAndConvertToTable(body)
+        return parseAndConvertToForm(body)
 
     }
 
-    private fun parseAndConvertToTable(yamlString: String): Table {
-        val table = Yaml.decodeFromString(TableWithoutId.serializer(), yamlString)
+    private fun parseAndConvertToForm(yamlString: String): Form {
+        val form = Yaml.decodeFromString(FormWithoutId.serializer(), yamlString)
 
-        return Table(
+        return Form(
             id = id,
-            name = table.name,
-            columns = table.columns,
-            records = table.records.map {
+            name = form.name,
+            columns = form.columns,
+            records = form.records.map {
                 Question(
                     id = it.id,
                     recordId = it.id,   // need to set recordId since all endpoints require it as of now

--- a/backend/src/main/kotlin/no/bekk/providers/clients/AirTableClient.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/clients/AirTableClient.kt
@@ -41,20 +41,20 @@ class AirTableClient(private val accessToken: String) {
     }
 
     suspend fun getBases(): AirTableBasesResponse {
-        val response = client.get(AppConfig.tables.airTable.baseUrl + "/v0/meta/bases")
+        val response = client.get(AppConfig.formConfig.airTable.baseUrl + "/v0/meta/bases")
         val responseBody = response.bodyAsText()
         return json.decodeFromString<AirTableBasesResponse>(responseBody)
     }
 
     suspend fun getBaseSchema(baseId: String): MetadataResponse {
-        val response = client.get(AppConfig.tables.airTable.baseUrl + "/v0/meta/bases/$baseId/tables")
+        val response = client.get(AppConfig.formConfig.airTable.baseUrl + "/v0/meta/bases/$baseId/tables")
         val responseBody = response.bodyAsText()
         return json.decodeFromString<MetadataResponse>(responseBody)
     }
 
     suspend fun getRecords(baseId: String, tableId: String, viewId: String? = null, offset: String? = null): AirtableResponse {
         val url = buildString {
-            append(AppConfig.tables.airTable.baseUrl)
+            append(AppConfig.formConfig.airTable.baseUrl)
             append("/v0/$baseId/$tableId")
             if (viewId != null) {
                 append("?view=$viewId")
@@ -72,13 +72,13 @@ class AirTableClient(private val accessToken: String) {
     }
 
     suspend fun getRecord(baseId: String, tableId: String, recordId: String): Record {
-        val response = client.get(AppConfig.tables.airTable.baseUrl + "/v0/$baseId/$tableId/$recordId")
+        val response = client.get(AppConfig.formConfig.airTable.baseUrl + "/v0/$baseId/$tableId/$recordId")
         val responseBody = response.bodyAsText()
         return json.decodeFromString<Record>(responseBody)
     }
 
     suspend fun refreshWebhook(baseId: String, webhookId: String): Int {
-        val url = "${AppConfig.tables.airTable.baseUrl}/v0/bases/$baseId/webhooks/$webhookId/refresh"
+        val url = "${AppConfig.formConfig.airTable.baseUrl}/v0/bases/$baseId/webhooks/$webhookId/refresh"
         val response: HttpResponse = client.post(url) {
             header("Authorization", "Bearer $accessToken")
         }

--- a/backend/src/main/kotlin/no/bekk/routes/AirTableWebhookRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/AirTableWebhookRouting.kt
@@ -69,7 +69,7 @@ fun Route.airTableWebhookRouting() {
 }
 
 private fun getAirTableProviderByWebhookId(webhookId: String): AirTableProvider? =
-    FormService.getTableProviders().filterIsInstance<AirTableProvider>().find { it.webhookId == webhookId }
+    FormService.getFormProviders().filterIsInstance<AirTableProvider>().find { it.webhookId == webhookId }
 
 
 private fun validateSignature(incomingSignature: String?, requestBody: String) {

--- a/backend/src/main/kotlin/no/bekk/routes/AirTableWebhookRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/AirTableWebhookRouting.kt
@@ -7,7 +7,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
 import no.bekk.providers.AirTableProvider
-import no.bekk.services.TableService
+import no.bekk.services.FormService
 import no.bekk.util.logger
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
@@ -69,7 +69,7 @@ fun Route.airTableWebhookRouting() {
 }
 
 private fun getAirTableProviderByWebhookId(webhookId: String): AirTableProvider? =
-    TableService.getTableProviders().filterIsInstance<AirTableProvider>().find { it.webhookId == webhookId }
+    FormService.getTableProviders().filterIsInstance<AirTableProvider>().find { it.webhookId == webhookId }
 
 
 private fun validateSignature(incomingSignature: String?, requestBody: String) {

--- a/backend/src/main/kotlin/no/bekk/routes/ContextRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/ContextRouting.kt
@@ -79,7 +79,7 @@ fun Route.contextRouting() {
             }
 
             if (formId != null) {
-                val context = ContextRepository.getContextByTeamIdAndTableId(teamId, formId)
+                val context = ContextRepository.getContextByTeamIdAndFormId(teamId, formId)
                 call.respond(HttpStatusCode.OK, Json.encodeToString(context))
                 return@get
             } else {

--- a/backend/src/main/kotlin/no/bekk/routes/ContextRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/ContextRouting.kt
@@ -58,14 +58,14 @@ fun Route.contextRouting() {
 
         get {
             val teamId = call.request.queryParameters["teamId"] ?: throw BadRequestException("Missing teamId parameter")
-            val tableId = call.request.queryParameters["tableId"]
+            val formId = call.request.queryParameters["formId"]
             if (!hasTeamAccess(call, teamId)) {
                 call.respond(HttpStatusCode.Forbidden)
                 return@get
             }
 
-            if (tableId != null) {
-                val context = ContextRepository.getContextByTeamIdAndTableId(teamId, tableId)
+            if (formId != null) {
+                val context = ContextRepository.getContextByTeamIdAndTableId(teamId, formId)
                 call.respond(HttpStatusCode.OK, Json.encodeToString(context))
                 return@get
             } else {

--- a/backend/src/main/kotlin/no/bekk/routes/FormRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/FormRouting.kt
@@ -7,7 +7,7 @@ import io.ktor.server.routing.*
 import no.bekk.services.FormService
 import no.bekk.util.logger
 
-fun Route.tableRouting() {
+fun Route.formRouting() {
     route("/forms") {
         get {
             val tables = FormService.getFormProviders().map {

--- a/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
@@ -10,7 +10,7 @@ import no.bekk.util.logger
 fun Route.tableRouting() {
     route("/tables") {
         get {
-            val tables = FormService.getTableProviders().map {
+            val tables = FormService.getFormProviders().map {
                 it.getForm()
             }
             call.respond(tables)
@@ -24,7 +24,7 @@ fun Route.tableRouting() {
             }
 
             try {
-                val table = FormService.getTableProvider(tableId).getForm()
+                val table = FormService.getFormProvider(tableId).getForm()
                 call.respond(table)
             } catch (e: IllegalArgumentException) {
                 logger.error("Error occurred while retrieving table for tableId: $tableId", e)
@@ -40,7 +40,7 @@ fun Route.tableRouting() {
                 return@get
             }
             try {
-                val question = FormService.getTableProvider(tableId).getQuestion(recordId)
+                val question = FormService.getFormProvider(tableId).getQuestion(recordId)
                 logger.info("Successfully retrieved question: $question")
                 call.respond(question)
             } catch (e: NotFoundException) {
@@ -59,7 +59,7 @@ fun Route.tableRouting() {
                 return@get
             }
             try {
-                val columns = FormService.getTableProvider(tableId).getColumns()
+                val columns = FormService.getFormProvider(tableId).getColumns()
                 logger.info("Successfully retrieved columns: $columns")
                 call.respond(columns)
             } catch (e: Exception) {

--- a/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
@@ -8,39 +8,39 @@ import no.bekk.services.FormService
 import no.bekk.util.logger
 
 fun Route.tableRouting() {
-    route("/tables") {
+    route("/forms") {
         get {
             val tables = FormService.getFormProviders().map {
                 it.getForm()
             }
             call.respond(tables)
         }
-        get("/{tableId}") {
-            val tableId = call.parameters["tableId"]
-            if (tableId == null) {
+        get("/{formId}") {
+            val formId = call.parameters["formId"]
+            if (formId == null) {
                 logger.warn("Request missing tableId")
-                call.respond(HttpStatusCode.BadRequest,"TableId is missing")
+                call.respond(HttpStatusCode.BadRequest,"FormId is missing")
                 return@get
             }
 
             try {
-                val table = FormService.getFormProvider(tableId).getForm()
+                val table = FormService.getFormProvider(formId).getForm()
                 call.respond(table)
             } catch (e: IllegalArgumentException) {
-                logger.error("Error occurred while retrieving table for tableId: $tableId", e)
+                logger.error("Error occurred while retrieving table for formId: $formId", e)
                 call.respond(HttpStatusCode.InternalServerError, "An error occured: ${e.message}")
             }
         }
-        get("/{tableId}/{recordId}") {
-            val tableId = call.parameters["tableId"]
+        get("/{formId}/{recordId}") {
+            val formId = call.parameters["formId"]
             val recordId = call.parameters["recordId"]
-            if (tableId == null || recordId == null) {
+            if (formId == null || recordId == null) {
                 logger.warn("Request missing tableId or recordId")
-                call.respond(HttpStatusCode.BadRequest,"TableId is missing")
+                call.respond(HttpStatusCode.BadRequest,"FormId is missing")
                 return@get
             }
             try {
-                val question = FormService.getFormProvider(tableId).getQuestion(recordId)
+                val question = FormService.getFormProvider(formId).getQuestion(recordId)
                 logger.info("Successfully retrieved question: $question")
                 call.respond(question)
             } catch (e: NotFoundException) {
@@ -51,19 +51,19 @@ fun Route.tableRouting() {
                 call.respond(HttpStatusCode.InternalServerError, "An error occured: ${e.message}")
             }
         }
-        get("/{tableId}/columns") {
-            val tableId = call.parameters["tableId"]
-            if (tableId == null) {
-                logger.warn("Request missing tableId")
-                call.respond(HttpStatusCode.BadRequest,"TableId is missing")
+        get("/{formId}/columns") {
+            val formId = call.parameters["formId"]
+            if (formId == null) {
+                logger.warn("Request missing FormId")
+                call.respond(HttpStatusCode.BadRequest,"FormId is missing")
                 return@get
             }
             try {
-                val columns = FormService.getFormProvider(tableId).getColumns()
+                val columns = FormService.getFormProvider(formId).getColumns()
                 logger.info("Successfully retrieved columns: $columns")
                 call.respond(columns)
             } catch (e: Exception) {
-                logger.error("Error occurred while retrieving columns from table: $tableId", e)
+                logger.error("Error occurred while retrieving columns from form: $formId", e)
                 call.respond(HttpStatusCode.InternalServerError, "An error occured: ${e.message}")
             }
         }

--- a/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
@@ -11,7 +11,7 @@ fun Route.tableRouting() {
     route("/tables") {
         get {
             val tables = TableService.getTableProviders().map {
-                it.getTable()
+                it.getForm()
             }
             call.respond(tables)
         }
@@ -24,7 +24,7 @@ fun Route.tableRouting() {
             }
 
             try {
-                val table = TableService.getTableProvider(tableId).getTable()
+                val table = TableService.getTableProvider(tableId).getForm()
                 call.respond(table)
             } catch (e: IllegalArgumentException) {
                 logger.error("Error occurred while retrieving table for tableId: $tableId", e)

--- a/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/TableRouting.kt
@@ -4,13 +4,13 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import no.bekk.services.TableService
+import no.bekk.services.FormService
 import no.bekk.util.logger
 
 fun Route.tableRouting() {
     route("/tables") {
         get {
-            val tables = TableService.getTableProviders().map {
+            val tables = FormService.getTableProviders().map {
                 it.getForm()
             }
             call.respond(tables)
@@ -24,7 +24,7 @@ fun Route.tableRouting() {
             }
 
             try {
-                val table = TableService.getTableProvider(tableId).getForm()
+                val table = FormService.getTableProvider(tableId).getForm()
                 call.respond(table)
             } catch (e: IllegalArgumentException) {
                 logger.error("Error occurred while retrieving table for tableId: $tableId", e)
@@ -40,7 +40,7 @@ fun Route.tableRouting() {
                 return@get
             }
             try {
-                val question = TableService.getTableProvider(tableId).getQuestion(recordId)
+                val question = FormService.getTableProvider(tableId).getQuestion(recordId)
                 logger.info("Successfully retrieved question: $question")
                 call.respond(question)
             } catch (e: NotFoundException) {
@@ -59,7 +59,7 @@ fun Route.tableRouting() {
                 return@get
             }
             try {
-                val columns = TableService.getTableProvider(tableId).getColumns()
+                val columns = FormService.getTableProvider(tableId).getColumns()
                 logger.info("Successfully retrieved columns: $columns")
                 call.respond(columns)
             } catch (e: Exception) {

--- a/backend/src/main/kotlin/no/bekk/services/FormService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/FormService.kt
@@ -8,7 +8,7 @@ import no.bekk.providers.FormProvider
 import no.bekk.providers.YamlProvider
 import no.bekk.providers.clients.AirTableClient
 
-object TableService {
+object FormService {
 
 
   private val providers: List<FormProvider> = AppConfig.formConfig.forms.map { table ->

--- a/backend/src/main/kotlin/no/bekk/services/FormService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/FormService.kt
@@ -11,23 +11,23 @@ import no.bekk.providers.clients.AirTableClient
 object FormService {
 
 
-  private val providers: List<FormProvider> = AppConfig.formConfig.forms.map { table ->
-        when (table) {
+  private val providers: List<FormProvider> = AppConfig.formConfig.forms.map { form ->
+        when (form) {
             is AirTableInstanceConfig -> AirTableProvider(
-                id = table.id,
+                id = form.id,
                 airtableClient = AirTableClient(
-                    table.accessToken
+                    form.accessToken
                 ),
-                baseId = table.baseId,
-                tableId =   table.tableId,
-                viewId = table.viewId,
-                webhookId = table.webhookId,
-                webhookSecret = table.webhookSecret,
+                baseId = form.baseId,
+                tableId =   form.tableId,
+                viewId = form.viewId,
+                webhookId = form.webhookId,
+                webhookSecret = form.webhookSecret,
             )
             is YAMLInstanceConfig -> YamlProvider(
-                id = table.id,
-                endpoint = table.endpoint,
-                resourcePath =   table.resourcePath,
+                id = form.id,
+                endpoint = form.endpoint,
+                resourcePath =   form.resourcePath,
             )
             else ->  throw Exception("Valid tabletype not found")
 
@@ -35,11 +35,11 @@ object FormService {
     }
 
 
-    fun getTableProvider(tableId: String): FormProvider {
-        return providers.find { it.id == tableId } ?: throw Exception("Table $tableId not found")
+    fun getFormProvider(formId: String): FormProvider {
+        return providers.find { it.id == formId } ?: throw Exception("Table $formId not found")
     }
 
-    fun getTableProviders(): List<FormProvider> {
+    fun getFormProviders(): List<FormProvider> {
         return providers
     }
 }

--- a/backend/src/main/kotlin/no/bekk/services/MicrosoftService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/MicrosoftService.kt
@@ -23,7 +23,7 @@ object MicrosoftService {
 
     suspend fun requestTokenOnBehalfOf(jwtToken: String?): String {
         val response: HttpResponse = jwtToken?.let {
-            client.post(AppConfig.oAuth.getTokenUrl()) {
+            client.post(getTokenUrl()) {
                 contentType(ContentType.Application.FormUrlEncoded)
                 setBody(
                     FormDataContent(

--- a/backend/src/main/kotlin/no/bekk/services/TableService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/TableService.kt
@@ -4,14 +4,14 @@ import no.bekk.configuration.AirTableInstanceConfig
 import no.bekk.configuration.AppConfig
 import no.bekk.configuration.YAMLInstanceConfig
 import no.bekk.providers.AirTableProvider
-import no.bekk.providers.TableProvider
+import no.bekk.providers.FormProvider
 import no.bekk.providers.YamlProvider
 import no.bekk.providers.clients.AirTableClient
 
 object TableService {
 
 
-  private val providers: List<TableProvider> = AppConfig.formConfig.forms.map { table ->
+  private val providers: List<FormProvider> = AppConfig.formConfig.forms.map { table ->
         when (table) {
             is AirTableInstanceConfig -> AirTableProvider(
                 id = table.id,
@@ -35,11 +35,11 @@ object TableService {
     }
 
 
-    fun getTableProvider(tableId: String): TableProvider {
+    fun getTableProvider(tableId: String): FormProvider {
         return providers.find { it.id == tableId } ?: throw Exception("Table $tableId not found")
     }
 
-    fun getTableProviders(): List<TableProvider> {
+    fun getTableProviders(): List<FormProvider> {
         return providers
     }
 }

--- a/backend/src/main/kotlin/no/bekk/services/TableService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/TableService.kt
@@ -6,29 +6,50 @@ import no.bekk.providers.TableProvider
 import no.bekk.providers.clients.AirTableClient
 
 object TableService {
-    private val providers: List<TableProvider> = listOf<TableProvider>(
-        AirTableProvider(
-            id = "570e9285-3228-4396-b82b-e9752e23cd73",
-            airtableClient = AirTableClient(
-                AppConfig.tables.sikkerhetskontroller.accessToken
-            ),
-            baseId = AppConfig.tables.sikkerhetskontroller.baseId,
-            tableId = AppConfig.tables.sikkerhetskontroller.tableId,
-            viewId = AppConfig.tables.sikkerhetskontroller.viewId,
-            webhookId = AppConfig.tables.sikkerhetskontroller.webhookId,
-            webhookSecret = AppConfig.tables.sikkerhetskontroller.webhookSecret,
-        ),
-        AirTableProvider(
-            id = "816cc808-9188-44a9-8f4b-5642fc2932c4",
-            airtableClient = AirTableClient(
-                AppConfig.tables.driftskontinuitet.accessToken
-            ),
-            baseId = AppConfig.tables.driftskontinuitet.baseId,
-            tableId = AppConfig.tables.driftskontinuitet.tableId,
-            viewId = AppConfig.tables.driftskontinuitet.viewId,
-            webhookId = AppConfig.tables.driftskontinuitet.webhookId,
-            webhookSecret = AppConfig.tables.driftskontinuitet.webhookSecret,
-        ),
+
+
+  private val providers: List<TableProvider> = AppConfig.tables.tables.map { table ->
+        if (table.type == "AIRTABLE") {
+            AirTableProvider(
+                id = table.id,
+                airtableClient = AirTableClient(
+                    table.accessToken
+                ),
+                baseId = table.baseId,
+                tableId =   table.tableId,
+                viewId = table.viewId,
+                webhookId = table.webhookId,
+                webhookSecret = table.webhookSecret,
+            )
+        } else {
+            throw Exception("Table ${table.type} not found")
+        }
+    }
+
+
+//    private val providers: List<TableProvider> = listOf<TableProvider>(
+//        AirTableProvider(
+//            id = "570e9285-3228-4396-b82b-e9752e23cd73",
+//            airtableClient = AirTableClient(
+//                AppConfig.tables.sikkerhetskontroller.accessToken
+//            ),
+//            baseId = AppConfig.tables.sikkerhetskontroller.baseId,
+//            tableId = AppConfig.tables.sikkerhetskontroller.tableId,
+//            viewId = AppConfig.tables.sikkerhetskontroller.viewId,
+//            webhookId = AppConfig.tables.sikkerhetskontroller.webhookId,
+//            webhookSecret = AppConfig.tables.sikkerhetskontroller.webhookSecret,
+//        ),
+//        AirTableProvider(
+//            id = "816cc808-9188-44a9-8f4b-5642fc2932c4",
+//            airtableClient = AirTableClient(
+//                AppConfig.tables.driftskontinuitet.accessToken
+//            ),
+//            baseId = AppConfig.tables.driftskontinuitet.baseId,
+//            tableId = AppConfig.tables.driftskontinuitet.tableId,
+//            viewId = AppConfig.tables.driftskontinuitet.viewId,
+//            webhookId = AppConfig.tables.driftskontinuitet.webhookId,
+//            webhookSecret = AppConfig.tables.driftskontinuitet.webhookSecret,
+//        ),
 //        AirTableProvider(
 //            id = "test-table",
 //            airtableClient = AirTableClient(
@@ -40,7 +61,7 @@ object TableService {
 //            webhookId = "achpY1AcPW93B9ucr",
 //            webhookSecret = System.getenv("AIRTABLE_WEBHOOK_SECRET")
 //        ),
-    )
+ //   )
 
 
     fun getTableProvider(tableId: String): TableProvider {

--- a/backend/src/main/kotlin/no/bekk/services/TableService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/TableService.kt
@@ -1,16 +1,20 @@
 package no.bekk.services
 
+import io.ktor.client.*
+import no.bekk.configuration.AirTableInstanceConfig
 import no.bekk.configuration.AppConfig
+import no.bekk.configuration.YAMLInstanceConfig
 import no.bekk.providers.AirTableProvider
 import no.bekk.providers.TableProvider
+import no.bekk.providers.YamlProvider
 import no.bekk.providers.clients.AirTableClient
 
 object TableService {
 
 
   private val providers: List<TableProvider> = AppConfig.tables.tables.map { table ->
-        if (table.type == "AIRTABLE") {
-            AirTableProvider(
+        when (table) {
+            is AirTableInstanceConfig -> AirTableProvider(
                 id = table.id,
                 airtableClient = AirTableClient(
                     table.accessToken
@@ -21,47 +25,15 @@ object TableService {
                 webhookId = table.webhookId,
                 webhookSecret = table.webhookSecret,
             )
-        } else {
-            throw Exception("Table ${table.type} not found")
+            is YAMLInstanceConfig -> YamlProvider(
+                id = table.id,
+                endpoint = table.endpoint,
+                resourcePath =   table.resourcePath,
+            )
+            else ->  throw Exception("Valid tabletype not found")
+
         }
     }
-
-
-//    private val providers: List<TableProvider> = listOf<TableProvider>(
-//        AirTableProvider(
-//            id = "570e9285-3228-4396-b82b-e9752e23cd73",
-//            airtableClient = AirTableClient(
-//                AppConfig.tables.sikkerhetskontroller.accessToken
-//            ),
-//            baseId = AppConfig.tables.sikkerhetskontroller.baseId,
-//            tableId = AppConfig.tables.sikkerhetskontroller.tableId,
-//            viewId = AppConfig.tables.sikkerhetskontroller.viewId,
-//            webhookId = AppConfig.tables.sikkerhetskontroller.webhookId,
-//            webhookSecret = AppConfig.tables.sikkerhetskontroller.webhookSecret,
-//        ),
-//        AirTableProvider(
-//            id = "816cc808-9188-44a9-8f4b-5642fc2932c4",
-//            airtableClient = AirTableClient(
-//                AppConfig.tables.driftskontinuitet.accessToken
-//            ),
-//            baseId = AppConfig.tables.driftskontinuitet.baseId,
-//            tableId = AppConfig.tables.driftskontinuitet.tableId,
-//            viewId = AppConfig.tables.driftskontinuitet.viewId,
-//            webhookId = AppConfig.tables.driftskontinuitet.webhookId,
-//            webhookSecret = AppConfig.tables.driftskontinuitet.webhookSecret,
-//        ),
-//        AirTableProvider(
-//            id = "test-table",
-//            airtableClient = AirTableClient(
-//                System.getenv("AIRTABLE_TEST_TOKEN")
-//            ),
-//            baseId = "appJFzRzW8GmaKuz3",
-//            tableId = "tblbiZLh6qn3k7wdt",
-//            viewId = "",
-//            webhookId = "achpY1AcPW93B9ucr",
-//            webhookSecret = System.getenv("AIRTABLE_WEBHOOK_SECRET")
-//        ),
- //   )
 
 
     fun getTableProvider(tableId: String): TableProvider {

--- a/backend/src/main/kotlin/no/bekk/services/TableService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/TableService.kt
@@ -1,6 +1,5 @@
 package no.bekk.services
 
-import io.ktor.client.*
 import no.bekk.configuration.AirTableInstanceConfig
 import no.bekk.configuration.AppConfig
 import no.bekk.configuration.YAMLInstanceConfig
@@ -12,7 +11,7 @@ import no.bekk.providers.clients.AirTableClient
 object TableService {
 
 
-  private val providers: List<TableProvider> = AppConfig.tables.tables.map { table ->
+  private val providers: List<TableProvider> = AppConfig.formConfig.forms.map { table ->
         when (table) {
             is AirTableInstanceConfig -> AirTableProvider(
                 id = table.id,

--- a/backend/src/main/kotlin/no/bekk/util/RefreshWebhookBackgroundTask.kt
+++ b/backend/src/main/kotlin/no/bekk/util/RefreshWebhookBackgroundTask.kt
@@ -3,14 +3,13 @@ package no.bekk.util
 import io.ktor.server.application.*
 import kotlinx.coroutines.*
 import no.bekk.providers.AirTableProvider
-import no.bekk.services.TableService
-import kotlin.reflect.typeOf
+import no.bekk.services.FormService
 
 fun Application.configureBackgroundTasks() {
     launchBackgroundTask {
         while (isActive) {
             try {
-                val airTableProviders = TableService.getTableProviders().filterIsInstance<AirTableProvider>()
+                val airTableProviders = FormService.getTableProviders().filterIsInstance<AirTableProvider>()
                 airTableProviders.forEach { provider ->
                     if (provider.webhookId.isNullOrEmpty()) {
                         logger.info("Table ${provider.id} has no webhook id. Nothing to refresh.")

--- a/backend/src/main/kotlin/no/bekk/util/RefreshWebhookBackgroundTask.kt
+++ b/backend/src/main/kotlin/no/bekk/util/RefreshWebhookBackgroundTask.kt
@@ -9,7 +9,7 @@ fun Application.configureBackgroundTasks() {
     launchBackgroundTask {
         while (isActive) {
             try {
-                val airTableProviders = FormService.getTableProviders().filterIsInstance<AirTableProvider>()
+                val airTableProviders = FormService.getFormProviders().filterIsInstance<AirTableProvider>()
                 airTableProviders.forEach { provider ->
                     if (provider.webhookId.isNullOrEmpty()) {
                         logger.info("Table ${provider.id} has no webhook id. Nothing to refresh.")

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -21,6 +21,23 @@ airTable:
     webhookId: "$DRIFTSKONTINUITET_WEBHOOK_ID:"
     webhookSecret: "$DRIFTSKONTINUITET_WEBHOOK_SECRET:"
 
+tables:
+- id: "570e9285-3228-4396-b82b-e9752e23cd73"
+  type : "AIRTABLE"
+  accessToken: $AIRTABLE_ACCESS_TOKEN
+  baseId: "appzJQ8Tkmm8DobrJ"
+  tableId: "tblLZbUqA0XnUgC2v"
+  viewId: "viw2XliGUJu5448Hk"
+  webhookId: "$SIKKERHETSKONTROLLER_WEBHOOK_ID:"
+  webhookSecret: "$SIKKERHETSKONTROLLER_WEBHOOK_SECRET:"
+- id: "816cc808-9188-44a9-8f4b-5642fc2932c4"
+  type: "AIRTABLE"
+  accessToken: $AIRTABLE_ACCESS_TOKEN
+  baseId: "appsIiBWlCCSsMmRB"
+  tableId: "tbl4pNqNp2wLyI6iv"
+  webhookId: "$DRIFTSKONTINUITET_WEBHOOK_ID:"
+  webhookSecret: "$DRIFTSKONTINUITET_WEBHOOK_SECRET:"
+
 microsoftGraph:
   baseUrl: "https://graph.microsoft.com"
   memberOfPath: "/v1.0/me/memberOf/microsoft.graph.group"

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -7,21 +7,8 @@ ktor:
 
 airTable:
   baseUrl: "https://api.airtable.com"
-  sikkerhetskontroller:
-    accessToken: $AIRTABLE_ACCESS_TOKEN
-    baseId: "appzJQ8Tkmm8DobrJ"
-    tableId: "tblLZbUqA0XnUgC2v"
-    viewId: "viw2XliGUJu5448Hk"
-    webhookId: "$SIKKERHETSKONTROLLER_WEBHOOK_ID:"
-    webhookSecret: "$SIKKERHETSKONTROLLER_WEBHOOK_SECRET:"
-  driftskontinuitet:
-    accessToken: $AIRTABLE_ACCESS_TOKEN
-    baseId: "appsIiBWlCCSsMmRB"
-    tableId: "tbl4pNqNp2wLyI6iv"
-    webhookId: "$DRIFTSKONTINUITET_WEBHOOK_ID:"
-    webhookSecret: "$DRIFTSKONTINUITET_WEBHOOK_SECRET:"
 
-tables:
+forms:
 - id: "570e9285-3228-4396-b82b-e9752e23cd73"
   type : "AIRTABLE"
   accessToken: $AIRTABLE_ACCESS_TOKEN

--- a/frontend/beCompliant/src/api/apiConfig.ts
+++ b/frontend/beCompliant/src/api/apiConfig.ts
@@ -97,14 +97,14 @@ export const apiConfig = {
       ],
       url: (contextId: string) => `${API_URL_CONTEXTS}/${contextId}`,
     },
-    forTeamAndTable: {
-      queryKey: (teamId: string, tableId: string) => [
+    forTeamAndForm: {
+      queryKey: (teamId: string, formId: string) => [
         PATH_CONTEXTS,
         teamId,
-        tableId,
+        formId,
       ],
-      url: (teamId: string, tableId: string) =>
-        `${API_URL_CONTEXTS}?teamId=${teamId}&tableId=${tableId}`,
+      url: (teamId: string, formId: string) =>
+        `${API_URL_CONTEXTS}?teamId=${teamId}&formId=${formId}`,
     },
   },
   dumpCSV: {

--- a/frontend/beCompliant/src/api/apiConfig.ts
+++ b/frontend/beCompliant/src/api/apiConfig.ts
@@ -2,7 +2,7 @@
 const PATH_ANSWERS = '/answers';
 const PATH_ANSWER = '/answer';
 const PATH_COMMENTS = '/comments';
-const PATH_TABLE = '/tables';
+const PATH_FORM = '/forms';
 const PATH_USERINFO = '/userinfo';
 const PATH_USERNAME = '/username';
 const PATH_COLUMNS = '/columns';
@@ -47,27 +47,27 @@ export const apiConfig = {
     queryKey: [PATH_COMMENTS],
     url: API_URL_COMMENTS,
   },
-  table: {
-    queryKey: (tableId: string) => [PATH_TABLE, tableId],
-    url: (tableId: string) => `${API_URL_BASE}${PATH_TABLE}/${tableId}`,
+  form: {
+    queryKey: (formId: string) => [PATH_FORM, formId],
+    url: (formId: string) => `${API_URL_BASE}${PATH_FORM}/${formId}`,
   },
-  tables: {
-    queryKey: () => [PATH_TABLE],
-    url: () => `${API_URL_BASE}${PATH_TABLE}`,
+  forms: {
+    queryKey: () => [PATH_FORM],
+    url: () => `${API_URL_BASE}${PATH_FORM}`,
   },
   question: {
-    queryKey: (tableId: string, recordId: string) => [
-      PATH_TABLE,
-      tableId,
+    queryKey: (formId: string, recordId: string) => [
+      PATH_FORM,
+      formId,
       recordId,
     ],
-    url: (tableId: string, recordId: string) =>
-      `${API_URL_BASE}${PATH_TABLE}/${tableId}/${recordId}`,
+    url: (formId: string, recordId: string) =>
+      `${API_URL_BASE}${PATH_FORM}/${formId}/${recordId}`,
   },
   columns: {
     queryKey: () => [PATH_COLUMNS],
-    url: (tableId: string) =>
-      `${API_URL_BASE}${PATH_TABLE}/${tableId}${PATH_COLUMNS}`,
+    url: (formId: string) =>
+      `${API_URL_BASE}${PATH_FORM}/${formId}${PATH_COLUMNS}`,
   },
   userinfo: {
     queryKey: [PATH_USERINFO],

--- a/frontend/beCompliant/src/api/types.ts
+++ b/frontend/beCompliant/src/api/types.ts
@@ -74,7 +74,7 @@ export type QuestionMetadata = {
   optionalFields: OptionalField[] | null;
 };
 
-export type Table = {
+export type Form = {
   id: string;
   columns: Column[];
   name: string;

--- a/frontend/beCompliant/src/components/Table.tsx
+++ b/frontend/beCompliant/src/components/Table.tsx
@@ -17,7 +17,7 @@ import { DataTable } from './table/DataTable';
 import { DataTableCell } from './table/DataTableCell';
 import { DataTableHeader } from './table/DataTableHeader';
 import { TableCell } from './table/TableCell';
-import { Column, OptionalField, Question, Table, User } from '../api/types';
+import { Column, OptionalField, Question, Form, User } from '../api/types';
 import { getSortFuncForColumn } from './table/TableSort';
 import { TableActions } from './tableActions/TableActions';
 import { TableFilters } from './tableActions/TableFilter';
@@ -30,7 +30,7 @@ type Props = {
   tableMetadata: Column[];
   filterByAnswer: boolean;
   data: Question[];
-  tableData: Table;
+  tableData: Form;
   user: User;
   contextId: string;
 };

--- a/frontend/beCompliant/src/components/createContextPage/CopyContextDropdown.tsx
+++ b/frontend/beCompliant/src/components/createContextPage/CopyContextDropdown.tsx
@@ -16,7 +16,7 @@ export function CopyContextDropdown({
     useFetchAllContexts();
 
   const contextsForTable: Context[] =
-    contexts?.filter((context) => context.tableId === tableId) ?? [];
+    contexts?.filter((context) => context.formId === tableId) ?? [];
 
   const isDisabled = contextsForTable.length === 0;
 

--- a/frontend/beCompliant/src/components/table/SettingsModal.tsx
+++ b/frontend/beCompliant/src/components/table/SettingsModal.tsx
@@ -107,7 +107,7 @@ export function SettingsModal({ onClose, isOpen }: Props) {
   const contextsForTable: Context[] =
     contexts?.filter(
       (context) =>
-        context.tableId === currentContext.data?.tableId &&
+        context.formId === currentContext.data?.formId &&
         context.id !== currentContext.data?.id
     ) ?? [];
 

--- a/frontend/beCompliant/src/hooks/useFetchForm.ts
+++ b/frontend/beCompliant/src/hooks/useFetchForm.ts
@@ -1,11 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { axiosFetch } from '../api/Fetch';
 import { apiConfig } from '../api/apiConfig';
-import { Table } from '../api/types';
+import { Form } from '../api/types';
 
-export function useFetchTables() {
-  const queryKeys = apiConfig.forms.queryKey();
-  const url = apiConfig.forms.url();
+export function useFetchForm(formId?: string) {
+  const queryKeys = apiConfig.form.queryKey(formId!);
+  const url = apiConfig.form.url(formId!);
 
   return useQuery({
     queryKey: queryKeys,
@@ -13,16 +13,13 @@ export function useFetchTables() {
     refetchOnMount: false,
     notifyOnChangeProps: ['data', 'error'],
     queryFn: () =>
-      axiosFetch<Table[]>({ url: url }).then((response) => response.data),
-    select: formatTablesData,
+      axiosFetch<Form>({ url: url }).then((response) => response.data),
+    select: formatFormData,
+    enabled: !!formId,
   });
 }
 
-function formatTablesData(data: Table[]) {
-  return data.map(formatTableData);
-}
-
-function formatTableData(data: Table) {
+function formatFormData(data: Form) {
   return {
     ...data,
     records: data.records.map((record) => {

--- a/frontend/beCompliant/src/hooks/useFetchForms.ts
+++ b/frontend/beCompliant/src/hooks/useFetchForms.ts
@@ -1,11 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { axiosFetch } from '../api/Fetch';
 import { apiConfig } from '../api/apiConfig';
-import { Table } from '../api/types';
+import { Form } from '../api/types';
 
-export function useFetchTable(tableId?: string) {
-  const queryKeys = apiConfig.form.queryKey(tableId!);
-  const url = apiConfig.form.url(tableId!);
+export function useFetchForms() {
+  const queryKeys = apiConfig.forms.queryKey();
+  const url = apiConfig.forms.url();
 
   return useQuery({
     queryKey: queryKeys,
@@ -13,13 +13,16 @@ export function useFetchTable(tableId?: string) {
     refetchOnMount: false,
     notifyOnChangeProps: ['data', 'error'],
     queryFn: () =>
-      axiosFetch<Table>({ url: url }).then((response) => response.data),
-    select: formatTableData,
-    enabled: !!tableId,
+      axiosFetch<Form[]>({ url: url }).then((response) => response.data),
+    select: formatFormData,
   });
 }
 
-function formatTableData(data: Table) {
+function formatFormData(data: Form[]) {
+  return data.map(formatFormatData);
+}
+
+function formatFormatData(data: Form) {
   return {
     ...data,
     records: data.records.map((record) => {

--- a/frontend/beCompliant/src/hooks/useFetchTable.ts
+++ b/frontend/beCompliant/src/hooks/useFetchTable.ts
@@ -4,8 +4,8 @@ import { apiConfig } from '../api/apiConfig';
 import { Table } from '../api/types';
 
 export function useFetchTable(tableId?: string) {
-  const queryKeys = apiConfig.table.queryKey(tableId!);
-  const url = apiConfig.table.url(tableId!);
+  const queryKeys = apiConfig.form.queryKey(tableId!);
+  const url = apiConfig.form.url(tableId!);
 
   return useQuery({
     queryKey: queryKeys,

--- a/frontend/beCompliant/src/hooks/useFetchTables.ts
+++ b/frontend/beCompliant/src/hooks/useFetchTables.ts
@@ -4,8 +4,8 @@ import { apiConfig } from '../api/apiConfig';
 import { Table } from '../api/types';
 
 export function useFetchTables() {
-  const queryKeys = apiConfig.tables.queryKey();
-  const url = apiConfig.tables.url();
+  const queryKeys = apiConfig.forms.queryKey();
+  const url = apiConfig.forms.url();
 
   return useQuery({
     queryKey: queryKeys,

--- a/frontend/beCompliant/src/hooks/useFetchTeamContexts.ts
+++ b/frontend/beCompliant/src/hooks/useFetchTeamContexts.ts
@@ -5,7 +5,7 @@ import { axiosFetch } from '../api/Fetch';
 export type Context = {
   id: string;
   name: string;
-  tableId: string;
+  formId: string;
   teamId: string;
 };
 

--- a/frontend/beCompliant/src/hooks/useFetchTeamTableContexts.ts
+++ b/frontend/beCompliant/src/hooks/useFetchTeamTableContexts.ts
@@ -3,13 +3,13 @@ import { apiConfig } from '../api/apiConfig';
 import { axiosFetch } from '../api/Fetch';
 import { Context } from './useFetchTeamContexts';
 
-export function useFetchTeamTableContexts(teamId: string, tableId: string) {
+export function useFetchTeamTableContexts(teamId: string, formId: string) {
   return useQuery({
-    queryKey: apiConfig.contexts.forTeamAndTable.queryKey(teamId, tableId),
+    queryKey: apiConfig.contexts.forTeamAndForm.queryKey(teamId, formId),
     queryFn: () =>
       axiosFetch<Context[]>({
-        url: `${apiConfig.contexts.forTeamAndTable.url(teamId, tableId)}`,
+        url: `${apiConfig.contexts.forTeamAndForm.url(teamId, formId)}`,
       }).then((response) => response.data),
-    enabled: !!teamId && !!tableId,
+    enabled: !!teamId && !!formId,
   });
 }

--- a/frontend/beCompliant/src/hooks/useSubmitContext.ts
+++ b/frontend/beCompliant/src/hooks/useSubmitContext.ts
@@ -6,7 +6,7 @@ import { AxiosError } from 'axios';
 
 type SubmitContextRequest = {
   teamId: string;
-  tableId: string;
+  formId: string;
   name: string;
   copyContext: string | null;
 };
@@ -14,7 +14,7 @@ type SubmitContextRequest = {
 export interface SubmitContextResponse {
   id: string;
   teamId: string;
-  tableId: string;
+  formId: string;
   name: string;
 }
 
@@ -27,79 +27,6 @@ export function useSubmitContext() {
     mutationKey: apiConfig.contexts.queryKey,
     mutationFn: (body: SubmitContextRequest) => {
       return axiosFetch<SubmitContextResponse>({
-        url: URL,
-        method: 'POST',
-        data: body,
-      });
-    },
-    onSuccess: async () => {
-      const toastId = 'submit-context-success';
-      if (!toast.isActive(toastId)) {
-        toast({
-          title: 'Suksess',
-          description: 'Konteksten ble opprettet',
-          status: 'success',
-          duration: 5000,
-          isClosable: true,
-        });
-      }
-      await queryClient.invalidateQueries({
-        queryKey: apiConfig.contexts.queryKey,
-      });
-    },
-    onError: (error: AxiosError) => {
-      if (error.response?.status === 409) {
-        const toastId = 'submit-context-conflict';
-        if (!toast.isActive(toastId)) {
-          toast({
-            id: toastId,
-            title: 'Konflikt',
-            description: 'Et skjema med dette navnet eksisterer allerede.',
-            status: 'warning',
-            duration: 5000,
-            isClosable: true,
-          });
-        }
-      } else {
-        const toastId = 'submit-context-error';
-        if (!toast.isActive(toastId)) {
-          toast({
-            id: toastId,
-            title: 'Å nei!',
-            description: 'Det har skjedd en feil. Prøv på nytt',
-            status: 'error',
-            duration: 5000,
-            isClosable: true,
-          });
-        }
-      }
-    },
-  });
-}
-
-export interface SubmitContextResponseFormVersion {
-  id: string;
-  teamId: string;
-  formId: string;
-  name: string;
-}
-
-type SubmitContextRequestFormVersion = {
-  teamId: string;
-  formId: string;
-  name: string;
-  copyContext: string | null;
-};
-
-export function useSubmitContextFormVersion() {
-  const URL = apiConfig.contexts.url;
-  const queryClient = useQueryClient();
-  const toast = useToast();
-
-  return useMutation({
-    mutationKey: apiConfig.contexts.queryKey,
-    mutationFn: (body: SubmitContextRequestFormVersion) => {
-      return axiosFetch<SubmitContextResponseFormVersion>({
         url: URL,
         method: 'POST',
         data: body,

--- a/frontend/beCompliant/src/hooks/useSubmitContext.ts
+++ b/frontend/beCompliant/src/hooks/useSubmitContext.ts
@@ -6,7 +6,7 @@ import { AxiosError } from 'axios';
 
 type SubmitContextRequest = {
   teamId: string;
-  formId: string;
+  tableId: string;
   name: string;
   copyContext: string | null;
 };
@@ -14,7 +14,7 @@ type SubmitContextRequest = {
 export interface SubmitContextResponse {
   id: string;
   teamId: string;
-  formId: string;
+  tableId: string;
   name: string;
 }
 
@@ -27,6 +27,79 @@ export function useSubmitContext() {
     mutationKey: apiConfig.contexts.queryKey,
     mutationFn: (body: SubmitContextRequest) => {
       return axiosFetch<SubmitContextResponse>({
+        url: URL,
+        method: 'POST',
+        data: body,
+      });
+    },
+    onSuccess: async () => {
+      const toastId = 'submit-context-success';
+      if (!toast.isActive(toastId)) {
+        toast({
+          title: 'Suksess',
+          description: 'Konteksten ble opprettet',
+          status: 'success',
+          duration: 5000,
+          isClosable: true,
+        });
+      }
+      await queryClient.invalidateQueries({
+        queryKey: apiConfig.contexts.queryKey,
+      });
+    },
+    onError: (error: AxiosError) => {
+      if (error.response?.status === 409) {
+        const toastId = 'submit-context-conflict';
+        if (!toast.isActive(toastId)) {
+          toast({
+            id: toastId,
+            title: 'Konflikt',
+            description: 'Et skjema med dette navnet eksisterer allerede.',
+            status: 'warning',
+            duration: 5000,
+            isClosable: true,
+          });
+        }
+      } else {
+        const toastId = 'submit-context-error';
+        if (!toast.isActive(toastId)) {
+          toast({
+            id: toastId,
+            title: 'Å nei!',
+            description: 'Det har skjedd en feil. Prøv på nytt',
+            status: 'error',
+            duration: 5000,
+            isClosable: true,
+          });
+        }
+      }
+    },
+  });
+}
+
+export interface SubmitContextResponseFormVersion {
+  id: string;
+  teamId: string;
+  formId: string;
+  name: string;
+}
+
+type SubmitContextRequestFormVersion = {
+  teamId: string;
+  formId: string;
+  name: string;
+  copyContext: string | null;
+};
+
+export function useSubmitContextFormVersion() {
+  const URL = apiConfig.contexts.url;
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation({
+    mutationKey: apiConfig.contexts.queryKey,
+    mutationFn: (body: SubmitContextRequestFormVersion) => {
+      return axiosFetch<SubmitContextResponseFormVersion>({
         url: URL,
         method: 'POST',
         data: body,

--- a/frontend/beCompliant/src/hooks/useSubmitContext.ts
+++ b/frontend/beCompliant/src/hooks/useSubmitContext.ts
@@ -6,7 +6,7 @@ import { AxiosError } from 'axios';
 
 type SubmitContextRequest = {
   teamId: string;
-  tableId: string;
+  formId: string;
   name: string;
   copyContext: string | null;
 };
@@ -14,7 +14,7 @@ type SubmitContextRequest = {
 export interface SubmitContextResponse {
   id: string;
   teamId: string;
-  tableId: string;
+  formId: string;
   name: string;
 }
 

--- a/frontend/beCompliant/src/pages/ActivityPage.tsx
+++ b/frontend/beCompliant/src/pages/ActivityPage.tsx
@@ -13,7 +13,7 @@ import { TableComponent } from '../components/Table';
 import { TableStatistics } from '../components/table/TableStatistics';
 import { useFetchAnswers } from '../hooks/useFetchAnswers';
 import { useFetchComments } from '../hooks/useFetchComments';
-import { useFetchTable } from '../hooks/useFetchTable';
+import { useFetchForm } from '../hooks/useFetchForm';
 import { ActiveFilter } from '../types/tableTypes';
 import { mapTableDataRecords } from '../utils/mapperUtil';
 import { AnswerType, Column, OptionalFieldType } from '../api/types';
@@ -65,7 +65,7 @@ export const ActivityPage = () => {
     data: tableData,
     error: tableError,
     isPending: tableIsPending,
-  } = useFetchTable(context?.tableId);
+  } = useFetchForm(context?.formId);
   const {
     data: comments,
     error: commentError,

--- a/frontend/beCompliant/src/pages/CreateContextPage.tsx
+++ b/frontend/beCompliant/src/pages/CreateContextPage.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { LockedCreateContextPage } from './LockedCreateContextPage';
 import { UnlockedCreateContextPage } from './UnlockedCreateContextPage';
-import { useFetchTables } from '../hooks/useFetchTables';
+import { useFetchForms } from '../hooks/useFetchForms';
 import { Center, Heading, Icon } from '@kvib/react';
 import { useSubmitContext } from '../hooks/useSubmitContext';
 import { FormEvent, useCallback } from 'react';
@@ -13,12 +13,12 @@ export const CreateContextPage = () => {
 
   const teamId = search.get('teamId');
   const name = search.get('name');
-  const tableId = search.get('tableId');
+  const formId = search.get('formId');
   const redirect = search.get('redirect');
 
-  const setTableId = useCallback(
-    (newTableId: string) => {
-      search.set('tableId', newTableId);
+  const setFormId = useCallback(
+    (newFormId: string) => {
+      search.set('formId', newFormId);
       setSearch(search);
     },
     [search, setSearch]
@@ -29,11 +29,11 @@ export const CreateContextPage = () => {
   const { mutate: submitContext, isPending: isLoading } = useSubmitContext();
 
   const {
-    data: tablesData,
-    isPending: tablesIsPending,
-    error: tablesError,
-  } = useFetchTables();
-  if (tablesError) {
+    data: formData,
+    isPending: formIsPending,
+    error: formError,
+  } = useFetchForms();
+  if (formError) {
     return (
       <Center height="70svh" flexDirection="column" gap="4">
         <Icon icon="error" size={64} weight={600} />
@@ -42,24 +42,24 @@ export const CreateContextPage = () => {
     );
   }
 
-  const isButtonDisabled = !teamId || !tableId || !name || isLoading;
+  const isButtonDisabled = !teamId || !formId || !name || isLoading;
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (teamId && name && tableId) {
+    if (teamId && name && formId) {
       submitContext(
-        { teamId, tableId, name, copyContext },
+        { teamId, formId: formId, name, copyContext },
         {
           onSuccess: (data) => {
             if (redirect) {
               const incomingRedirect = decodeURIComponent(redirect)
                 .replace('{contextId}', data.data.id)
-                .replace('{tableId}', tableId)
+                .replace('{tableId}', formId) // Dette er til FRISK tror jeg - vent med å oppdatere?
                 .replace('{contextName}', data.data.name)
                 .replace(
                   '{tableName}',
-                  tablesData?.find((table) => table.id === data.data.tableId)
-                    ?.name ?? tableId
+                  formData?.find((form) => form.id === data.data.formId)
+                    ?.name ?? formId
                 );
               const fullRedirect = new URL(incomingRedirect);
               const newRedirect = new URL(
@@ -77,33 +77,33 @@ export const CreateContextPage = () => {
         }
       );
     } else {
-      console.error('teamId, tableId, and contextName must be provided');
+      console.error('teamId, formId, and contextName must be provided');
     }
   };
 
   return locked ? (
     <LockedCreateContextPage
-      tablesData={{
-        data: tablesData,
-        isPending: tablesIsPending,
+      formsData={{
+        data: formData,
+        isPending: formIsPending,
       }}
       handleSumbit={handleSubmit}
       isLoading={isLoading}
       isButtonDisabled={isButtonDisabled}
-      setTableId={setTableId}
+      setFormId={setFormId}
       name={name}
       teamId={teamId}
     />
   ) : (
     <UnlockedCreateContextPage
-      tablesData={{
-        data: tablesData,
-        isPending: tablesIsPending,
+      formsData={{
+        data: formData,
+        isPending: formIsPending,
       }}
       handleSumbit={handleSubmit}
       isLoading={isLoading}
       isButtonDisabled={isButtonDisabled}
-      setTableId={setTableId}
+      setFormId={setFormId}
       name={name}
       teamId={teamId}
     />

--- a/frontend/beCompliant/src/pages/CreateContextPage.tsx
+++ b/frontend/beCompliant/src/pages/CreateContextPage.tsx
@@ -33,7 +33,6 @@ export const CreateContextPage = () => {
     isPending: tablesIsPending,
     error: tablesError,
   } = useFetchTables();
-
   if (tablesError) {
     return (
       <Center height="70svh" flexDirection="column" gap="4">

--- a/frontend/beCompliant/src/pages/CreateContextPage.tsx
+++ b/frontend/beCompliant/src/pages/CreateContextPage.tsx
@@ -3,10 +3,7 @@ import { LockedCreateContextPage } from './LockedCreateContextPage';
 import { UnlockedCreateContextPage } from './UnlockedCreateContextPage';
 import { useFetchForms } from '../hooks/useFetchForms';
 import { Center, Heading, Icon } from '@kvib/react';
-import {
-  useSubmitContext,
-  useSubmitContextFormVersion,
-} from '../hooks/useSubmitContext';
+import { useSubmitContext } from '../hooks/useSubmitContext';
 import { FormEvent, useCallback } from 'react';
 
 export const CreateContextPage = () => {
@@ -29,8 +26,7 @@ export const CreateContextPage = () => {
 
   const copyContext = search.get('copyContext');
 
-  const { mutate: submitContext, isPending: isLoading } =
-    useSubmitContextFormVersion();
+  const { mutate: submitContext, isPending: isLoading } = useSubmitContext();
 
   const {
     data: formData,

--- a/frontend/beCompliant/src/pages/CreateContextPage.tsx
+++ b/frontend/beCompliant/src/pages/CreateContextPage.tsx
@@ -3,7 +3,10 @@ import { LockedCreateContextPage } from './LockedCreateContextPage';
 import { UnlockedCreateContextPage } from './UnlockedCreateContextPage';
 import { useFetchForms } from '../hooks/useFetchForms';
 import { Center, Heading, Icon } from '@kvib/react';
-import { useSubmitContext } from '../hooks/useSubmitContext';
+import {
+  useSubmitContext,
+  useSubmitContextFormVersion,
+} from '../hooks/useSubmitContext';
 import { FormEvent, useCallback } from 'react';
 
 export const CreateContextPage = () => {
@@ -26,7 +29,8 @@ export const CreateContextPage = () => {
 
   const copyContext = search.get('copyContext');
 
-  const { mutate: submitContext, isPending: isLoading } = useSubmitContext();
+  const { mutate: submitContext, isPending: isLoading } =
+    useSubmitContextFormVersion();
 
   const {
     data: formData,

--- a/frontend/beCompliant/src/pages/FrontPage.tsx
+++ b/frontend/beCompliant/src/pages/FrontPage.tsx
@@ -18,7 +18,7 @@ import { Page } from '../components/layout/Page';
 import { useFetchUserinfo } from '../hooks/useFetchUserinfo';
 import { useFetchTeamContexts } from '../hooks/useFetchTeamContexts';
 import { useFetchContext } from '../hooks/useFetchContext';
-import { useFetchTables } from '../hooks/useFetchTables';
+import { useFetchForms } from '../hooks/useFetchForms';
 import { DeleteContextModal } from '../components/DeleteContextModal';
 import { apiConfig } from '../api/apiConfig';
 import { axiosFetch } from '../api/Fetch';
@@ -139,10 +139,10 @@ function TeamContexts({ teamId }: { teamId: string }) {
   const { data: contexts = [], isPending: contextsIsPending } =
     useFetchTeamContexts(teamId);
 
-  const { data: tablesData, isPending: tablesIsPending } = useFetchTables();
+  const { data: tablesData, isPending: tablesIsPending } = useFetchForms();
 
   const uniqueTableIds = Array.from(
-    new Set(contexts?.map((context) => context.tableId))
+    new Set(contexts?.map((context) => context.formId))
   );
 
   const contextTables = tablesData?.filter((table) =>
@@ -154,7 +154,7 @@ function TeamContexts({ teamId }: { teamId: string }) {
       <Skeleton isLoaded={!contextsIsPending || !tablesIsPending} fitContent>
         {contextTables?.map((table) => {
           const contextsForTable = contexts.filter(
-            (context) => context.tableId === table.id
+            (context) => context.formId === table.id
           );
 
           return (

--- a/frontend/beCompliant/src/pages/LockedCreateContextPage.tsx
+++ b/frontend/beCompliant/src/pages/LockedCreateContextPage.tsx
@@ -14,26 +14,26 @@ import {
   Text,
 } from '@kvib/react';
 import { FormEvent, useCallback } from 'react';
-import { Table } from '../api/types';
+import { Form } from '../api/types';
 import { CopyContextDropdown } from '../components/createContextPage/CopyContextDropdown';
 import { useSearchParams } from 'react-router-dom';
 
 type Props = {
-  tablesData: { data: Table[] | undefined; isPending: boolean };
+  formsData: { data: Form[] | undefined; isPending: boolean };
   handleSumbit: (event: FormEvent<HTMLFormElement>) => void;
   isLoading: boolean;
   isButtonDisabled: boolean;
-  setTableId: (newTableId: string) => void;
+  setFormId: (newFormId: string) => void;
   name: string | null;
   teamId: string | null;
 };
 
 export const LockedCreateContextPage = ({
-  tablesData,
+  formsData,
   handleSumbit,
   isLoading,
   isButtonDisabled,
-  setTableId,
+  setFormId,
   name,
   teamId,
 }: Props) => {
@@ -108,17 +108,17 @@ export const LockedCreateContextPage = ({
               >
                 Velg sikkerhetsskjema du ønsker å opprette
               </FormLabel>
-              <Skeleton isLoaded={!tablesData.isPending}>
+              <Skeleton isLoaded={!formsData.isPending}>
                 <Select
                   id="tableSelect"
-                  onChange={(e) => setTableId(e.target.value)}
+                  onChange={(e) => setFormId(e.target.value)}
                   placeholder="Velg skjema"
                   required
                   bgColor="white"
                   borderColor="gray.200"
                   value={tableId ?? undefined}
                 >
-                  {tablesData?.data?.map((table) => (
+                  {formsData?.data?.map((table) => (
                     <option key={table.id} value={table.id}>
                       {table.name}
                     </option>

--- a/frontend/beCompliant/src/pages/QuestionPage.tsx
+++ b/frontend/beCompliant/src/pages/QuestionPage.tsx
@@ -28,7 +28,7 @@ export const QuestionPage = () => {
     data: question,
     error: questionError,
     isPending: questionIsLoading,
-  } = useFetchQuestion(context?.tableId, recordId);
+  } = useFetchQuestion(context?.formId, recordId);
 
   const {
     data: answers,
@@ -88,7 +88,7 @@ export const QuestionPage = () => {
     isCommentEditing ? onDiscardOpen() : handleDiscard();
   };
 
-  if (!context.tableId || !recordId || !contextId) {
+  if (!context.formId || !recordId || !contextId) {
     return null;
   }
 
@@ -135,7 +135,7 @@ export const QuestionPage = () => {
             choices={question.metadata.answerMetadata.options}
             answerExpiry={question.metadata.answerMetadata.expiry}
           />
-          <QuestionInfoBox question={question} tableId={context.tableId} />
+          <QuestionInfoBox question={question} tableId={context.formId} />
         </Flex>
         <QuestionComment
           question={question}

--- a/frontend/beCompliant/src/pages/UnlockedCreateContextPage.tsx
+++ b/frontend/beCompliant/src/pages/UnlockedCreateContextPage.tsx
@@ -16,24 +16,24 @@ import {
 } from '@kvib/react';
 import { useSearchParams } from 'react-router-dom';
 import { FormEvent, useCallback, useEffect } from 'react';
-import { Table } from '../api/types';
+import { Form } from '../api/types';
 
 type Props = {
-  tablesData: { data: Table[] | undefined; isPending: boolean };
+  formsData: { data: Form[] | undefined; isPending: boolean };
   handleSumbit: (event: FormEvent<HTMLFormElement>) => void;
   isLoading: boolean;
   isButtonDisabled: boolean;
-  setTableId: (newTableId: string) => void;
+  setFormId: (newFormId: string) => void;
   name: string | null;
   teamId: string | null;
 };
 
 export const UnlockedCreateContextPage = ({
-  tablesData,
+  formsData,
   handleSumbit,
   isLoading,
   isButtonDisabled,
-  setTableId,
+  setFormId,
   name,
   teamId,
 }: Props) => {
@@ -79,10 +79,10 @@ export const UnlockedCreateContextPage = ({
     teamId,
     name,
     tableId,
-    tablesData,
+    formsData,
     setTeamId,
     setName,
-    setTableId,
+    setFormId,
   ]);
 
   if (isUserinfoError) {
@@ -142,17 +142,17 @@ export const UnlockedCreateContextPage = ({
             >
               Velg sikkerhetsskjema
             </FormLabel>
-            <Skeleton isLoaded={!tablesData.isPending}>
+            <Skeleton isLoaded={!formsData.isPending}>
               <Select
                 id="tableSelect"
                 placeholder="Velg skjema"
                 required
                 bgColor="white"
                 borderColor="gray.200"
-                onChange={(e) => setTableId(e.target.value)}
+                onChange={(e) => setFormId(e.target.value)}
                 value={tableId ?? undefined}
               >
-                {tablesData.data?.map((table) => (
+                {formsData.data?.map((table) => (
                   <option key={table.id} value={table.id}>
                     {table.name}
                   </option>

--- a/frontend/beCompliant/src/utils/mapperUtil.test.ts
+++ b/frontend/beCompliant/src/utils/mapperUtil.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { Answer, AnswerType, Comment, Table } from '../api/types';
+import { Answer, AnswerType, Comment, Form } from '../api/types';
 import { groupByField, mapTableDataRecords } from './mapperUtil';
 
 describe(mapTableDataRecords.name, () => {
   it('should map table data records with associated comments and answers', () => {
-    const tableData: Table = {
+    const tableData: Form = {
       id: 'table1',
       name: 'Sample Table',
       columns: [],
@@ -161,7 +161,7 @@ describe(mapTableDataRecords.name, () => {
   });
 
   it('should return an empty array for comments and answers if none match', () => {
-    const tableData: Table = {
+    const tableData: Form = {
       id: 'table1',
       name: 'Sample Table',
       columns: [],

--- a/frontend/beCompliant/src/utils/mapperUtil.ts
+++ b/frontend/beCompliant/src/utils/mapperUtil.ts
@@ -1,7 +1,7 @@
-import { Answer, Comment, Table } from '../api/types';
+import { Answer, Comment, Form } from '../api/types';
 
 export const mapTableDataRecords = (
-  tableData: Table,
+  tableData: Form,
   commentData: Comment[],
   answerData: Answer[]
 ) => {


### PR DESCRIPTION
Byttet navn på nesten alle variabler/filer som het table til form, med unntak av ting i Airtable filene og komponenter/ting i frontend som ikke var avhengig av apiet. 

ContextRouting.kt sitt post endepunkt har fått en try catch block slik at de fortsatt kan støtte kall som bruker tableID, slik at dettte kan byttes i frisk. 

Schema har ikke blitt endret navn på - skal den det?


Test dette godt hehe
