### PR TITLE
limit cors and start refactoring from singleton

### DIFF
--- a/.github/workflows/build-deploy-backend-gcp.yml
+++ b/.github/workflows/build-deploy-backend-gcp.yml
@@ -30,6 +30,7 @@ env:
   FRONTEND_URL_HOST: regelrett-frontend-1024826672490.europe-north1.run.app
   SIKKERHETSKONTROLLER_WEBHOOK_ID: "ach2vlnWcdxY8Cl3k"
   DRIFTSKONTINUITET_WEBHOOK_ID: "achCxVfK6DaWMhchX"
+  ALLOWED_CORS_HOSTS: "regelrett-frontend-1024826672490.europe-north1.run.app,frisk-frontend.fly.dev,localhost:5173"
 
 jobs:
   build-and-push:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,4 +8,5 @@ RUN adduser -D user && chown -R user /app
 WORKDIR .
 COPY build/libs/*.jar /app/regelrett.jar
 USER user
+ENV ALLOWED_CORS_HOSTS="regelrett.atgcp1-dev.kartverket-intern.cloud,regelrett.atgcp1-prod.kartverket-intern.cloud,frisk.atgcp1-dev.kartverket-intern.cloud,frisk.atgcp1-prod.kartverket-intern.cloud"
 ENTRYPOINT ["java", "-Duser.timezone=Europe/Oslo", "-jar", "/app/regelrett.jar"]

--- a/backend/src/main/kotlin/no/bekk/Application.kt
+++ b/backend/src/main/kotlin/no/bekk/Application.kt
@@ -4,11 +4,12 @@ import no.bekk.plugins.*
 import io.ktor.server.application.*
 import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.serialization.kotlinx.json.*
-import io.ktor.server.config.*
 import io.ktor.server.plugins.defaultheaders.*
 import kotlinx.coroutines.*
 import no.bekk.authentication.initializeAuthentication
 import no.bekk.configuration.*
+import no.bekk.services.FormService
+import no.bekk.services.MicrosoftService
 import no.bekk.util.configureBackgroundTasks
 import no.bekk.util.logger
 import kotlin.time.Duration
@@ -18,82 +19,8 @@ fun main(args: Array<String>) {
     io.ktor.server.netty.EngineMain.main(args)
 }
 
-private fun loadAppConfig(config: ApplicationConfig) {
-
-    AppConfig.formConfig = FormConfig.apply {
-        airTable = AirTableConfig.apply {
-            baseUrl = config.propertyOrNull("airTable.baseUrl")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"airTable.baseUrl\"")
-        }
-
-        forms = config.configList("forms").map { table ->
-
-            when (table.propertyOrNull("type")?.getString()) {
-                "AIRTABLE" -> AirTableInstanceConfig(
-                id = table.propertyOrNull("id")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"id\""),
-                accessToken = table.propertyOrNull("accessToken")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"accessToken\""),
-                baseId = table.propertyOrNull("baseId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"baseId\""),
-                tableId = table.propertyOrNull("tableId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"tableId\""),
-                viewId = table.propertyOrNull("viewId")?.getString(),
-                webhookId = table.propertyOrNull("webhookId")?.getString(),
-                webhookSecret = table.propertyOrNull("webhookSecret")?.getString(),
-            )
-                "YAML" -> YAMLInstanceConfig(
-                    id = table.propertyOrNull("id")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"id\""),
-                    endpoint = table.propertyOrNull("endpoint")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"baseId\""),
-                    resourcePath = table.propertyOrNull("resourcePath")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"tableId\""),
-                )
-                else -> throw IllegalStateException("Illegal type \"type\"")
-
-            }
-
-        }
-    }
-
-    // MicrosoftGraph config
-    AppConfig.microsoftGraph = MicrosoftGraphConfig.apply {
-        baseUrl = config.propertyOrNull("microsoftGraph.baseUrl")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"microsoftGraph.baseUrl\"")
-        memberOfPath = config.propertyOrNull("microsoftGraph.memberOfPath")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"microsoftGraph.memberOfPath\"")
-    }
-
-    // OAuth config
-    AppConfig.oAuth = OAuthConfig.apply {
-        baseUrl = config.propertyOrNull("oAuth.baseUrl")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"oAuth.baseurl\"")
-        tenantId = config.propertyOrNull("oAuth.tenantId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"oAuth.tenantId\"")
-        issuerPath = config.propertyOrNull("oAuth.issuerPath")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"oAuth.issuerPath\"")
-        authPath = config.propertyOrNull("oAuth.authPath")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"oAuth.authPath\"")
-        tokenPath = config.propertyOrNull("oAuth.tokenPath")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"oAuth.tokenPath\"")
-        jwksPath = config.propertyOrNull("oAuth.jwksPath")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"oAuth.jwksPath\"")
-        clientId = config.propertyOrNull("oAuth.clientId")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"oAuth.clientId\"")
-        clientSecret = config.propertyOrNull("oAuth.clientSecret")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"oAuth.clientSecret\"")
-        providerUrl = config.propertyOrNull("oAuth.providerUrl")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"oAuth.providerUrl\"")
-        superUserGroup = config.propertyOrNull("oAuth.superUserGroup")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"oAuth.superUserGroup\"")
-    }
-
-    // Frontend config
-    AppConfig.frontend = FrontendConfig.apply {
-        host = config.propertyOrNull("frontend.host")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"frontend.host\"")
-    }
-
-    AppConfig.backend = BackendConfig.apply {
-        host = config.propertyOrNull("backend.host")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"backend.host\"")
-    }
-
-    // Db config
-    AppConfig.db = DbConfig.apply {
-        url = config.propertyOrNull("db.url")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"db.url\"")
-        username = config.propertyOrNull("db.username")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"db.username\"")
-        password = config.propertyOrNull("db.password")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"db.password\"")
-    }
-
-    // Answer history cleanup config
-    AppConfig.answerHistoryCleanup = AnswerHistoryCleanupConfig.apply {
-        cleanupIntervalWeeks = config.propertyOrNull("answerHistoryCleanup.cleanupIntervalWeeks")?.getString() ?: throw IllegalStateException("Unable to initialize app config \"answerHistoryCleanup.cleanupIntervalWeeks\"")
-    }
-}
-
-fun CoroutineScope.launchCleanupJob(): Job {
-    val cleanupIntervalWeeks = AppConfig.answerHistoryCleanup.cleanupIntervalWeeks.toInt()
-    val cleanupInterval: Duration = (cleanupIntervalWeeks * 7).days
+fun CoroutineScope.launchCleanupJob(cleanupIntervalWeeks: String): Job {
+    val cleanupInterval: Duration = (cleanupIntervalWeeks.toInt() * 7).days
 
     return launch(Dispatchers.IO) {
         while (isActive) {
@@ -134,24 +61,26 @@ fun cleanupAnswersHistory() {
 }
 
 fun Application.module() {
-    loadAppConfig(environment.config)
+    val config = AppConfig.load(environment.config)
+    MicrosoftService.config = config
+    FormService.config = config
 
     install(DefaultHeaders) {
         header("Content-Security-Policy",
-              "default-src 'self' '${AppConfig.backend.host}'; "
+              "default-src 'self' '${config.backend.host}'; "
         )
     }
     install(ContentNegotiation) {
         json()
     }
-    configureCors()
-    Database.initDatabase()
-    runFlywayMigration()
-    initializeAuthentication()
-    configureRouting()
+    configureCors(config)
+    Database.initDatabase(config)
+    runFlywayMigration(config)
+    initializeAuthentication(config)
+    configureRouting(config)
     configureBackgroundTasks()
 
-    launchCleanupJob()
+    launchCleanupJob(config.answerHistoryCleanup.cleanupIntervalWeeks)
 
     environment.monitor.subscribe(ApplicationStopped) {
         Database.closePool()

--- a/backend/src/main/kotlin/no/bekk/authentication/Authentication.kt
+++ b/backend/src/main/kotlin/no/bekk/authentication/Authentication.kt
@@ -14,10 +14,10 @@ import no.bekk.services.MicrosoftService
 import java.net.URI
 import java.util.concurrent.TimeUnit
 
-fun Application.initializeAuthentication() {
-    val issuer = getIssuer()
-    val clientId = AppConfig.oAuth.clientId
-    val jwksUri = getJwksUrl()
+fun Application.initializeAuthentication(config: AppConfig) {
+    val issuer = getIssuer(config)
+    val clientId = config.oAuth.clientId
+    val jwksUri = getJwksUrl(config)
 
     val jwkProvider = JwkProviderBuilder(URI(jwksUri).toURL())
         .cached(10, 24, TimeUnit.HOURS)
@@ -81,8 +81,8 @@ suspend fun hasContextAccess(call: ApplicationCall, contextId: String,): Boolean
     return hasTeamAccess(call, context.teamId)
 }
 
-suspend fun hasSuperUserAccess(call: ApplicationCall): Boolean {
-    return hasTeamAccess(call, AppConfig.oAuth.superUserGroup)
+suspend fun hasSuperUserAccess(call: ApplicationCall, config: AppConfig): Boolean {
+    return hasTeamAccess(call, config.oAuth.superUserGroup)
 }
 
 suspend fun getTeamIdFromName(call: ApplicationCall, teamName: String): String? {

--- a/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
+++ b/backend/src/main/kotlin/no/bekk/configuration/AppConfig.kt
@@ -1,30 +1,132 @@
 package no.bekk.configuration
 
+import io.ktor.server.config.*
 
-object AppConfig {
-    lateinit var formConfig: FormConfig
-    lateinit var microsoftGraph: MicrosoftGraphConfig
-    lateinit var oAuth: OAuthConfig
-    lateinit var frontend: FrontendConfig
-    lateinit var backend: BackendConfig
-    lateinit var db: DbConfig
-    lateinit var answerHistoryCleanup: AnswerHistoryCleanupConfig
+
+data class AppConfig(
+    val formConfig: FormConfig,
+    val microsoftGraph: MicrosoftGraphConfig,
+    val oAuth: OAuthConfig,
+    val frontend: FrontendConfig,
+    val backend: BackendConfig,
+    val db: DbConfig,
+    val answerHistoryCleanup: AnswerHistoryCleanupConfig,
+    val allowedCORSHosts: List<String>
+) {
+    companion object {
+        fun load(config: ApplicationConfig): AppConfig {
+            val allowedCORSHosts = System.getenv("ALLOWED_CORS_HOSTS").split(",")
+
+            return AppConfig(
+                formConfig = FormConfig(
+                    airTable = AirTableConfig(
+                        baseUrl = config.propertyOrNull("airTable.baseUrl")
+                            ?.getString()
+                            ?: throw IllegalStateException("Unable to initialize app config \"airTable.baseUrl\"")
+                    ),
+                    forms = config.configList("forms").map { table ->
+
+                        when (table.propertyOrNull("type")?.getString()) {
+                            "AIRTABLE" -> AirTableInstanceConfig(
+                                id = table.propertyOrNull("id")?.getString()
+                                    ?: throw IllegalStateException("Unable to initialize app config \"id\""),
+                                accessToken = table.propertyOrNull("accessToken")?.getString()
+                                    ?: throw IllegalStateException("Unable to initialize app config \"accessToken\""),
+                                baseId = table.propertyOrNull("baseId")?.getString()
+                                    ?: throw IllegalStateException("Unable to initialize app config \"baseId\""),
+                                tableId = table.propertyOrNull("tableId")?.getString()
+                                    ?: throw IllegalStateException("Unable to initialize app config \"tableId\""),
+                                viewId = table.propertyOrNull("viewId")?.getString(),
+                                webhookId = table.propertyOrNull("webhookId")?.getString(),
+                                webhookSecret = table.propertyOrNull("webhookSecret")?.getString(),
+                            )
+
+                            "YAML" -> YAMLInstanceConfig(
+                                id = table.propertyOrNull("id")?.getString()
+                                    ?: throw IllegalStateException("Unable to initialize app config \"id\""),
+                                endpoint = table.propertyOrNull("endpoint")?.getString() ?: throw IllegalStateException(
+                                    "Unable to initialize app config \"baseId\""
+                                ),
+                                resourcePath = table.propertyOrNull("resourcePath")?.getString()
+                                    ?: throw IllegalStateException("Unable to initialize app config \"tableId\""),
+                            )
+
+                            else -> throw IllegalStateException("Illegal type \"type\"")
+
+                        }
+
+                    }
+
+                ),
+                microsoftGraph = MicrosoftGraphConfig(
+                    baseUrl = config.propertyOrNull("microsoftGraph.baseUrl")?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"microsoftGraph.baseUrl\""),
+                    memberOfPath = config.propertyOrNull("microsoftGraph.memberOfPath")?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"microsoftGraph.memberOfPath\"")
+                ),
+                oAuth = OAuthConfig(
+                    baseUrl = config.propertyOrNull("oAuth.baseUrl")?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"oAuth.baseurl\""),
+                    tenantId = config.propertyOrNull("oAuth.tenantId")?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"oAuth.tenantId\""),
+                    issuerPath = config.propertyOrNull("oAuth.issuerPath")?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"oAuth.issuerPath\""),
+                    authPath = config.propertyOrNull("oAuth.authPath")?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"oAuth.authPath\""),
+                    tokenPath = config.propertyOrNull("oAuth.tokenPath")?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"oAuth.tokenPath\""),
+                    jwksPath = config.propertyOrNull("oAuth.jwksPath")?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"oAuth.jwksPath\""),
+                    clientId = config.propertyOrNull("oAuth.clientId")?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"oAuth.clientId\""),
+                    clientSecret = config.propertyOrNull("oAuth.clientSecret")?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"oAuth.clientSecret\""),
+                    providerUrl = config.propertyOrNull("oAuth.providerUrl")?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"oAuth.providerUrl\""),
+                    superUserGroup = config.propertyOrNull("oAuth.superUserGroup")?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"oAuth.superUserGroup\"")
+                ),
+                frontend = FrontendConfig(
+                    host = config.propertyOrNull("frontend.host")?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"frontend.host\"")
+                ),
+                backend = BackendConfig(
+                    host = config.propertyOrNull("backend.host")?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"backend.host\"")
+                ),
+                db = DbConfig(
+                    url = config.propertyOrNull("db.url")?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"db.url\""),
+                    username = config.propertyOrNull("db.username")?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"db.username\""),
+                    password = config.propertyOrNull("db.password")?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"db.password\"")
+                ),
+                answerHistoryCleanup = AnswerHistoryCleanupConfig(
+                    cleanupIntervalWeeks = config.propertyOrNull("answerHistoryCleanup.cleanupIntervalWeeks")
+                        ?.getString()
+                        ?: throw IllegalStateException("Unable to initialize app config \"answerHistoryCleanup.cleanupIntervalWeeks\"")
+                ),
+                allowedCORSHosts = allowedCORSHosts
+            )
+        }
+    }
 }
 
-object FormConfig {
-    lateinit var airTable: AirTableConfig
-    lateinit var forms: List<FormInstances>
-}
+data class FormConfig(
+    val airTable: AirTableConfig,
+    val forms: List<FormInstances>
+)
 
-object AirTableConfig {
-    lateinit var baseUrl: String
-}
+data class AirTableConfig(
+    val baseUrl: String
+)
 
 interface FormInstances {
     val id: String
 }
 
-data class AirTableInstanceConfig (
+data class AirTableInstanceConfig(
     override val id: String,
     val accessToken: String,
     val baseId: String,
@@ -34,51 +136,50 @@ data class AirTableInstanceConfig (
     var webhookSecret: String? = null,
 ) : FormInstances
 
-data class YAMLInstanceConfig (
+data class YAMLInstanceConfig(
     override val id: String,
     val endpoint: String? = null,
     val resourcePath: String? = null
 ) : FormInstances
 
 
+data class MicrosoftGraphConfig(
+    val baseUrl: String,
+    val memberOfPath: String
+)
 
-object MicrosoftGraphConfig {
-    lateinit var baseUrl: String
-    lateinit var memberOfPath: String
-}
+data class OAuthConfig(
+    val baseUrl: String,
+    val tenantId: String,
+    val issuerPath: String,
+    val authPath: String,
+    val tokenPath: String,
+    val jwksPath: String,
+    val clientId: String,
+    val clientSecret: String,
+    val providerUrl: String,
+    val superUserGroup: String
+)
 
-object OAuthConfig {
-    lateinit var baseUrl: String
-    lateinit var tenantId: String
-    lateinit var issuerPath: String
-    lateinit var authPath: String
-    lateinit var tokenPath: String
-    lateinit var jwksPath: String
-    lateinit var clientId: String
-    lateinit var clientSecret: String
-    lateinit var providerUrl: String
-    lateinit var superUserGroup: String
-}
-
-fun getIssuer() = AppConfig.oAuth.baseUrl + "/" + AppConfig.oAuth.tenantId + AppConfig.oAuth.issuerPath
-fun getTokenUrl() = AppConfig.oAuth.baseUrl + "/" + AppConfig.oAuth.tenantId + AppConfig.oAuth.tokenPath
-fun getJwksUrl() = AppConfig.oAuth.baseUrl + "/" + AppConfig.oAuth.tenantId + AppConfig.oAuth.jwksPath
+fun getIssuer(config: AppConfig) = config.oAuth.baseUrl + "/" + config.oAuth.tenantId + config.oAuth.issuerPath
+fun getTokenUrl(config: AppConfig) = config.oAuth.baseUrl + "/" + config.oAuth.tenantId + config.oAuth.tokenPath
+fun getJwksUrl(config: AppConfig) = config.oAuth.baseUrl + "/" + config.oAuth.tenantId + config.oAuth.jwksPath
 
 
-object FrontendConfig {
-    lateinit var host: String
-}
+data class FrontendConfig(
+    val host: String
+)
 
-object BackendConfig {
-    lateinit var host: String
-}
+data class BackendConfig(
+    val host: String
+)
 
-object DbConfig {
-    lateinit var url: String
-    lateinit var username: String
-    lateinit var password: String
-}
+data class DbConfig(
+    val url: String,
+    val username: String,
+    val password: String
+)
 
-object AnswerHistoryCleanupConfig {
-    lateinit var cleanupIntervalWeeks: String
-}
+data class AnswerHistoryCleanupConfig(
+    val cleanupIntervalWeeks: String
+)

--- a/backend/src/main/kotlin/no/bekk/configuration/DbConfiguration.kt
+++ b/backend/src/main/kotlin/no/bekk/configuration/DbConfiguration.kt
@@ -6,13 +6,13 @@ import com.zaxxer.hikari.HikariDataSource
 object Database {
     private lateinit var dataSource: HikariDataSource
 
-    fun initDatabase() {
+    fun initDatabase(config: AppConfig) {
         val hikariConfig = HikariConfig()
         hikariConfig.apply {
             schema = "regelrett"
-            jdbcUrl = AppConfig.db.url
-            username = AppConfig.db.username
-            password = AppConfig.db.password
+            jdbcUrl = config.db.url
+            username = config.db.username
+            password = config.db.password
             driverClassName = "org.postgresql.Driver"
         }
         dataSource = HikariDataSource(hikariConfig)

--- a/backend/src/main/kotlin/no/bekk/plugins/Cors.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/Cors.kt
@@ -3,10 +3,11 @@ package no.bekk.plugins
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.plugins.cors.routing.*
+import no.bekk.configuration.AppConfig
 
-fun Application.configureCors() {
+fun Application.configureCors(config: AppConfig) {
     install(CORS) {
-        allowHost("*")
+        config.allowedCORSHosts.forEach { host -> allowHost(host) }
         allowCredentials = true
         allowSameOrigin = true
         allowHeader(HttpHeaders.ContentType)

--- a/backend/src/main/kotlin/no/bekk/plugins/FlywayMigrate.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/FlywayMigrate.kt
@@ -3,14 +3,14 @@ package no.bekk.plugins
 import no.bekk.configuration.AppConfig
 import org.flywaydb.core.Flyway
 
-fun runFlywayMigration() {
+fun runFlywayMigration(config: AppConfig) {
     val flyway = Flyway.configure()
         .createSchemas(true)
         .defaultSchema("regelrett")
         .dataSource(
-            AppConfig.db.url,
-            AppConfig.db.username,
-            AppConfig.db.password
+            config.db.url,
+            config.db.username,
+            config.db.password
         )
         .validateMigrationNaming(true)
         .load()

--- a/backend/src/main/kotlin/no/bekk/plugins/Routing.kt
+++ b/backend/src/main/kotlin/no/bekk/plugins/Routing.kt
@@ -5,10 +5,11 @@ import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import no.bekk.configuration.AppConfig
 import no.bekk.routes.*
 import no.bekk.services.FormService
 
-fun Application.configureRouting() {
+fun Application.configureRouting(config: AppConfig) {
 
     routing {
         get("/") {
@@ -31,8 +32,8 @@ fun Application.configureRouting() {
             commentRouting()
             contextRouting()
             formRouting()
-            userInfoRouting()
-            uploadCSVRouting()
+            userInfoRouting(config)
+            uploadCSVRouting(config)
         }
 
         airTableWebhookRouting()

--- a/backend/src/main/kotlin/no/bekk/providers/clients/AirTableClient.kt
+++ b/backend/src/main/kotlin/no/bekk/providers/clients/AirTableClient.kt
@@ -26,7 +26,7 @@ data class AirTableBase(
     val permissionLevel: String,
 )
 
-class AirTableClient(private val accessToken: String) {
+class AirTableClient(private val accessToken: String, private val config: AppConfig) {
 
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -41,20 +41,20 @@ class AirTableClient(private val accessToken: String) {
     }
 
     suspend fun getBases(): AirTableBasesResponse {
-        val response = client.get(AppConfig.formConfig.airTable.baseUrl + "/v0/meta/bases")
+        val response = client.get(config.formConfig.airTable.baseUrl + "/v0/meta/bases")
         val responseBody = response.bodyAsText()
         return json.decodeFromString<AirTableBasesResponse>(responseBody)
     }
 
     suspend fun getBaseSchema(baseId: String): MetadataResponse {
-        val response = client.get(AppConfig.formConfig.airTable.baseUrl + "/v0/meta/bases/$baseId/tables")
+        val response = client.get(config.formConfig.airTable.baseUrl + "/v0/meta/bases/$baseId/tables")
         val responseBody = response.bodyAsText()
         return json.decodeFromString<MetadataResponse>(responseBody)
     }
 
     suspend fun getRecords(baseId: String, tableId: String, viewId: String? = null, offset: String? = null): AirtableResponse {
         val url = buildString {
-            append(AppConfig.formConfig.airTable.baseUrl)
+            append(config.formConfig.airTable.baseUrl)
             append("/v0/$baseId/$tableId")
             if (viewId != null) {
                 append("?view=$viewId")
@@ -72,13 +72,13 @@ class AirTableClient(private val accessToken: String) {
     }
 
     suspend fun getRecord(baseId: String, tableId: String, recordId: String): Record {
-        val response = client.get(AppConfig.formConfig.airTable.baseUrl + "/v0/$baseId/$tableId/$recordId")
+        val response = client.get(config.formConfig.airTable.baseUrl + "/v0/$baseId/$tableId/$recordId")
         val responseBody = response.bodyAsText()
         return json.decodeFromString<Record>(responseBody)
     }
 
     suspend fun refreshWebhook(baseId: String, webhookId: String): Int {
-        val url = "${AppConfig.formConfig.airTable.baseUrl}/v0/bases/$baseId/webhooks/$webhookId/refresh"
+        val url = "${config.formConfig.airTable.baseUrl}/v0/bases/$baseId/webhooks/$webhookId/refresh"
         val response: HttpResponse = client.post(url) {
             header("Authorization", "Bearer $accessToken")
         }

--- a/backend/src/main/kotlin/no/bekk/routes/UploadCSVRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/UploadCSVRouting.kt
@@ -11,14 +11,15 @@ import java.sql.ResultSet
 import java.sql.SQLException
 import java.util.Date
 import io.ktor.http.ContentType
+import no.bekk.configuration.AppConfig
 import no.bekk.util.logger
 
 
-fun Route.uploadCSVRouting() {
+fun Route.uploadCSVRouting(config: AppConfig) {
     route("/dump-csv") {
         get {
             logger.debug("Received GET /dump-csv")
-            if (!hasSuperUserAccess(call)) {
+            if (!hasSuperUserAccess(call, config)) {
                 call.respond(HttpStatusCode.Unauthorized)
                 return@get
             }

--- a/backend/src/main/kotlin/no/bekk/routes/UserInfoRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/UserInfoRouting.kt
@@ -8,16 +8,17 @@ import no.bekk.authentication.getGroupsOrEmptyList
 import no.bekk.authentication.getCurrentUser
 import no.bekk.authentication.hasSuperUserAccess
 import no.bekk.authentication.getUserByUserId
+import no.bekk.configuration.AppConfig
 import no.bekk.domain.UserInfoResponse
 import no.bekk.util.logger
 
-fun Route.userInfoRouting() {
+fun Route.userInfoRouting(config: AppConfig) {
     route("/userinfo") {
         get {
             logger.debug("Received GET /userinfo")
             val groups = getGroupsOrEmptyList(call)
             val user = getCurrentUser(call)
-            val superuser = hasSuperUserAccess(call)
+            val superuser = hasSuperUserAccess(call, config)
             call.respond(UserInfoResponse(groups, user, superuser))
         }
 

--- a/backend/src/main/kotlin/no/bekk/services/FormService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/FormService.kt
@@ -9,28 +9,33 @@ import no.bekk.providers.YamlProvider
 import no.bekk.providers.clients.AirTableClient
 
 object FormService {
+    lateinit var config: AppConfig
 
+    private val providers: List<FormProvider> by lazy {
+        config.formConfig.forms.map { form ->
+            when (form) {
+                is AirTableInstanceConfig -> AirTableProvider(
+                    id = form.id,
+                    airtableClient = AirTableClient(
+                        form.accessToken,
+                        config
+                    ),
+                    baseId = form.baseId,
+                    tableId = form.tableId,
+                    viewId = form.viewId,
+                    webhookId = form.webhookId,
+                    webhookSecret = form.webhookSecret,
+                )
 
-  private val providers: List<FormProvider> = AppConfig.formConfig.forms.map { form ->
-        when (form) {
-            is AirTableInstanceConfig -> AirTableProvider(
-                id = form.id,
-                airtableClient = AirTableClient(
-                    form.accessToken
-                ),
-                baseId = form.baseId,
-                tableId =   form.tableId,
-                viewId = form.viewId,
-                webhookId = form.webhookId,
-                webhookSecret = form.webhookSecret,
-            )
-            is YAMLInstanceConfig -> YamlProvider(
-                id = form.id,
-                endpoint = form.endpoint,
-                resourcePath =   form.resourcePath,
-            )
-            else ->  throw Exception("Valid tabletype not found")
+                is YAMLInstanceConfig -> YamlProvider(
+                    id = form.id,
+                    endpoint = form.endpoint,
+                    resourcePath = form.resourcePath,
+                )
 
+                else -> throw Exception("Valid tabletype not found")
+
+            }
         }
     }
 

--- a/backend/src/main/kotlin/no/bekk/services/MicrosoftService.kt
+++ b/backend/src/main/kotlin/no/bekk/services/MicrosoftService.kt
@@ -21,16 +21,18 @@ object MicrosoftService {
 
     val client = HttpClient(CIO)
 
+    lateinit var config: AppConfig
+
     suspend fun requestTokenOnBehalfOf(jwtToken: String?): String {
         val response: HttpResponse = jwtToken?.let {
-            client.post(getTokenUrl()) {
+            client.post(getTokenUrl(config)) {
                 contentType(ContentType.Application.FormUrlEncoded)
                 setBody(
                     FormDataContent(
                         Parameters.build {
                             append("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
-                            append("client_id", AppConfig.oAuth.clientId)
-                            append("client_secret", AppConfig.oAuth.clientSecret)
+                            append("client_id", config.oAuth.clientId)
+                            append("client_secret", config.oAuth.clientSecret)
                             append("assertion", it)
                             append("scope", "GroupMember.Read.All")
                             append("requested_token_use", "on_behalf_of")
@@ -48,7 +50,7 @@ object MicrosoftService {
     suspend fun fetchGroups(bearerToken: String): List<MicrosoftGraphGroup> {
         // The relevant groups from Entra ID have a known prefix.
         val url =
-            "${AppConfig.microsoftGraph.baseUrl + AppConfig.microsoftGraph.memberOfPath}?\$count=true&\$select=id,displayName"
+            "${config.microsoftGraph.baseUrl + config.microsoftGraph.memberOfPath}?\$count=true&\$select=id,displayName"
 
         val response: HttpResponse = client.get(url) {
             bearerAuth(bearerToken)
@@ -66,7 +68,7 @@ object MicrosoftService {
     }
 
     suspend fun fetchCurrentUser(bearerToken: String): MicrosoftGraphUser {
-        val url = "${AppConfig.microsoftGraph.baseUrl}/v1.0/me?\$select=id,displayName,mail"
+        val url = "${config.microsoftGraph.baseUrl}/v1.0/me?\$select=id,displayName,mail"
 
         val response: HttpResponse = client.get(url) {
             bearerAuth(bearerToken)
@@ -78,7 +80,7 @@ object MicrosoftService {
     }
 
     suspend fun fetchUserByUserId(bearerToken: String, userId: String): MicrosoftGraphUser {
-        val url = "${AppConfig.microsoftGraph.baseUrl}/v1.0/users/$userId"
+        val url = "${config.microsoftGraph.baseUrl}/v1.0/users/$userId"
 
         val response: HttpResponse = client.get(url) {
             bearerAuth(bearerToken)


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 
Begrense CORS og gjøre det konfigurerbart

**Løsning**

🆕 Endring: 
- La til CORS konfigurering for gcp og skip
- Refaktorerte AppConfig og Application for å gjøre det enklere å sende inn config og starte refaktoring fra singletons og til å supporte injection pattern. Førte til litt endringer i andre filer. 

OBS: Instantiering av configen til FormService og MicrosoftService i module() vil fjernes etter at de er gjort om til klasser. "by lazy" som ble lagt til i FormService vil også gå bort. Gjorde det sånn nå for å minimere PR'en. 

**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?

Resolves #643 
