### PR TITLE
675 bug sikkerhetskontroller skjema er tomt

### DIFF
--- a/frontend/beCompliant/src/pages/ActivityPage.tsx
+++ b/frontend/beCompliant/src/pages/ActivityPage.tsx
@@ -111,6 +111,14 @@ export const ActivityPage = () => {
     }
 
     if (activeFilters[tableData.id]?.length > 0) {
+      setActiveFilters((prev) => ({
+        ...prev,
+        [tableData.id]: prev[tableData.id].filter((filterObject) =>
+          tableData.columns.some(
+            (column) => column.name === filterObject.filterName
+          )
+        ),
+      }));
       setFilters(activeFilters[tableData.id]);
     } else {
       setFilters(null);


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 
Ved endring av navn på kolonne i airtable forble et ugyldig filtenavn i localstorage, og filteret gikk sin gang og fant ingen rader som tilfredstilte ekstisterende løsning.

**Løsning**

🆕 Endring: 

Lagt til en sjekk på at de lagrede filterene i local storage; hvis filter ikke tilsvarer kolonnenavn så fjernes det fra `activeFilters`

Dette er ikke en optimal løsning, så har laget enda en ticket på å løse litt opp i spaghettien som gjelder å styre med url filtere og local storage filtere. Den ligger foreløpig i blocked. 
