### PR TITLE
Tydeligere ikon for se mer knappen

### DIFF
--- a/frontend/beCompliant/src/components/Table.tsx
+++ b/frontend/beCompliant/src/components/Table.tsx
@@ -182,7 +182,7 @@ export function TableComponent({
         <Tooltip label="Se mer">
           <IconButton
             aria-label="se mer"
-            icon="open_in_full"
+            icon="info"
             size="md"
             variant="ghost"
             onClick={() => navigate(`${row.original.recordId}`)}


### PR DESCRIPTION
Byttet fra expand ikon til info ikon på "se mer" knappen 

![image](https://github.com/user-attachments/assets/9b687b09-2c85-427b-8fa7-10d6a3c99a8d)

