### PR TITLE
remove submit comment with shift return

### DIFF
--- a/frontend/beCompliant/src/components/questionPage/QuestionComment.tsx
+++ b/frontend/beCompliant/src/components/questionPage/QuestionComment.tsx
@@ -76,10 +76,6 @@ export function QuestionComment({
     if (event.key === 'Escape') {
       handleDiscardChanges();
     }
-
-    if (event.key === 'Enter' && event.shiftKey) {
-      handleCommentSubmit();
-    }
   };
 
   return (

--- a/frontend/beCompliant/src/components/table/Comment.tsx
+++ b/frontend/beCompliant/src/components/table/Comment.tsx
@@ -78,10 +78,6 @@ export function Comment({
     if (event.key === 'Escape') {
       handleDiscardChanges();
     }
-
-    if (event.key === 'Enter' && event.shiftKey) {
-      handleCommentSubmit();
-    }
   };
 
   if (isEditMode) {


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 
Shift + return i kommentarfelt submittet kommentaren. Fra tilbakemeldinger var det ønsket at det heller skulle være en soft return.

**Løsning**

🆕 Endring: 
Fjernet fra handleKeyDown() i kommentar-komponentene

**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?

Resolves #620 
