### PR TITLE
401 -> 403 ved forbidden request

### DIFF
--- a/frontend/beCompliant/src/pages/activityPage/ActivityPage.tsx
+++ b/frontend/beCompliant/src/pages/activityPage/ActivityPage.tsx
@@ -57,7 +57,7 @@ export default function ActivityPage() {
 
   if (contextError) {
     const statusCode = contextError.response?.status;
-    if (statusCode === 401) {
+    if (statusCode === 403) {
       return (
         <ErrorState message="Du har ikke tilgang til denne skjemautfyllingen" />
       );


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 

Frontenden kastet error state på at du mangler tilgang til contexten på statuskode 401 - dette skal være 403, ettersom det ble rettet opp i backenden. 

