### PR TITLE
Toggle detaljertvisning bug

### DIFF
--- a/frontend/beCompliant/src/components/Table.tsx
+++ b/frontend/beCompliant/src/components/Table.tsx
@@ -49,7 +49,6 @@ export function TableComponent({
     setColumnVisibility,
     unHideColumn,
     unHideColumns,
-    hasHiddenColumns,
     showOnlyFillModeColumns,
   ] = useColumnVisibility();
 
@@ -246,7 +245,6 @@ export function TableComponent({
         table={table}
         unHideColumn={unHideColumn}
         unHideColumns={unHideColumns}
-        hasHiddenColumns={hasHiddenColumns}
         showOnlyFillModeColumns={showOnlyFillModeColumns}
       />
     </>

--- a/frontend/beCompliant/src/components/table/DataTable.tsx
+++ b/frontend/beCompliant/src/components/table/DataTable.tsx
@@ -27,8 +27,7 @@ interface Props<TData> {
   table: TanstackTable<TData>;
   showSearch?: boolean;
   unHideColumn: (name: string) => void;
-  unHideColumns: () => void;
-  hasHiddenColumns?: boolean;
+  unHideColumns: (name: string[]) => void;
   showOnlyFillModeColumns: (name: string[]) => void;
 }
 
@@ -37,10 +36,8 @@ export function DataTable<TData>({
   showSearch = true,
   unHideColumn,
   unHideColumns,
-  hasHiddenColumns = false,
   showOnlyFillModeColumns,
 }: Props<TData>) {
-  const columnVisibility = table.getState().columnVisibility;
   const theme = useTheme();
   const headerNames = table.getAllColumns().map((column) => column.id);
 
@@ -48,12 +45,9 @@ export function DataTable<TData>({
     if (!isDetailViewChecked) {
       showOnlyFillModeColumns(headerNames);
     } else {
-      unHideColumns();
+      unHideColumns(headerNames);
     }
   };
-
-  console.log('HEADER', headerNames);
-  console.log('HEADER', table.getIsAllColumnsVisible());
 
   return (
     <TableStateProvider>
@@ -69,7 +63,9 @@ export function DataTable<TData>({
           marginRight="10"
         />
         <Flex
-          justifyContent={hasHiddenColumns ? 'space-between' : 'flex-end'}
+          justifyContent={
+            table.getIsAllColumnsVisible() ? 'flex-end' : 'space-between'
+          }
           alignItems="end"
           width="100%"
           paddingX="10"
@@ -83,7 +79,7 @@ export function DataTable<TData>({
                 <Button
                   aria-label={'Show all columns'}
                   onClick={() => {
-                    unHideColumns();
+                    unHideColumns(headerNames);
                   }}
                   colorScheme="blue"
                   size="xs"
@@ -93,23 +89,25 @@ export function DataTable<TData>({
                   </Text>
                 </Button>
                 <Divider height="5" orientation="vertical" />
-                {Object.entries(columnVisibility)
-                  .filter(([n, visible]) => !visible && headerNames.includes(n))
-                  .map(([name, _]) => (
-                    <Tag
-                      colorScheme="blue"
-                      variant="subtle"
-                      size="md"
-                      key={name}
-                    >
-                      <TagLabel>{name}</TagLabel>
-                      <TagCloseButton
-                        onClick={() => {
-                          unHideColumn(name);
-                        }}
-                      />
-                    </Tag>
-                  ))}
+
+                {table.getAllLeafColumns().map(
+                  (column) =>
+                    !column.getIsVisible() && (
+                      <Tag
+                        colorScheme="blue"
+                        variant="subtle"
+                        size="md"
+                        key={column.id}
+                      >
+                        <TagLabel>{column.id}</TagLabel>
+                        <TagCloseButton
+                          onClick={() => {
+                            unHideColumn(column.id);
+                          }}
+                        />
+                      </Tag>
+                    )
+                )}
               </Flex>
             </Flex>
           )}

--- a/frontend/beCompliant/src/components/table/DataTable.tsx
+++ b/frontend/beCompliant/src/components/table/DataTable.tsx
@@ -52,6 +52,9 @@ export function DataTable<TData>({
     }
   };
 
+  console.log('HEADER', headerNames);
+  console.log('HEADER', table.getIsAllColumnsVisible());
+
   return (
     <TableStateProvider>
       <Flex flexDirection="column" width="100%" gap="4">
@@ -71,7 +74,7 @@ export function DataTable<TData>({
           width="100%"
           paddingX="10"
         >
-          {hasHiddenColumns && (
+          {!table.getIsAllColumnsVisible() && (
             <Flex direction="column" gap="2">
               <Heading size="xs" fontWeight="semibold">
                 Skjulte kolonner
@@ -91,7 +94,7 @@ export function DataTable<TData>({
                 </Button>
                 <Divider height="5" orientation="vertical" />
                 {Object.entries(columnVisibility)
-                  .filter(([_, visible]) => !visible)
+                  .filter(([n, visible]) => !visible && headerNames.includes(n))
                   .map(([name, _]) => (
                     <Tag
                       colorScheme="blue"
@@ -103,11 +106,6 @@ export function DataTable<TData>({
                       <TagCloseButton
                         onClick={() => {
                           unHideColumn(name);
-                          const hiddenColumns = Object.entries(
-                            columnVisibility
-                          ).filter(([_, visible]) => !visible).length;
-                          if (hiddenColumns === 1) {
-                          }
                         }}
                       />
                     </Tag>
@@ -135,7 +133,7 @@ export function DataTable<TData>({
               <Switch
                 onChange={(e) => handleOnChange(e.target.checked)}
                 colorScheme="blue"
-                isChecked={!hasHiddenColumns}
+                isChecked={table.getIsAllColumnsVisible()}
               />
             </Flex>
             <Text

--- a/frontend/beCompliant/src/hooks/useColumnVisibility.ts
+++ b/frontend/beCompliant/src/hooks/useColumnVisibility.ts
@@ -6,10 +6,6 @@ export function useColumnVisibility() {
     Record<string, boolean>
   >('columnVisibility', {});
 
-  const hasHiddenColumns = Object.values(columnVisibility).some(
-    (value) => value === false
-  );
-
   const unHideColumn = (name: string) => {
     setColumnVisibility((prev: Record<string, boolean>) => ({
       ...prev,
@@ -24,9 +20,11 @@ export function useColumnVisibility() {
     }));
   };
 
-  const unHideColumns = () => {
-    Object.keys(columnVisibility).forEach((key) => {
-      unHideColumn(key);
+  const unHideColumns = (names: string[]) => {
+    names.forEach((name, i) => {
+      if (!FILLMODE_COLUMN_IDXS.includes(i)) {
+        unHideColumn(name);
+      }
     });
   };
 
@@ -41,15 +39,13 @@ export function useColumnVisibility() {
   const getShownColumns = (
     record: Record<string, boolean>,
     keysToCheck: string[]
-  ): string[] =>
-    keysToCheck.filter((key) => record[key] === true || !(key in record));
+  ): string[] => keysToCheck.filter((key) => record[key] || !(key in record));
 
   return [
     columnVisibility,
     setColumnVisibility,
     unHideColumn,
     unHideColumns,
-    hasHiddenColumns,
     showOnlyFillModeColumns,
     getShownColumns,
   ] as const;


### PR DESCRIPTION
## Background

Jobis toggle detaljert visning mellom skjema bugs. Viste seg at det ble kluss fordi sikkerhetsskjema fikk det andre skjematrtpen sine kolonner opp i "skjulte kolonner" og vica versa. 

## Solution

Slettet `hasHiddenColumns` og byttet den ut med `table.getIsAllColumnsVisible()` for å få riktig oppdatering av skjulte kolonner per skjema. i tilegg, isdet for å iterer over headers i local-storage variabelen burker jeg heller visiblecolumns. DeleteColumns måtte også oppderees slik at den ikkke satte alle headers i alle skjema til visible, men heller kun de som gjelder skjeamet man er inne i. 

Resolves #issue-this-pr-resolves
