### PR TITLE
Upgrade libxml2 to fix vulnerabilities

### DIFF
--- a/frontend/beCompliant/Dockerfile
+++ b/frontend/beCompliant/Dockerfile
@@ -1,5 +1,9 @@
 FROM nginx:alpine
 
+# Update to exact version to keep image "mostly" stable
+# Can be removed once nginx:alpine is updated
+RUN apk upgrade libxml2=2.12.7-r2
+
 COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
 
 COPY ./dist /usr/share/nginx/html/


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: Bumper libxml2 for å fikse sårbarheter oppdaga av Pharos

**Løsning**

🆕 Endring: Oppdaterer libxml2 til spesifikk versjon med fix for de oppdaga sårbarhetene. Pinner image for å holde image litt mer stabilt, slik at den ikke plutselig oppdaterer libxml2 til noe helt annet uten at vi velger det.

**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?
