### PR TITLE
remove unused schema migration endpoint

### DIFF
--- a/backend/src/main/kotlin/no/bekk/database/ContextRepository.kt
+++ b/backend/src/main/kotlin/no/bekk/database/ContextRepository.kt
@@ -5,7 +5,6 @@ import no.bekk.configuration.Database
 import java.util.*
 import java.sql.SQLException
 
-
 object ContextRepository {
     fun insertContext(context: DatabaseContextRequest): DatabaseContext {
         val sqlStatement =
@@ -39,8 +38,6 @@ object ContextRepository {
             }
         }
     }
-
-
 
     fun getContextsByTeamId(teamId: String): List<DatabaseContext> {
         val sqlStatement = "SELECT * FROM contexts WHERE team_id = ?"
@@ -108,22 +105,6 @@ object ContextRepository {
                     )
                 } else {
                     throw NotFoundException("Context with id $id not found")
-                }
-            }
-        }
-    }
-
-    //This can be removed after schemas in frisk are migrated to new metadata
-    fun getContextTableId(id: String): String {
-        val sqlStatement = "SELECT table_id FROM contexts WHERE id = ?"
-        Database.getConnection().use { conn ->
-            conn.prepareStatement(sqlStatement).use { statement ->
-                statement.setObject(1, UUID.fromString(id))
-                val result = statement.executeQuery()
-                if (result.next()) {
-                    return result.getString("table_id")
-                } else {
-                    throw RuntimeException("Error getting table_id for this context")
                 }
             }
         }

--- a/backend/src/main/kotlin/no/bekk/plugins/Routing.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/Routing.kt
@@ -3,13 +3,10 @@ package no.bekk.plugins
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
-import io.ktor.server.plugins.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import no.bekk.database.ContextRepository
 import no.bekk.routes.*
 import no.bekk.services.FormService
-import no.bekk.util.logger
 
 fun Application.configureRouting() {
 
@@ -27,15 +24,6 @@ fun Application.configureRouting() {
                 it.getSchema()
             }
             call.respond(schemas)
-        }
-
-        //This endpoint can be removed after schemas in frisk are migrated to new metadata
-        get("/contexts/{contextId}/tableId") {
-            logger.debug("Received GET /contexts/{contextId}/tableId with id: ${call.parameters["contextId"]}")
-            val contextId = call.parameters["contextId"] ?: throw BadRequestException("Missing contextId")
-            val tableId = ContextRepository.getContextTableId(contextId);
-            call.respond(HttpStatusCode.OK, tableId)
-            return@get
         }
 
         authenticate("auth-jwt") {


### PR DESCRIPTION
OBS: kan merges etter at PR 109 i FRISK er merged
**Beskrivelse**

🥅 Mål med PRen:
Fjerne endepunktet som ble brukt til skjema-metadata migrering i Frisk

**Løsning**

🆕 Endring: 
slettet endepunktet

**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?

Resolves #637 
