### PR TITLE
Hvis svar eller kommentarer er tomme, skip insert i db

### DIFF
--- a/backend/src/main/kotlin/no/bekk/database/AnswerRepository.kt
+++ b/backend/src/main/kotlin/no/bekk/database/AnswerRepository.kt
@@ -108,6 +108,7 @@ class AnswerRepositoryImpl(private val database: Database) : AnswerRepository {
                 contextId = newContextId
             )
         }
+        if (databaseAnswerRequestList.isEmpty()) return
 
         try {
             insertAnswersOnContextBatch(databaseAnswerRequestList)
@@ -173,7 +174,6 @@ class AnswerRepositoryImpl(private val database: Database) : AnswerRepository {
     }
 
     override fun insertAnswersOnContextBatch(answers: List<DatabaseAnswerRequest>): List<DatabaseAnswer> {
-        require(answers.isNotEmpty()) { "You must provide at least one answer" }
         answers.forEach { require(it.contextId != null) { "You have to supply a contextId" } }
 
         logger.debug("Inserting {} answers into database", answers.size)

--- a/backend/src/main/kotlin/no/bekk/database/CommentRepository.kt
+++ b/backend/src/main/kotlin/no/bekk/database/CommentRepository.kt
@@ -99,7 +99,6 @@ class CommentRepositoryImpl(private val database: Database) : CommentRepository 
     }
 
     override fun insertCommentsOnContextBatch(comments: List<DatabaseCommentRequest>): List<DatabaseComment> {
-        require(comments.isNotEmpty()) { "You must provide at least one comment" }
         comments.forEach { require(it.contextId != null) { "You have to supply a contextId" } }
 
         logger.debug("Inserting or updating {} comments into database", comments.size)
@@ -182,7 +181,7 @@ class CommentRepositoryImpl(private val database: Database) : CommentRepository 
                 contextId = newContextId
             )
         }
-
+        if (databaseCommentRequestList.isEmpty()) return;
         try {
             insertCommentsOnContextBatch(databaseCommentRequestList)
             logger.info("Comment copied to context $newContextId")


### PR DESCRIPTION
Manglet en sjekk på om svar eller kommentarer man skal kopiere fra et skjema er tomme, som gjorde at insert feilet. La til fiks 
