### PR TITLE
accept either teamname or teamid in context team patch

### DIFF
--- a/backend/src/main/kotlin/no/bekk/routes/ContextRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/ContextRouting.kt
@@ -127,17 +127,24 @@ fun Route.contextRouting(
                     val contextId = call.parameters["contextId"] ?: throw BadRequestException("Missing contextId")
 
                     val payload = call.receive<TeamUpdateRequest>()
-                    val newTeam = payload.teamName ?: throw BadRequestException("Missing teamName in request body")
-
+                    val newTeam = when {
+                        payload.teamId != null -> {
+                            payload.teamId
+                        }
+                        payload.teamName != null -> {
+                            authService.getTeamIdFromName(call, payload.teamName) ?: throw BadRequestException("TeamName: ${payload.teamName} not valid")
+                        }
+                        else -> {
+                            throw BadRequestException("Request must contain either teamId or teamName")
+                        }
+                    }
 
                     if (!authService.hasContextAccess(call, contextId)) {
                         call.respond(HttpStatusCode.Forbidden)
                         return@patch
                     }
 
-                    val teamId = authService.getTeamIdFromName(call, newTeam) ?: throw BadRequestException("TeamName not valid")
-
-                    val success = contextRepository.changeTeam(contextId, teamId)
+                    val success = contextRepository.changeTeam(contextId, newTeam)
                     if (success) {
                         call.respond(HttpStatusCode.OK)
                         return@patch
@@ -206,7 +213,7 @@ fun Route.contextRouting(
 }
 
 @Serializable
-data class TeamUpdateRequest(val teamName: String?)
+data class TeamUpdateRequest(val teamName: String? = null, val teamId: String? = null)
 
 @Serializable
 data class CopyContextRequest(val copyContextId: String?)

--- a/backend/src/main/kotlin/no/bekk/routes/ContextRouting.kt
+++ b/backend/src/main/kotlin/no/bekk/routes/ContextRouting.kt
@@ -126,6 +126,11 @@ fun Route.contextRouting(
                     logger.info("Received PATCH /contexts with id: ${call.parameters["contextId"]}")
                     val contextId = call.parameters["contextId"] ?: throw BadRequestException("Missing contextId")
 
+                    if (!authService.hasContextAccess(call, contextId)) {
+                        call.respond(HttpStatusCode.Forbidden)
+                        return@patch
+                    }
+
                     val payload = call.receive<TeamUpdateRequest>()
                     val newTeam = when {
                         payload.teamId != null -> {
@@ -139,10 +144,6 @@ fun Route.contextRouting(
                         }
                     }
 
-                    if (!authService.hasContextAccess(call, contextId)) {
-                        call.respond(HttpStatusCode.Forbidden)
-                        return@patch
-                    }
 
                     val success = contextRepository.changeTeam(contextId, newTeam)
                     if (success) {

--- a/backend/src/test/kotlin/no/bekk/routes/ContextRoutingTest.kt
+++ b/backend/src/test/kotlin/no/bekk/routes/ContextRoutingTest.kt
@@ -391,7 +391,13 @@ class ContextRoutingTest {
     @Test
     fun `update context team missing team name returns BadRequest`() = testApplication {
         application {
-            testModule()
+            testModule(
+                authService = object : MockAuthService {
+                    override suspend fun hasContextAccess(call: ApplicationCall, contextId: String): Boolean {
+                        return true
+                    }
+                }
+            )
         }
 
         val response = client.patch("/contexts/id/team") {

--- a/frontend/beCompliant/src/hooks/useContext.ts
+++ b/frontend/beCompliant/src/hooks/useContext.ts
@@ -220,7 +220,9 @@ export function useChangeTeamForContext({
   return useMutation({
     mutationFn: async (newTeam: string) => {
       return axiosFetch({
-        url: contextId ? `${API_URL_BASE}/contexts/${contextId}` : undefined,
+        url: contextId
+          ? `${API_URL_BASE}/contexts/${contextId}/team`
+          : undefined,
         method: 'PATCH',
         data: {
           teamName: newTeam,


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: 
Frisk sender med teamId for å endre en skjemautfylling (context) sitt team, mens regelrett-frontenden sender teamname for å ikke være begrenset av team en selv er medlem av. 


**Løsning**

🆕 Endring:
For å tillate frisk å kunne endre teamet til skjemautfyllingen, aksepterer patch-endepunktet enten en teamId eller teamcontext. 

I tillegg hadde regelrett-endreteam-hooken feil URL - så slang på /team


**🧪 Testing**

*Er det noe spesielt den som reviewer PRen bør sjekke?*

🔒 **Sikkerhet / Trusselvurdering**

- Er det potensielle risikoer knyttet til endringen?
- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?

Resolves #issue-this-pr-resolves
