### PR TITLE
Improve team change in settings modal

### DIFF
--- a/frontend/beCompliant/src/components/table/SettingsModal.tsx
+++ b/frontend/beCompliant/src/components/table/SettingsModal.tsx
@@ -77,17 +77,15 @@ export function SettingsModal({ onClose, isOpen, currentTeamName }: Props) {
     },
   });
 
-  const handleTeamSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleTeamSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!contextId) return;
 
-    const newTeam = (
-      e.currentTarget.elements.namedItem('editTeam') as HTMLSelectElement
-    )?.value;
+    const newTeam = new FormData(e.currentTarget).get('editTeam');
 
     if (!newTeam) return;
 
-    teamSubmitMutation.mutate(newTeam);
+    teamSubmitMutation.mutate(newTeam as string);
   };
 
   const handleCopySubmit = async (e: React.FormEvent<HTMLFormElement>) => {

--- a/frontend/beCompliant/src/pages/ActivityPage.tsx
+++ b/frontend/beCompliant/src/pages/ActivityPage.tsx
@@ -5,6 +5,7 @@ import {
   Heading,
   IconButton,
   Skeleton,
+  Text,
   useDisclosure,
 } from '@kvib/react';
 import { useParams, useSearchParams } from 'react-router-dom';
@@ -170,6 +171,10 @@ export const ActivityPage = () => {
       record.metadata?.answerMetadata?.type === AnswerType.SELECT_SINGLE
   );
 
+  const teamName = userinfo?.groups.find(
+    (team) => team.id === context?.teamId
+  )?.displayName;
+
   return (
     <Page>
       <Flex flexDirection="column" marginX="10" gap="2">
@@ -185,6 +190,11 @@ export const ActivityPage = () => {
               onClick={() => onSettingsOpen()}
             />
           </Flex>
+        </Skeleton>
+        <Skeleton isLoaded={!contextIsPending && !userinfoIsPending} fitContent>
+          <Text fontSize="xl" fontWeight="600" pb="7">
+            Team: {teamName}{' '}
+          </Text>
         </Skeleton>
         <Skeleton
           isLoaded={!tableIsPending && !answerIsPending && !commentIsPending}
@@ -235,6 +245,7 @@ export const ActivityPage = () => {
         onOpen={onSettingsOpen}
         onClose={onSettingsClose}
         isOpen={isSettingsOpen}
+        currentTeamName={teamName}
       />
     </Page>
   );


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen:
Tydeligere tilbakemelding til brukeren når team på skjema skal endres.

**Løsning**

🆕 Endring:
- La til teamet til skjemautfyllingen øverst på siden
- La til teamnavn i redigeringsboksen
- Endret feilmeldingen fra toast til rød border + tekst under dersom brukeren skriver inn feil teamnavn
- Modalen lukkes og en toast dukker opp hvis teamet endres
- Småendringer på tekst i redigeringsboksen fra skissene

![image](https://github.com/user-attachments/assets/6802c472-e86a-469d-aa8a-b976d4814db5)

![image](https://github.com/user-attachments/assets/24ff17fa-d9f0-491e-816e-3156607f47f0)

**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?

Resolves #650 
