### PR TITLE
831 unngå at brukere trykker på slett skjemautfylling ved en feil

### DIFF
--- a/frontend/beCompliant/src/components/ui/sonner.tsx
+++ b/frontend/beCompliant/src/components/ui/sonner.tsx
@@ -2,7 +2,7 @@ import { useTheme } from 'next-themes';
 import { Toaster as Sonner, ToasterProps } from 'sonner';
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  // bytt tilbake til "system" når man øsnker å støtte drakmode.
+  // bytt tilbake til "system" når man ønsker å støtte drakmode.
   const { theme = 'light' } = useTheme();
 
   return (

--- a/frontend/beCompliant/src/components/ui/sonner.tsx
+++ b/frontend/beCompliant/src/components/ui/sonner.tsx
@@ -2,7 +2,8 @@ import { useTheme } from 'next-themes';
 import { Toaster as Sonner, ToasterProps } from 'sonner';
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = 'system' } = useTheme();
+  // bytt tilbake til "system" når man øsnker å støtte drakmode.
+  const { theme = 'light' } = useTheme();
 
   return (
     <Sonner

--- a/frontend/beCompliant/src/components/ui/sonner.tsx
+++ b/frontend/beCompliant/src/components/ui/sonner.tsx
@@ -2,7 +2,7 @@ import { useTheme } from 'next-themes';
 import { Toaster as Sonner, ToasterProps } from 'sonner';
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  // bytt tilbake til "system" når man ønsker å støtte drakmode.
+  // bytt tilbake til "system" når man ønsker å støtte darkmode.
   const { theme = 'light' } = useTheme();
 
   return (

--- a/frontend/beCompliant/src/pages/frontPage/ContextLink.tsx
+++ b/frontend/beCompliant/src/pages/frontPage/ContextLink.tsx
@@ -61,7 +61,7 @@ export function ContextLink({
             )
             .join('&')}`}
         >
-          <Card className="min-w-[450px] py-4 transition hover:bg-secondary hover:shadow-md">
+          <Card className="min-w-[450px] py-4 transition hover:bg-primary-foreground hover:shadow-md">
             <CardContent className="w-full self-start">
               <div className="flex justify-between items-start">
                 <div className="flex flex-col gap-1 items-start">

--- a/frontend/beCompliant/src/pages/frontPage/ContextLink.tsx
+++ b/frontend/beCompliant/src/pages/frontPage/ContextLink.tsx
@@ -14,7 +14,6 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Trash2 } from 'lucide-react';
 import { useAnswers } from '@/hooks/useAnswers';
-import { formatDateTime } from '@/utils/formatTime';
 
 export function ContextLink({
   contextId,
@@ -116,6 +115,7 @@ export function ContextLink({
         isOpen={isDeleteOpen}
         teamId={context?.teamId ?? ''}
         contextId={contextId}
+        formId={formId}
       />
     </SkeletonLoader>
   );

--- a/frontend/beCompliant/src/pages/frontPage/ContextLink.tsx
+++ b/frontend/beCompliant/src/pages/frontPage/ContextLink.tsx
@@ -50,7 +50,6 @@ export function ContextLink({
   const { data: context, isPending: contextIsPending } = useContext(contextId);
   const { data: answers, isPending: answerIsPending } = useAnswers(contextId);
 
-  console.log('nlablab', answers, contextId);
   const latest = answers?.length
     ? answers.reduce((latest, current) =>
         new Date(current.updated) > new Date(latest.updated) ? current : latest

--- a/frontend/beCompliant/src/pages/frontPage/ContextLink.tsx
+++ b/frontend/beCompliant/src/pages/frontPage/ContextLink.tsx
@@ -50,6 +50,7 @@ export function ContextLink({
   const { data: context, isPending: contextIsPending } = useContext(contextId);
   const { data: answers, isPending: answerIsPending } = useAnswers(contextId);
 
+  console.log('nlablab', answers, contextId);
   const latest = answers?.length
     ? answers.reduce((latest, current) =>
         new Date(current.updated) > new Date(latest.updated) ? current : latest
@@ -77,7 +78,7 @@ export function ContextLink({
               <div className="flex justify-between items-start">
                 <div className="flex flex-col gap-1 items-start">
                   <div className="flex items-center gap-1">
-                    <TruncatedText str={context?.name ?? ''} maxLength={27} />
+                    <TruncatedText str={context?.name ?? ''} maxLength={22} />
                     <Button
                       aria-label="Slett utfylling"
                       variant="ghost"
@@ -100,7 +101,7 @@ export function ContextLink({
                       Sist endret:{' '}
                       {latest
                         ? latest.updated.toLocaleDateString('nb-NO')
-                        : 'Klarte ikke å hente'}
+                        : 'aldri'}
                     </p>
                   </SkeletonLoader>
                 </div>

--- a/frontend/beCompliant/src/pages/frontPage/ContextLink.tsx
+++ b/frontend/beCompliant/src/pages/frontPage/ContextLink.tsx
@@ -12,6 +12,9 @@ import { useState } from 'react';
 import { SkeletonLoader } from '@/components/SkeletonLoader';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Trash2 } from 'lucide-react';
+import { useAnswers } from '@/hooks/useAnswers';
+import { formatDateTime } from '@/utils/formatTime';
 
 export function ContextLink({
   contextId,
@@ -33,17 +36,26 @@ export function ContextLink({
       return (
         <Tooltip>
           <TooltipTrigger>
-            <p className="font-bold text-lg">{str.slice(0, maxLength)}...</p>
+            <p className="font-semibold text-xl">
+              {str.slice(0, maxLength)}...
+            </p>
           </TooltipTrigger>
           <TooltipContent>{str}</TooltipContent>
         </Tooltip>
       );
     } else {
-      return <p className="font-bold text-lg">{str}</p>;
+      return <p className="font-semibold text-xl align">{str}</p>;
     }
   }
 
   const { data: context, isPending: contextIsPending } = useContext(contextId);
+  const { data: answers, isPending: answerIsPending } = useAnswers(contextId);
+
+  const latest = answers?.length
+    ? answers.reduce((latest, current) =>
+        new Date(current.updated) > new Date(latest.updated) ? current : latest
+      )
+    : undefined;
 
   return (
     <SkeletonLoader
@@ -65,19 +77,33 @@ export function ContextLink({
             <CardContent className="w-full self-start">
               <div className="flex justify-between items-start">
                 <div className="flex flex-col gap-1 items-start">
-                  <TruncatedText str={context?.name ?? ''} maxLength={27} />
-                  <Button
-                    aria-label="Slett utfylling"
-                    variant="link"
-                    size="sm"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setIsDeleteOpen(true);
-                    }}
-                    className="text-destructive hover:text-destructive p-0"
+                  <div className="flex items-center gap-1">
+                    <TruncatedText str={context?.name ?? ''} maxLength={27} />
+                    <Button
+                      aria-label="Slett utfylling"
+                      variant="ghost"
+                      size="icon"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setIsDeleteOpen(true);
+                      }}
+                      className="text-destructive hover:text-destructive"
+                    >
+                      <Trash2 />
+                    </Button>
+                  </div>
+                  <SkeletonLoader
+                    loading={answerIsPending}
+                    width="w-[450px]"
+                    height="h-[98px]"
                   >
-                    Slett skjemautfyllingen
-                  </Button>
+                    <p className="text-xs text-muted-foreground">
+                      Sist endret:{' '}
+                      {latest
+                        ? latest.updated.toLocaleDateString('nb-NO')
+                        : 'Klarte ikke å hente'}
+                    </p>
+                  </SkeletonLoader>
                 </div>
                 <ProgressCircle contextId={contextId} formId={formId} />
               </div>

--- a/frontend/beCompliant/src/pages/frontPage/DeleteContextModal.tsx
+++ b/frontend/beCompliant/src/pages/frontPage/DeleteContextModal.tsx
@@ -7,20 +7,24 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { useDeleteContext } from '../../hooks/useContext';
+import { useContext, useDeleteContext } from '../../hooks/useContext';
 import { Trash2 } from 'lucide-react';
+import { useForm } from '@/hooks/useForm';
+import { SkeletonLoader } from '@/components/SkeletonLoader';
 
 type Props = {
   onClose: () => void;
   isOpen: boolean;
   contextId: string;
   teamId: string;
+  formId: string;
 };
 export function DeleteContextModal({
   onClose,
   isOpen,
   contextId,
   teamId,
+  formId,
 }: Props) {
   const { mutate: deleteContext, isPending: isLoading } = useDeleteContext(
     contextId,
@@ -28,15 +32,22 @@ export function DeleteContextModal({
     onClose
   );
 
+  const { data: context, isPending: contextIsPending } = useContext(contextId);
+  const { data: form, isPending: tableIsPending } = useForm(formId);
+
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <DialogContent className="sm:max-w-[450px]">
         <DialogHeader>
           <DialogTitle className="text-xl">Slett skjemautfylling</DialogTitle>
         </DialogHeader>
-        <DialogDescription className="text-base">
-          Er du sikker på at du vil slette skjemautfyllingen?
-        </DialogDescription>
+        <SkeletonLoader loading={contextIsPending || tableIsPending}>
+          <DialogDescription className="text-base">
+            Er du sikker på at du vil slette skjemautfyllingen for{' '}
+            <span className="font-bold">{form?.name}</span> med navn{' '}
+            <span className="font-bold">{context?.name}</span>?
+          </DialogDescription>
+        </SkeletonLoader>
 
         <DialogFooter className="flex justify-end space-x-2 pt-4">
           <Button variant="outline" onClick={onClose}>

--- a/frontend/beCompliant/src/pages/frontPage/DeleteContextModal.tsx
+++ b/frontend/beCompliant/src/pages/frontPage/DeleteContextModal.tsx
@@ -11,6 +11,7 @@ import { useContext, useDeleteContext } from '../../hooks/useContext';
 import { Trash2 } from 'lucide-react';
 import { useForm } from '@/hooks/useForm';
 import { SkeletonLoader } from '@/components/SkeletonLoader';
+import { toast } from 'sonner';
 
 type Props = {
   onClose: () => void;
@@ -42,10 +43,9 @@ export function DeleteContextModal({
           <DialogTitle className="text-xl">Slett skjemautfylling</DialogTitle>
         </DialogHeader>
         <SkeletonLoader loading={contextIsPending || tableIsPending}>
-          <DialogDescription className="text-base">
+          <DialogDescription className="text-base break-words max-w-sm">
             Er du sikker på at du vil slette skjemautfyllingen for{' '}
-            <span className="font-bold">{form?.name}</span> med navn{' '}
-            <span className="font-bold">{context?.name}</span>?
+            <b>{form?.name}</b> med navn <b>{context?.name}</b>?
           </DialogDescription>
         </SkeletonLoader>
 
@@ -55,7 +55,14 @@ export function DeleteContextModal({
           </Button>
           <Button
             variant="destructive"
-            onClick={() => deleteContext()}
+            onClick={() => {
+              deleteContext();
+              const toastId = 'delete-context-success';
+              toast.success(`Skjemautfyllingen ble slettet`, {
+                duration: 5000,
+                id: toastId,
+              });
+            }}
             disabled={isLoading}
           >
             {isLoading ? (
@@ -63,7 +70,7 @@ export function DeleteContextModal({
             ) : (
               <>
                 <Trash2 className="size-5" />
-                Slett skjemautfylling
+                Slett
               </>
             )}
           </Button>

--- a/frontend/beCompliant/src/styles.css
+++ b/frontend/beCompliant/src/styles.css
@@ -93,7 +93,7 @@
   --secondary: oklch(1 0 89.876);
   --secondary-foreground: oklch(0.208 0.04 265.755);
   --muted: oklch(0.968 0.007 247.896);
-  --muted-foreground: oklch(0.578 0.111 272.865);
+  --muted-foreground: oklch(0.554 0.041 257.417);
   --accent: oklch(0.909 0.003 17.218);
   --accent-foreground: oklch(0.208 0.04 265.755);
   --destructive: oklch(0.479 0.159 37.355);


### PR DESCRIPTION
**Beskrivelse**

🥅 Mål med PRen: Minske trykkflaten for slett-skjemaløsningen, og forbedre designet.

**Løsning**

🆕 Endring: 
- Minsket slett-teksten til en liten knapp til venstre for overskriften. 
- Lagt på sist-endret dato på skjemautfyllings-kortet
- Lagt til toast ved sletting
- Lagt til navn på skjema og skjemautfylling i slett-dialogen. 
- Endret hoverfargen til litt mer blå.

Mer detaljert beskrivelse: 
Det er veldig enkelt å ved en feil trykke på «Slett skjematufylling» på oversiktsiden til Regelrett i dag, når man egentlig skal inn på et skjema. Det er ikke helt kritisk, siden man uansett må bekrefte sletting, men kan være ganske irriterende.

Vi endrer derfor til en ghost-knapp slik at området for å slette blir mye mindre. Vi legger samtidig til dato for når skjemaet sist ble endret. Og vi gjør det tydeligere hvilket kort man hovrer over, med å legge til en svak blånyanse.

I tillegg gjør vi endringer på modalen for å bekrefte for at det skal være tydelig hva man er i ferd med å slette. Og en bekreftelse etter at skjemaet er slettet. 


| Før | Etter |
|---|---|
| ![image](https://github.com/user-attachments/assets/e5714963-7c8e-48fd-b8ed-8620484694fa) | ![image](https://github.com/user-attachments/assets/a524908b-8168-425e-a34d-6a7659ee4674) |
| ![image](https://github.com/user-attachments/assets/342b640a-47b9-4910-a5d1-2d8644d0417e) | ![image](https://github.com/user-attachments/assets/c027a153-2c52-42cb-9d38-0b87e35107f3) |
||![image](https://github.com/user-attachments/assets/1cd621ff-ef1e-4b56-889d-5f62d38f04c6)|


