### PR TITLE
replace progress circle with bar

### DIFF
--- a/frontend/beCompliant/src/pages/activityPage/ActivityPage.tsx
+++ b/frontend/beCompliant/src/pages/activityPage/ActivityPage.tsx
@@ -1,12 +1,4 @@
-import {
-  Box,
-  Flex,
-  Heading,
-  IconButton,
-  Separator,
-  Skeleton,
-  Text,
-} from '@kvib/react';
+import { Flex, Heading, IconButton, Skeleton, Text } from '@kvib/react';
 import { useParams } from 'react-router';
 import { Page } from '../../components/layout/Page';
 import { TableComponent } from './table/Table';
@@ -95,7 +87,7 @@ export default function ActivityPage() {
     <>
       <RedirectBackButton />
       <Page>
-        <Flex flexDirection="column" maxW="100%" alignSelf="center" gap="8">
+        <Flex flexDirection="column" maxW="100%" alignSelf="center" gap="4">
           <Flex flexDirection="column" gap="2" px="10">
             <Skeleton loading={contextIsPending || tableIsPending}>
               <Flex justifyContent="space-between">
@@ -114,7 +106,7 @@ export default function ActivityPage() {
               </Flex>
             </Skeleton>
             <Skeleton loading={contextIsPending || userinfoIsPending}>
-              <Text fontSize="xl" fontWeight="600" pb="7">
+              <Text fontSize="xl" fontWeight="600">
                 Team: {teamName}{' '}
               </Text>
             </Skeleton>
@@ -124,9 +116,6 @@ export default function ActivityPage() {
               <TableStatistics filteredData={tableData?.records ?? []} />
             </Skeleton>
           </Flex>
-          <Box width="100%" paddingX="10">
-            <Separator borderColor="gray.400" />
-          </Box>
           <Skeleton
             loading={
               tableIsPending ||

--- a/frontend/beCompliant/src/pages/activityPage/TableStatistics.tsx
+++ b/frontend/beCompliant/src/pages/activityPage/TableStatistics.tsx
@@ -1,4 +1,4 @@
-import { AbsoluteCenter, KvibProgressCircle, Mark, Text } from '@kvib/react';
+import { KvibProgress, HStack } from '@kvib/react';
 import { Question } from '../../api/types';
 
 interface Props {
@@ -19,26 +19,20 @@ export const TableStatistics = ({ filteredData }: Props) => {
   );
 
   return (
-    <>
-      <Text minHeight="28px" fontSize="lg">
-        <Mark fontWeight="bold">{numberOfAnswers}</Mark> av{' '}
-        <Mark fontWeight="bold">{numberOfQuestions}</Mark> spørsmål besvart
-      </Text>
-      <KvibProgressCircle.Root
-        value={isNaN(percentageAnswered) ? 0 : percentageAnswered}
-        size="xl"
-        colorPalette="blue"
-      >
-        <KvibProgressCircle.Circle>
-          <KvibProgressCircle.Track />
-          <KvibProgressCircle.Range strokeLinecap="round" />
-        </KvibProgressCircle.Circle>
-        <AbsoluteCenter>
-          <KvibProgressCircle.Label>
-            <Text fontWeight="bold">{numberOfAnswers}</Text>
-          </KvibProgressCircle.Label>
-        </AbsoluteCenter>
-      </KvibProgressCircle.Root>
-    </>
+    <KvibProgress.Root
+      value={isNaN(percentageAnswered) ? 0 : percentageAnswered}
+      colorPalette="blue"
+      maxW="40%"
+    >
+      <HStack gap="2">
+        <KvibProgress.Track flex="1">
+          <KvibProgress.Range />
+        </KvibProgress.Track>
+        <KvibProgress.ValueText fontSize="sm" fontWeight="semibold">
+          {numberOfAnswers}/{numberOfQuestions} spørsmål besvart (
+          {percentageAnswered}%)
+        </KvibProgress.ValueText>
+      </HStack>
+    </KvibProgress.Root>
   );
 };


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 
Endre progress sirkelen til en bar for å gi mer plass til tabellen

**Løsning**

🆕 Endring: 
Endret fra dette:
![image](https://github.com/user-attachments/assets/fb91c747-7e11-4897-814e-c3f5062841f9)

Til dette:
![image](https://github.com/user-attachments/assets/ede33cc2-68c6-49b1-b841-4632c7ec02ac)


**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?

Resolves #759 
