### PR TITLE
get context by contextId Unauthorized -> Forbidden ved maglende tilgang.

### DIFF
--- a/backend/src/main/kotlin/no/bekk/routes/ContextRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/ContextRouting.kt
@@ -102,7 +102,7 @@ fun Route.contextRouting(
                 val contextId = call.parameters["contextId"] ?: throw BadRequestException("Missing contextId")
 
                 if (!authService.hasContextAccess(call, contextId)) {
-                    call.respond(HttpStatusCode.Unauthorized)
+                    call.respond(HttpStatusCode.Forbidden)
                     return@get
                 }
                 val context = contextRepository.getContext(contextId)

--- a/backend/src/test/kotlin/no/bekk/routes/ContextRoutingTest.kt
+++ b/backend/src/test/kotlin/no/bekk/routes/ContextRoutingTest.kt
@@ -294,7 +294,7 @@ class ContextRoutingTest {
     }
 
     @Test
-    fun `get context missing context access returns Unauthorized`() = testApplication {
+    fun `get context missing context access returns Forbidden`() = testApplication {
         application {
             testModule(
                 authService = object : MockAuthService {
@@ -308,7 +308,7 @@ class ContextRoutingTest {
         val response = client.get("/contexts/contextId") {
             header(HttpHeaders.Authorization, "Bearer ${generateTestToken()}")
         }
-        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        assertEquals(HttpStatusCode.Forbidden, response.status)
     }
 
     @Test


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 

get context på contextId endepunktet returnerer unautherized hvis man ikke er medlem av teamet som eier contexten. Men da sjekken tar til grunnlag at man sender med token for å sjekke opp om man faktisk er meldme av riktig team, er det forbidden som blir riktig respons da dte ikke mangler vedlagt autentisering. De andre endepunktene svarer med forbidden på samme sjekk. 

**Løsning**

🆕 Endring: endre fra Unauthorized til Forbidden 

**🧪 Testing**

Test funksjonaliteten godt lokalt i tillfelle jeg har oversett noe funksjonalitet som er avhengig av 401 feilmelding her. 


