### PR TITLE
forenkle get answers endepunktet

### DIFF
--- a/backend/src/main/kotlin/no/bekk/routes/AnswerRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/AnswerRouting.kt
@@ -1,11 +1,9 @@
 package no.bekk.routes
 
 import io.ktor.http.*
-import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import no.bekk.database.AnswerRepository
 import no.bekk.database.DatabaseAnswer
@@ -53,7 +51,7 @@ fun Route.answerRouting(authService: AuthService, answerRepository: AnswerReposi
         if (recordId != null) {
             answers = answerRepository.getAnswersByContextAndRecordIdFromDatabase(contextId, recordId)
         } else {
-            answers = answerRepository.getAnswersByContextIdFromDatabase(contextId)
+            answers = answerRepository.getLatestAnswersByContextIdFromDatabase(contextId)
         }
 
         val answersJson = Json.encodeToString(answers)

--- a/backend/src/main/kotlin/no/bekk/routes/CommentRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/CommentRouting.kt
@@ -1,17 +1,15 @@
 package no.bekk.routes
 
 import io.ktor.http.*
-import io.ktor.server.application.*
 import io.ktor.server.plugins.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import no.bekk.database.DatabaseComment
-import no.bekk.database.CommentRepository
-import no.bekk.database.DatabaseCommentRequest
 import no.bekk.authentication.AuthService
+import no.bekk.database.CommentRepository
+import no.bekk.database.DatabaseComment
+import no.bekk.database.DatabaseCommentRequest
 import no.bekk.util.logger
 
 fun Route.commentRouting(authService: AuthService, commentRepository: CommentRepository) {

--- a/backend/src/main/kotlin/no/bekk/routes/ContextRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/ContextRouting.kt
@@ -1,16 +1,14 @@
 package no.bekk.routes
 
 import io.ktor.http.*
-import io.ktor.server.application.*
 import io.ktor.server.plugins.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import no.bekk.database.*
 import no.bekk.authentication.AuthService
+import no.bekk.database.*
 import no.bekk.util.logger
 
 fun Route.contextRouting(

--- a/backend/src/main/kotlin/no/bekk/routes/FormRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/FormRouting.kt
@@ -1,7 +1,6 @@
 package no.bekk.routes
 
 import io.ktor.http.*
-import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.bekk.services.FormService

--- a/backend/src/main/kotlin/no/bekk/routes/UploadCSVRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/UploadCSVRouting.kt
@@ -1,11 +1,10 @@
 package no.bekk.routes
 
 import io.ktor.http.*
-import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import no.bekk.configuration.Database
 import no.bekk.authentication.AuthService
+import no.bekk.configuration.Database
 import no.bekk.util.logger
 import java.io.StringWriter
 import java.sql.ResultSet

--- a/backend/src/main/kotlin/no/bekk/routes/UserInfoRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/UserInfoRouting.kt
@@ -1,7 +1,6 @@
 package no.bekk.routes
 
 import io.ktor.http.*
-import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.coroutines.Dispatchers

--- a/backend/src/test/kotlin/no/bekk/database/AnswerRepositoryTest.kt
+++ b/backend/src/test/kotlin/no/bekk/database/AnswerRepositoryTest.kt
@@ -23,7 +23,7 @@ class AnswerRepositoryTest {
         )
         answerRepository.insertAnswerOnContext(request)
 
-        val fetchedAnswers = answerRepository.getAnswersByContextIdFromDatabase(context.id)
+        val fetchedAnswers = answerRepository.getLatestAnswersByContextIdFromDatabase(context.id)
         assertEquals(1, fetchedAnswers.size)
         assertEquals(request.actor, fetchedAnswers.first().actor)
         assertEquals(request.recordId, fetchedAnswers.first().recordId)
@@ -73,7 +73,7 @@ class AnswerRepositoryTest {
 
         answerRepository.copyAnswersFromOtherContext(destinationContext.id, sourceContext.id)
 
-        val destinationContextAnswers = answerRepository.getAnswersByContextIdFromDatabase(destinationContext.id)
+        val destinationContextAnswers = answerRepository.getLatestAnswersByContextIdFromDatabase(destinationContext.id)
         assertEquals(1, destinationContextAnswers.size)
         assertEquals(request.actor, destinationContextAnswers.first().actor)
         assertEquals(request.recordId, destinationContextAnswers.first().recordId)

--- a/backend/src/test/kotlin/no/bekk/routes/AnswerRoutingTest.kt
+++ b/backend/src/test/kotlin/no/bekk/routes/AnswerRoutingTest.kt
@@ -5,7 +5,6 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.testing.*
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import no.bekk.MockAuthService
 import no.bekk.TestUtils.generateTestToken
@@ -170,7 +169,7 @@ class AnswerRoutingTest {
         application {
             testModule(
                 answerRepository = object : MockAnswerRepository {
-                    override fun getAnswersByContextIdFromDatabase(
+                    override fun getLatestAnswersByContextIdFromDatabase(
                         contextId: String,
                     ): List<DatabaseAnswer> {
                         return listOf(mockedAnswer)

--- a/backend/src/test/kotlin/no/bekk/routes/MockAnswerRepository.kt
+++ b/backend/src/test/kotlin/no/bekk/routes/MockAnswerRepository.kt
@@ -3,7 +3,7 @@ package no.bekk.routes
 import no.bekk.database.*
 
 interface MockAnswerRepository : AnswerRepository {
-    override fun getAnswersByContextIdFromDatabase(contextId: String): List<DatabaseAnswer> {
+    override fun getLatestAnswersByContextIdFromDatabase(contextId: String): List<DatabaseAnswer> {
         TODO("Not yet implemented")
     }
 


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 
Alle svarene hentes ut i tabellvisningen, det er ikke nødvendig da vi kun viser det nyeste svaret og alle svarene blir hentet ut i spørsmålssiden

**Løsning**

🆕 Endring: 
Endret til å kun hente ut de nyeste svarene i tabellvisningen. Vi hadde allerede en metode som gjorde det så fikk forenklet litt og fjernet kode. `getAnswersByContextAndRecordIdFromDatabase` ble ikke endret da det er det som henter ut svar til spørsmålssiden

**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?

Resolves #776 
