### PR TITLE
fix querykey in useFetchUsername

### DIFF
--- a/frontend/beCompliant/src/api/apiConfig.ts
+++ b/frontend/beCompliant/src/api/apiConfig.ts
@@ -74,7 +74,7 @@ export const apiConfig = {
     url: API_URL_USERINFO,
   },
   username: {
-    queryKey: () => [PATH_USERNAME],
+    queryKey: (userId: string) => [PATH_USERNAME, userId],
     url: (userId: string) =>
       `${API_URL_BASE}${PATH_USERINFO}/${userId}${PATH_USERNAME}`,
   },

--- a/frontend/beCompliant/src/hooks/useUser.ts
+++ b/frontend/beCompliant/src/hooks/useUser.ts
@@ -26,7 +26,7 @@ export const useUser = () => {
 
 export function useFetchUsername(userId: string) {
   return useQuery({
-    queryKey: apiConfig.username.queryKey(),
+    queryKey: apiConfig.username.queryKey(userId),
     queryFn: () =>
       axiosFetch<string>({
         url: apiConfig.username.url(userId),


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 
QueryKey til å fetche usename manglet userId som førte til at den bare hentet fra cache i stedet for å hente username når userId endret seg

**Løsning**

🆕 Endring: 
La til userId i querykey'en

**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?

Resolves #issue-this-pr-resolves
