### PR TITLE
fix comment and answer cleanup in database

### DIFF
--- a/backend/src/main/kotlin/no/bekk/Application.kt
+++ b/backend/src/main/kotlin/no/bekk/Application.kt
@@ -110,18 +110,11 @@ fun CoroutineScope.launchCleanupJob(): Job {
 
 fun cleanupAnswersHistory() {
     logger.info("Running scheduled cleanup for answers table")
-    val query = "WITH ranked_answers AS (\n" +
-            "    SELECT id, \n" +
-            "           record_id, \n" +
-            "           context_id, \n" +
-            "           created,\n" +
-            "           ROW_NUMBER() OVER (PARTITION BY record_id, context_id ORDER BY created DESC) AS rn\n" +
-            "    FROM answers\n" +
-            ")\n" +
-            "DELETE FROM answers\n" +
-            "USING ranked_answers\n" +
-            "WHERE answers.id = ranked_answers.id\n" +
-            "AND ranked_answers.rn > 1;"
+    val query = "WITH ranked_answers AS " +
+            "(SELECT id, record_id, context_id, created, ROW_NUMBER() OVER (PARTITION BY record_id, context_id ORDER BY created DESC) AS rn FROM answers) " +
+            "DELETE FROM answers " +
+            "USING ranked_answers " +
+            "WHERE answers.id = ranked_answers.id AND ranked_answers.rn > 3;"
 
     Database.getConnection().use { conn ->
         conn.prepareStatement(query).use { stmt ->

--- a/backend/src/main/kotlin/no/bekk/Application.kt
+++ b/backend/src/main/kotlin/no/bekk/Application.kt
@@ -6,9 +6,13 @@ import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.config.*
 import io.ktor.server.plugins.defaultheaders.*
+import kotlinx.coroutines.*
 import no.bekk.authentication.initializeAuthentication
 import no.bekk.configuration.*
 import no.bekk.util.configureBackgroundTasks
+import no.bekk.util.logger
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
 
 fun main(args: Array<String>) {
     io.ktor.server.netty.EngineMain.main(args)
@@ -80,6 +84,51 @@ private fun loadAppConfig(config: ApplicationConfig) {
         username = config.propertyOrNull("db.username")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"db.username\"")
         password = config.propertyOrNull("db.password")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"db.password\"")
     }
+
+    // Answer history cleanup config
+    AppConfig.answerHistoryCleanup = AnswerHistoryCleanupConfig.apply {
+        cleanupIntervalWeeks = config.propertyOrNull("answerHistoryCleanup.cleanupIntervalWeeks")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"answerHistoryCleanup.cleanupIntervalWeeks\"")
+    }
+}
+
+fun CoroutineScope.launchCleanupJob(): Job {
+    val cleanupIntervalWeeks = AppConfig.answerHistoryCleanup.cleanupIntervalWeeks.toInt()
+    val cleanupInterval: Duration = (cleanupIntervalWeeks * 7).days
+
+    return launch(Dispatchers.IO) {
+        while (isActive) {
+            try {
+                logger.info("Running scheduled cleanup every $cleanupIntervalWeeks weeks.")
+                cleanupAnswersHistory()
+            } catch (e: Exception) {
+                logger.error("Error during answers history cleanup: ${e.message}")
+            }
+            delay(cleanupInterval.inWholeMilliseconds)
+        }
+    }
+}
+
+fun cleanupAnswersHistory() {
+    logger.info("Running scheduled cleanup for answers table")
+    val query = "WITH ranked_answers AS (\n" +
+            "    SELECT id, \n" +
+            "           record_id, \n" +
+            "           context_id, \n" +
+            "           created,\n" +
+            "           ROW_NUMBER() OVER (PARTITION BY record_id, context_id ORDER BY created DESC) AS rn\n" +
+            "    FROM answers\n" +
+            ")\n" +
+            "DELETE FROM answers\n" +
+            "USING ranked_answers\n" +
+            "WHERE answers.id = ranked_answers.id\n" +
+            "AND ranked_answers.rn > 1;"
+
+    Database.getConnection().use { conn ->
+        conn.prepareStatement(query).use { stmt ->
+            val deletedRows = stmt.executeUpdate()
+            logger.info("Answer cleanup completed. Deleted $deletedRows rows.")
+        }
+    }
 }
 
 fun Application.module() {
@@ -99,6 +148,8 @@ fun Application.module() {
     initializeAuthentication()
     configureRouting()
     configureBackgroundTasks()
+
+    launchCleanupJob()
 
     environment.monitor.subscribe(ApplicationStopped) {
         Database.closePool()

--- a/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
+++ b/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
@@ -8,6 +8,7 @@ object AppConfig {
     lateinit var frontend: FrontendConfig
     lateinit var backend: BackendConfig
     lateinit var db: DbConfig
+    lateinit var answerHistoryCleanup: AnswerHistoryCleanupConfig
 }
 
 object FormConfig {
@@ -76,4 +77,8 @@ object DbConfig {
     lateinit var url: String
     lateinit var username: String
     lateinit var password: String
+}
+
+object AnswerHistoryCleanupConfig {
+    lateinit var cleanupIntervalWeeks: String
 }

--- a/backend/src/main/kotlin/no/bekk/database/CommentRepository.kt
+++ b/backend/src/main/kotlin/no/bekk/database/CommentRepository.kt
@@ -2,6 +2,7 @@ package no.bekk.database
 
 import no.bekk.configuration.Database
 import no.bekk.util.logger
+import java.sql.ResultSet
 import java.sql.SQLException
 import java.util.*
 
@@ -86,10 +87,9 @@ object CommentRepository {
             "You have to supply a contextId"
         }
 
-        logger.debug("Inserting answer into database: {}", comment)
-        try {
-
-            return insertCommentRow(comment)
+        logger.debug("Inserting comment into database: {}", comment)
+        return try {
+            insertCommentRow(comment)
         } catch (e: SQLException) {
             logger.error("Error inserting answer row into database: ${e.message}")
             throw RuntimeException("Error fetching answers from database", e)
@@ -101,46 +101,85 @@ object CommentRepository {
             "You have to supply a contextId"
         }
 
-        logger.debug("Inserting comment row into database: {}", comment)
+        logger.debug("Checking if comment exists for recordId={} and contextId={}", comment.recordId, comment.contextId)
 
-        val sqlStatement =
-            "INSERT INTO comments (actor, record_id, question_id, comment, context_id) VALUES (?, ?, ?, ?, ?) returning *"
+        val selectQuery = "SELECT * FROM comments WHERE record_id = ? AND context_id = ?"
+        val updateQuery = "UPDATE comments SET comment = ?, updated = NOW() WHERE context_id = ? AND record_id = ?"
+        val insertQuery = """
+        INSERT INTO comments (actor, record_id, question_id, comment, context_id) 
+        VALUES (?, ?, ?, ?, ?) 
+        RETURNING * 
+    """
 
         Database.getConnection().use { conn ->
-            conn.prepareStatement(sqlStatement).use { statement ->
+            conn.prepareStatement(selectQuery).use { statement ->
+                statement.setString(1, comment.recordId)
+                statement.setObject(2, UUID.fromString(comment.contextId))
+
+                val resultSet = statement.executeQuery()
+                if (resultSet.next()) {
+                    logger.debug(
+                        "Updating existing comment for recordId={} and contextId={}",
+                        comment.recordId,
+                        comment.contextId
+                    )
+                    conn.prepareStatement(updateQuery).use { updateStatement ->
+                        updateStatement.setString(1, comment.comment)
+                        updateStatement.setObject(2, UUID.fromString(comment.contextId))
+                        updateStatement.setString(3, comment.recordId)
+
+                        val updatedResult = updateStatement.executeUpdate()
+                        if (updatedResult > 0) {
+                            conn.prepareStatement(selectQuery).use { statement ->
+                                statement.setString(1, comment.recordId)
+                                statement.setObject(2, UUID.fromString(comment.contextId))
+                                val updatedResultSet = statement.executeQuery()
+                                if (updatedResultSet.next()) {
+                                    return mapResultSetToDatabaseComment(updatedResultSet)
+                                }
+                            }
+                        }
+                        throw RuntimeException("Error updating comment")
+                    }
+                }
+            }
+            logger.debug("Inserting comment row into database: {}", comment)
+            conn.prepareStatement(insertQuery).use { statement ->
                 statement.setString(1, comment.actor)
                 statement.setString(2, comment.recordId)
                 statement.setString(3, comment.questionId)
                 statement.setString(4, comment.comment)
                 statement.setObject(5, UUID.fromString(comment.contextId))
 
-                val result = statement.executeQuery()
-                if (result.next()) {
-                    return DatabaseComment(
-                        actor = result.getString("actor"),
-                        recordId = result.getString("record_id"),
-                        questionId = result.getString("question_id"),
-                        comment = result.getString("comment"),
-                        updated = result.getObject("updated", java.time.LocalDateTime::class.java).toString(),
-                        contextId = result.getString("context_id")
-                    )
-                } else {
-                    throw RuntimeException("Error inserting comments from database")
+                val insertedResult = statement.executeQuery()
+                if (insertedResult.next()) {
+                    return mapResultSetToDatabaseComment(insertedResult)
                 }
+                throw RuntimeException("Error inserting comment into database")
             }
         }
     }
 
-    fun deleteCommentFromDatabase(comment: DatabaseComment) {
-        logger.debug("Deleting comment from database: {}", comment)
-        insertCommentRow(
-            DatabaseCommentRequest(
-                comment.actor,
-                comment.recordId,
-                comment.questionId,
-                "",
-                comment.contextId
-            )
+    private fun mapResultSetToDatabaseComment(resultSet: ResultSet): DatabaseComment {
+        return DatabaseComment(
+            actor = resultSet.getString("actor"),
+            recordId = resultSet.getString("record_id"),
+            questionId = resultSet.getString("question_id"),
+            comment = resultSet.getString("comment"),
+            updated = resultSet.getObject("updated", java.time.LocalDateTime::class.java).toString(),
+            contextId = resultSet.getString("context_id")
         )
+    }
+
+    fun deleteCommentFromDatabase(contextId: String, recordId: String): Boolean {
+        logger.debug("Deleting comment from database with recordId: $recordId and contextId: $contextId")
+        val query = "DELETE FROM comments WHERE context_id = ? AND record_id = ?"
+        Database.getConnection().use { conn ->
+            conn.prepareStatement(query).use { statement ->
+                statement.setObject(1, UUID.fromString(contextId))
+                statement.setString(2, recordId)
+                return statement.executeUpdate() > 0
+            }
+        }
     }
 }

--- a/backend/src/main/kotlin/no/bekk/database/CommentRepository.kt
+++ b/backend/src/main/kotlin/no/bekk/database/CommentRepository.kt
@@ -103,7 +103,7 @@ object CommentRepository {
 
         logger.debug("Checking if comment exists for recordId={} and contextId={}", comment.recordId, comment.contextId)
 
-        val insertQuery = """
+        val upsertQuery = """
         INSERT INTO comments (actor, record_id, question_id, comment, context_id) 
         VALUES (?, ?, ?, ?, ?) 
         ON CONFLICT (context_id, record_id) DO UPDATE SET updated = NOW(), comment = ?

--- a/backend/src/main/kotlin/no/bekk/database/CommentRepository.kt
+++ b/backend/src/main/kotlin/no/bekk/database/CommentRepository.kt
@@ -111,7 +111,7 @@ object CommentRepository {
     """
 
         Database.getConnection().use { conn ->
-            logger.debug("Inserting comment row into database: {}", comment)
+            logger.debug("Inserting or updating comment row into database: {}", comment)
             conn.prepareStatement(insertQuery).use { statement ->
                 statement.setString(1, comment.actor)
                 statement.setString(2, comment.recordId)

--- a/backend/src/main/kotlin/no/bekk/database/CommentRepository.kt
+++ b/backend/src/main/kotlin/no/bekk/database/CommentRepository.kt
@@ -101,7 +101,7 @@ object CommentRepository {
             "You have to supply a contextId"
         }
 
-        logger.debug("Checking if comment exists for recordId={} and contextId={}", comment.recordId, comment.contextId)
+        logger.debug("Inserting or updating comment for recordId={} and contextId={}", comment.recordId, comment.contextId)
 
         val upsertQuery = """
         INSERT INTO comments (actor, record_id, question_id, comment, context_id) 

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -68,3 +68,6 @@ db:
   url: "$DB_URL:jdbc:postgresql://localhost:5432/regelrett"
   username: "$DB_NAME:postgres"
   password: "$DB_PASSWORD:pwd"
+
+answerHistoryCleanup:
+  cleanupIntervalWeeks: "4"

--- a/backend/src/main/resources/db/migration/V13__add_comments_constraint.sql
+++ b/backend/src/main/resources/db/migration/V13__add_comments_constraint.sql
@@ -1,0 +1,16 @@
+DELETE FROM comments
+WHERE id IN (
+    SELECT id
+    FROM (
+             SELECT id,
+                    record_id,
+                    context_id,
+                    created,
+                    ROW_NUMBER() OVER (PARTITION BY record_id, context_id ORDER BY created DESC) AS rn
+             FROM comments
+         ) AS duplicates
+    WHERE rn > 1
+);
+
+ALTER TABLE comments
+    ADD CONSTRAINT unique_comments UNIQUE (record_id, context_id)

--- a/frontend/beCompliant/src/components/questionPage/QuestionComment.tsx
+++ b/frontend/beCompliant/src/components/questionPage/QuestionComment.tsx
@@ -158,12 +158,8 @@ export function QuestionComment({
             onOpen={onDeleteOpen}
             onClose={onDeleteClose}
             isOpen={isDeleteOpen}
-            comment={latestComment ?? ''}
-            questionId={question.id}
             recordId={question.recordId}
             contextId={contextId}
-            setEditMode={setIsEditing}
-            user={user}
           />
         </>
       )}

--- a/frontend/beCompliant/src/components/table/Comment.tsx
+++ b/frontend/beCompliant/src/components/table/Comment.tsx
@@ -186,13 +186,8 @@ export function Comment({
         onOpen={onDeleteOpen}
         onClose={onDeleteClose}
         isOpen={isDeleteOpen}
-        comment={comment}
-        questionId={questionId}
         recordId={recordId}
         contextId={contextId}
-        setEditMode={setIsEditing}
-        setCommentDeleted={setCommentDeleted}
-        user={user}
       />
     </>
   );

--- a/frontend/beCompliant/src/components/table/DeleteCommentModal.tsx
+++ b/frontend/beCompliant/src/components/table/DeleteCommentModal.tsx
@@ -10,54 +10,26 @@ import {
   Stack,
   Text,
 } from '@kvib/react';
-import { User } from '../../api/types';
 import { useDeleteComment } from '../../hooks/useComments';
 
 type Props = {
   onOpen: () => void;
   onClose: () => void;
   isOpen: boolean;
-  comment: string;
-  questionId: string;
   recordId: string;
   contextId: string;
-  setEditMode: (value: boolean) => void;
-  setCommentDeleted?: (deleted: boolean) => void;
-  user: User;
 };
 export function DeleteCommentModal({
   onClose,
   isOpen,
-  comment,
-  questionId,
   recordId,
   contextId,
-  setEditMode,
-  setCommentDeleted,
-  user,
 }: Props) {
-  const handleDeleteSuccess = () => {
-    setEditMode(false);
-    setCommentDeleted?.(true);
-    onClose();
-  };
-
   const { mutate: deleteComment, isPending: isLoading } = useDeleteComment(
     contextId,
     recordId,
-    handleDeleteSuccess
+    onClose
   );
-
-  const handleCommentDelete = async () => {
-    deleteComment({
-      actor: user.id,
-      recordId: recordId,
-      questionId: questionId,
-      comment: comment,
-      contextId,
-      updated: new Date(),
-    });
-  };
 
   return (
     <Modal onClose={onClose} isOpen={isOpen} isCentered>
@@ -79,7 +51,7 @@ export function DeleteCommentModal({
               variant="primary"
               colorScheme="red"
               leftIcon="delete"
-              onClick={handleCommentDelete}
+              onClick={() => deleteComment()}
               isLoading={isLoading}
             >
               Slett kommentar

--- a/frontend/beCompliant/src/hooks/useComments.ts
+++ b/frontend/beCompliant/src/hooks/useComments.ts
@@ -50,16 +50,18 @@ export function useDeleteComment(
 
   return useMutation({
     mutationKey: apiConfig.comments.queryKey(contextId, recordId),
-    mutationFn: (body: Comment) => {
+    mutationFn: () => {
       return axiosFetch({
         url: URL,
         method: 'DELETE',
-        data: JSON.stringify(body),
       });
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: apiConfig.comments.queryKey(contextId, recordId),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: apiConfig.comments.queryKey(contextId),
       });
       onSuccess();
     },


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 
- Faktisk fjerne data og ikke bare la det bli liggende i DB

**Løsning**

🆕 Endring: 
- Kommentarer blir faktisk slettet når de slettes i UI (før ble bare en tom rad lagt til i DB)
- Hvis en kommentar endres så endres comment-kolonnen på den samme raden i DB (Før ble en ny rad lagt til i DB)
- Lagt til en cleanup job som sletter svar hver 4. uke (kan konfigureres), da slettes alle svar bortsett fra de 3 nyeste. Den ser på context_id og record_id for å ta hensyn til både skjemautfyllingen og spørsmålet.

**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*
Kan kjøre opp lokalt og se at DB endringene blir riktig

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?
Tror ikke dette er relevant

Resolves #629
