### PR TITLE
some layout changes

### DIFF
--- a/frontend/beCompliant/src/components/CSVDownload.tsx
+++ b/frontend/beCompliant/src/components/CSVDownload.tsx
@@ -45,6 +45,7 @@ export function CSVDownload({ rows, headerArray, ...rest }: Props) {
       as="a"
       href={url}
       download="table_data.csv"
+      leftIcon="download"
       width="fit-content"
       {...rest}
     >

--- a/frontend/beCompliant/src/components/Table.tsx
+++ b/frontend/beCompliant/src/components/Table.tsx
@@ -241,7 +241,7 @@ export function TableComponent({
       <Flex
         justifyContent="space-between"
         alignItems="center"
-        pl="10"
+        px="10"
         flexWrap="wrap"
       >
         <DataTableSearch table={table} />

--- a/frontend/beCompliant/src/components/Table.tsx
+++ b/frontend/beCompliant/src/components/Table.tsx
@@ -22,8 +22,10 @@ import { getSortFuncForColumn } from './table/TableSort';
 import { TableActions } from './tableActions/TableActions';
 import { TableFilters } from './tableActions/TableFilter';
 import { useEffect, useState } from 'react';
-import { IconButton, Tooltip } from '@kvib/react';
+import { Flex, IconButton, Tooltip } from '@kvib/react';
 import { useNavigate } from 'react-router-dom';
+import { DataTableSearch } from './table/DataTableSearch';
+import { CSVDownload } from './CSVDownload';
 
 type Props = {
   filters: TableFilters;
@@ -232,8 +234,27 @@ export function TableComponent({
     },
   });
 
+  const headerNames = table.getAllColumns().map((column) => column.id);
+
   return (
     <>
+      <Flex
+        justifyContent="space-between"
+        alignItems="center"
+        pl="10"
+        flexWrap="wrap"
+      >
+        <DataTableSearch table={table} />
+        <CSVDownload
+          rows={
+            table
+              .getFilteredRowModel()
+              .rows.map((row) => row.original) as Question[]
+          }
+          headerArray={headerNames}
+          alignSelf="flex-end"
+        />
+      </Flex>
       <TableActions
         resetTable={table.reset}
         filters={filters}

--- a/frontend/beCompliant/src/components/table/DataTable.tsx
+++ b/frontend/beCompliant/src/components/table/DataTable.tsx
@@ -13,19 +13,14 @@ import {
   Text,
   Thead,
   Tr,
-  useTheme,
 } from '@kvib/react';
 import { Table as TanstackTable, flexRender } from '@tanstack/react-table';
 import React from 'react';
-import { Question } from '../../api/types';
-import { CSVDownload } from '../CSVDownload';
-import { DataTableSearch } from './DataTableSearch';
 import { PaginationButtonContainer } from './pagination/PaginationButtonContainer';
 import { TableStateProvider } from './TableState';
 
 interface Props<TData> {
   table: TanstackTable<TData>;
-  showSearch?: boolean;
   unHideColumn: (name: string) => void;
   unHideColumns: (name: string[]) => void;
   showOnlyFillModeColumns: (name: string[]) => void;
@@ -33,12 +28,10 @@ interface Props<TData> {
 
 export function DataTable<TData>({
   table,
-  showSearch = true,
   unHideColumn,
   unHideColumns,
   showOnlyFillModeColumns,
 }: Props<TData>) {
-  const theme = useTheme();
   const headerNames = table.getAllColumns().map((column) => column.id);
 
   const handleOnChange = (isDetailViewChecked: boolean) => {
@@ -52,23 +45,13 @@ export function DataTable<TData>({
   return (
     <TableStateProvider>
       <Flex flexDirection="column" width="100%" gap="4">
-        <CSVDownload
-          rows={
-            table
-              .getFilteredRowModel()
-              .rows.map((row) => row.original) as Question[]
-          }
-          headerArray={headerNames}
-          alignSelf="flex-end"
-          marginRight="10"
-        />
         <Flex
           justifyContent={
             table.getIsAllColumnsVisible() ? 'flex-end' : 'space-between'
           }
           alignItems="end"
           width="100%"
-          paddingX="10"
+          pl="10"
         >
           {!table.getIsAllColumnsVisible() && (
             <Flex direction="column" gap="2">
@@ -111,38 +94,15 @@ export function DataTable<TData>({
               </Flex>
             </Flex>
           )}
-          <Flex alignItems="center" gap={3}>
-            <Flex
-              alignItems="center"
-              flexDirection="row"
-              backgroundColor={theme.colors.blue[50]}
-              padding={4}
-              borderRadius="5px"
-              maxHeight="28px"
-            >
-              <Text
-                fontWeight="bold"
-                marginRight="15px"
-                color={theme.colors.gray[700]}
-                w="130px"
-              >
-                Detaljert visning
-              </Text>
-              <Switch
-                onChange={(e) => handleOnChange(e.target.checked)}
-                colorScheme="blue"
-                isChecked={table.getIsAllColumnsVisible()}
-              />
-            </Flex>
-            <Text
-              maxWidth="350px"
-              fontSize="small"
-              color={theme.colors.gray[500]}
-            >
-              Skru av for å kun vise essensielle kolonner for en ryddigere
-              visning
+          <Flex alignItems="center" flexDirection="row">
+            <Text fontWeight="bold" marginRight="15px" w="130px">
+              Vis alle kolonner
             </Text>
-            {showSearch && <DataTableSearch table={table} />}
+            <Switch
+              onChange={(e) => handleOnChange(e.target.checked)}
+              colorScheme="blue"
+              isChecked={table.getIsAllColumnsVisible()}
+            />
           </Flex>
         </Flex>
         <TableContainer backgroundColor="white" paddingX="3">

--- a/frontend/beCompliant/src/components/table/DataTable.tsx
+++ b/frontend/beCompliant/src/components/table/DataTable.tsx
@@ -51,7 +51,7 @@ export function DataTable<TData>({
           }
           alignItems="end"
           width="100%"
-          pl="10"
+          px="10"
         >
           {!table.getIsAllColumnsVisible() && (
             <Flex direction="column" gap="2">

--- a/frontend/beCompliant/src/components/table/DataTableSearch.tsx
+++ b/frontend/beCompliant/src/components/table/DataTableSearch.tsx
@@ -23,13 +23,13 @@ export function DataTableSearch<TData>({ table, ...rest }: Props<TData>) {
   }, [debouncedValue]);
 
   return (
-    <InputGroup maxWidth="18rem" background="white" {...rest}>
+    <InputGroup maxWidth="26rem" background="white" {...rest}>
       <InputLeftElement margin={-1}>
         <Icon icon="search" size={16} />
       </InputLeftElement>
       <Input
         value={value ?? ''}
-        placeholder="Søk her..."
+        placeholder="Søk i tabellen"
         aria-label="Søk i tabell"
         type="search"
         onChange={(event) => setValue(event.target.value)}

--- a/frontend/beCompliant/src/pages/ActivityPage.tsx
+++ b/frontend/beCompliant/src/pages/ActivityPage.tsx
@@ -177,41 +177,36 @@ export const ActivityPage = () => {
 
   return (
     <Page>
-      <Flex flexDirection="column" marginX="10" gap="2">
-        <Skeleton isLoaded={!contextIsPending && !tableIsPending} fitContent>
-          <Flex>
-            <Heading lineHeight="1.2">{`${context?.name} - ${tableData?.name}`}</Heading>
-            <IconButton
-              variant="ghost"
-              icon="settings"
-              size="lg"
-              aria-label="Edit context"
-              colorScheme="blue"
-              onClick={() => onSettingsOpen()}
-            />
-          </Flex>
-        </Skeleton>
-        <Skeleton isLoaded={!contextIsPending && !userinfoIsPending} fitContent>
-          <Text fontSize="xl" fontWeight="600" pb="7">
-            Team: {teamName}{' '}
-          </Text>
-        </Skeleton>
-        <Skeleton
-          isLoaded={!tableIsPending && !answerIsPending && !commentIsPending}
-          fitContent
-        >
-          <TableStatistics filteredData={filteredData} />
-        </Skeleton>
-      </Flex>
-      <Box width="100%" paddingX="10">
-        <Divider borderColor="gray.400" />
-      </Box>
-      <Box
-        minH="100vh"
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-      >
+      <Flex flexDirection="column" maxW="100%" alignSelf="center" gap="8">
+        <Flex flexDirection="column" gap="2" px="10">
+          <Skeleton isLoaded={!contextIsPending && !tableIsPending} fitContent>
+            <Flex>
+              <Heading lineHeight="1.2">{`${context?.name} - ${tableData?.name}`}</Heading>
+              <IconButton
+                variant="ghost"
+                icon="settings"
+                size="lg"
+                aria-label="Edit context"
+                colorScheme="blue"
+                onClick={() => onSettingsOpen()}
+              />
+            </Flex>
+          </Skeleton>
+            <Skeleton isLoaded={!contextIsPending && !userinfoIsPending} fitContent>
+                <Text fontSize="xl" fontWeight="600" pb="7">
+                    Team: {teamName}{' '}
+                </Text>
+            </Skeleton>
+          <Skeleton
+            isLoaded={!tableIsPending && !answerIsPending && !commentIsPending}
+            fitContent
+          >
+            <TableStatistics filteredData={filteredData} />
+          </Skeleton>
+        </Flex>
+        <Box width="100%" paddingX="10">
+          <Divider borderColor="gray.400" />
+        </Box>
         <Skeleton
           isLoaded={
             !tableIsPending &&
@@ -240,13 +235,13 @@ export const ActivityPage = () => {
               />
             )}
         </Skeleton>
-      </Box>
-      <SettingsModal
-        onOpen={onSettingsOpen}
-        onClose={onSettingsClose}
-        isOpen={isSettingsOpen}
-        currentTeamName={teamName}
-      />
+        <SettingsModal
+          onOpen={onSettingsOpen}
+          onClose={onSettingsClose}
+          isOpen={isSettingsOpen}
+          currentTeamName={teamName}
+        />
+      </Flex>
     </Page>
   );
 };

--- a/frontend/beCompliant/src/pages/ActivityPage.tsx
+++ b/frontend/beCompliant/src/pages/ActivityPage.tsx
@@ -192,11 +192,14 @@ export const ActivityPage = () => {
               />
             </Flex>
           </Skeleton>
-            <Skeleton isLoaded={!contextIsPending && !userinfoIsPending} fitContent>
-                <Text fontSize="xl" fontWeight="600" pb="7">
-                    Team: {teamName}{' '}
-                </Text>
-            </Skeleton>
+          <Skeleton
+            isLoaded={!contextIsPending && !userinfoIsPending}
+            fitContent
+          >
+            <Text fontSize="xl" fontWeight="600" pb="7">
+              Team: {teamName}{' '}
+            </Text>
+          </Skeleton>
           <Skeleton
             isLoaded={!tableIsPending && !answerIsPending && !commentIsPending}
             fitContent


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen:
Fikse litt opp i layouten på skjemautfylling etter skissene til Magnus

**Løsning**

🆕 Endring: 
- Lagt til ikon på “last ned CSV”-knappen
- Nytt design på detaljert visning-switch. Forenklet med beskrivelsen "Vis alle kolonner"
- Flytte søkefelt over filtre, og legge til label “Søk i tabell”
- Overskriften og progress-sirkelen er nå på samme linje som innholdet under divideren

Før:
![image](https://github.com/user-attachments/assets/e3bd0be9-d4cf-494f-8b7a-c6bae7a2a869)

Etter:
![image](https://github.com/user-attachments/assets/90e4f3ad-92c3-4aad-987e-0fd548582f71)

**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?

Resolves #648 
