### PR TITLE
Bug: switchen på vis alle kolonner funker ikke når man unhider en kolonner definert som utfyllingsmodus.

### DIFF
--- a/frontend/beCompliant/src/components/table/DataTable.tsx
+++ b/frontend/beCompliant/src/components/table/DataTable.tsx
@@ -31,14 +31,6 @@ export function DataTable<TData>({
 }: Props<TData>) {
   const headerNames = table.getAllColumns().map((column) => column.id);
 
-  const handleOnChange = (isDetailViewChecked: boolean) => {
-    if (!isDetailViewChecked) {
-      showOnlyFillModeColumns(headerNames);
-    } else {
-      unHideColumns(headerNames);
-    }
-  };
-
   return (
     <TableStateProvider>
       <Flex flexDirection="column" width="100%" gap="4">
@@ -98,9 +90,11 @@ export function DataTable<TData>({
               Vis alle kolonner
             </Text>
             <Switch
-              onCheckedChange={(e) => {
-                handleOnChange(e.checked);
-              }}
+              onCheckedChange={(e) =>
+                e.checked
+                  ? unHideColumns(headerNames)
+                  : showOnlyFillModeColumns(headerNames)
+              }
               colorPalette="blue"
               checked={table.getIsAllColumnsVisible()}
             />

--- a/frontend/beCompliant/src/hooks/useColumnVisibility.ts
+++ b/frontend/beCompliant/src/hooks/useColumnVisibility.ts
@@ -21,10 +21,8 @@ export function useColumnVisibility() {
   };
 
   const unHideColumns = (names: string[]) => {
-    names.forEach((name, i) => {
-      if (!FILLMODE_COLUMN_IDXS.includes(i)) {
-        unHideColumn(name);
-      }
+    names.forEach((name) => {
+      unHideColumn(name);
     });
   };
 


### PR DESCRIPTION

**Beskrivelse**

🥅 Mål med PRen: 
Når man manuelt skjulte en av kolonnen i tabellen som ikke skjules av switchen (aka utfylingsmodus kolonnen svar, id etc), så fikk man ikke un-hidet de med switchen. 

**Løsning**

🆕 Endring: 
fjernet en sjekk som fohindret unhide av kolonner som var i utfyllingsmoduskolonne indeks lista. 
Mens jeg var i gang forenklet jeg onchange til inline. 

**🧪 Testing**

test godt funkskjonelt.

🔒 **Sikkerhet / Trusselvurdering**

Man kan manuelt hide alle kolonenne i tabellen. er det ønskelig?


Vi er i denne seksjonen visuelt i rr: 
<img width="828" alt="image" src="https://github.com/user-attachments/assets/240c4393-1221-4b38-b3ff-1dd6add3818b" />

