### PR TITLE
605 utforske nytt ikon for oppdater svar

### DIFF
--- a/frontend/beCompliant/src/components/answers/PercentAnswer.tsx
+++ b/frontend/beCompliant/src/components/answers/PercentAnswer.tsx
@@ -1,9 +1,12 @@
 import {
+  IconButton,
   InputGroup,
+  InputLeftAddon,
   InputRightAddon,
   NumberInput,
   NumberInputField,
   Stack,
+  Tooltip,
 } from '@kvib/react';
 import { LastUpdated } from '../table/LastUpdated';
 import { useRef } from 'react';
@@ -46,12 +49,29 @@ export function PercentAnswer({
     <Stack spacing={1} direction="column">
       <Stack spacing={2} direction="row">
         <InputGroup width="fit-content">
+          <InputLeftAddon
+            background={'White'}
+            border="1px solid"
+            borderColor="gray.400"
+          >
+            <Tooltip label="Forny svaret" aria-label="Forny svaret">
+              <IconButton
+                aria-label="Forny svaret"
+                icon="update"
+                color="black"
+                variant="tertiary"
+                size="xs"
+              />
+            </Tooltip>
+          </InputLeftAddon>
           <NumberInput value={value} background={'white'} borderRadius="5px">
             <NumberInputField
               onChange={handlePercentAnswer}
               type="number"
               borderRight={'none'}
+              borderLeft={'none'}
               borderRightRadius={0}
+              borderLeftRadius={0}
               onBlur={() => {
                 if (value != initialValue) {
                   submitAnswer(value ?? '');

--- a/frontend/beCompliant/src/components/answers/PercentAnswer.tsx
+++ b/frontend/beCompliant/src/components/answers/PercentAnswer.tsx
@@ -1,12 +1,9 @@
 import {
-  IconButton,
   InputGroup,
-  InputLeftAddon,
   InputRightAddon,
   NumberInput,
   NumberInputField,
   Stack,
-  Tooltip,
 } from '@kvib/react';
 import { LastUpdated } from '../table/LastUpdated';
 import { useRef } from 'react';
@@ -49,29 +46,12 @@ export function PercentAnswer({
     <Stack spacing={1} direction="column">
       <Stack spacing={2} direction="row">
         <InputGroup width="fit-content">
-          <InputLeftAddon
-            background={'White'}
-            border="1px solid"
-            borderColor="gray.400"
-          >
-            <Tooltip label="Forny svaret" aria-label="Forny svaret">
-              <IconButton
-                aria-label="Forny svaret"
-                icon="update"
-                color="black"
-                variant="tertiary"
-                size="xs"
-              />
-            </Tooltip>
-          </InputLeftAddon>
           <NumberInput value={value} background={'white'} borderRadius="5px">
             <NumberInputField
               onChange={handlePercentAnswer}
               type="number"
               borderRight={'none'}
-              borderLeft={'none'}
               borderRightRadius={0}
-              borderLeftRadius={0}
               onBlur={() => {
                 if (value != initialValue) {
                   submitAnswer(value ?? '');

--- a/frontend/beCompliant/src/components/questionPage/TextAreaAnswer.tsx
+++ b/frontend/beCompliant/src/components/questionPage/TextAreaAnswer.tsx
@@ -1,4 +1,4 @@
-import { Text, Textarea, Stack, Flex, Tooltip, IconButton } from '@kvib/react';
+import { Text, Textarea, Stack, Flex } from '@kvib/react';
 import { useSubmitAnswers } from '../../hooks/useSubmitAnswers';
 import { Question, User } from '../../api/types';
 import { useEffect, useState } from 'react';
@@ -57,7 +57,7 @@ export function TextAreaAnswer({
         <Textarea
           value={answerInput}
           onChange={handleChange}
-          background="white"
+          backgroundColor="white"
           resize="vertical"
           onBlur={() => {
             if (answerInput !== latestAnswer) {
@@ -65,20 +65,6 @@ export function TextAreaAnswer({
             }
           }}
         />
-        {submitTextAnswer && (
-          <Tooltip label="Forny svaret" aria-label="Forny svaret">
-            <IconButton
-              aria-label="Forny svaret"
-              icon="update"
-              color="black"
-              variant="tertiary"
-              size="xs"
-              onClick={() => {
-                submitTextAnswer();
-              }}
-            />
-          </Tooltip>
-        )}
       </Stack>
       <LastUpdated
         updated={lastUpdated}

--- a/frontend/beCompliant/src/components/questionPage/TextAreaAnswer.tsx
+++ b/frontend/beCompliant/src/components/questionPage/TextAreaAnswer.tsx
@@ -1,4 +1,4 @@
-import { Text, Textarea, Stack, Flex } from '@kvib/react';
+import { Text, Textarea, Stack, Flex, Tooltip, IconButton } from '@kvib/react';
 import { useSubmitAnswers } from '../../hooks/useSubmitAnswers';
 import { Question, User } from '../../api/types';
 import { useEffect, useState } from 'react';
@@ -65,6 +65,20 @@ export function TextAreaAnswer({
             }
           }}
         />
+        {submitTextAnswer && (
+          <Tooltip label="Forny svaret" aria-label="Forny svaret">
+            <IconButton
+              aria-label="Forny svaret"
+              icon="update"
+              color="black"
+              variant="tertiary"
+              size="xs"
+              onClick={() => {
+                submitTextAnswer();
+              }}
+            />
+          </Tooltip>
+        )}
       </Stack>
       <LastUpdated
         updated={lastUpdated}

--- a/frontend/beCompliant/src/components/table/LastUpdated.tsx
+++ b/frontend/beCompliant/src/components/table/LastUpdated.tsx
@@ -68,7 +68,7 @@ export function LastUpdated({
         <Tooltip label="Forny svaret" aria-label="Forny svaret">
           <IconButton
             aria-label="Forny svaret"
-            icon="autorenew"
+            icon="update"
             color="black"
             variant="tertiary"
             size="xs"

--- a/frontend/beCompliant/src/components/table/LastUpdated.tsx
+++ b/frontend/beCompliant/src/components/table/LastUpdated.tsx
@@ -1,4 +1,4 @@
-import { Stack, Text, IconButton, Tooltip, Icon, Box } from '@kvib/react';
+import { Stack, Text, Tooltip, Icon, Box, Button } from '@kvib/react';
 import { formatDateTime } from '../../utils/formatTime';
 
 type Props = {
@@ -65,18 +65,18 @@ export function LastUpdated({
         {formatDateTime(updated)}
       </Text>
       {!isComment && submitAnswer && (
-        <Tooltip label="Forny svaret" aria-label="Forny svaret">
-          <IconButton
-            aria-label="Forny svaret"
-            icon="update"
-            color="black"
-            variant="tertiary"
-            size="xs"
-            onClick={() => {
-              submitAnswer(value ?? '', unitAnswer);
-            }}
-          />
-        </Tooltip>
+        <Button
+          aria-label="Forny svaret"
+          rightIcon="autorenew"
+          color="black"
+          variant={'tertiary'}
+          size="xs"
+          onClick={() => {
+            submitAnswer(value ?? '', unitAnswer);
+          }}
+        >
+          Forny svar
+        </Button>
       )}
     </Stack>
   );


### PR DESCRIPTION
## Background

Bruker skjønte ikke hva iconet for å fornye svaret var. Mål: gjøre knappen tydligere

## Solution

Gjorde icon-button om til en button med telsten Forny svar.

(måtte også gjør om background til backgroundColor i textAreaAnswer pga warning fra intellij. 

![image](https://github.com/user-attachments/assets/ec2f9c63-eaa0-4a76-bab5-a0d1f3a9f7a5)

Resolves [#605](https://github.com/kartverket/regelrett/issues/605)