### PR TITLE
Oppdatere ui på filtrerte svar

### DIFF
--- a/frontend/beCompliant/src/pages/activityPage/ActivityPage.tsx
+++ b/frontend/beCompliant/src/pages/activityPage/ActivityPage.tsx
@@ -1,7 +1,6 @@
 import { useParams } from 'react-router';
 import { Page } from '../../components/layout/Page';
 import { TableComponent } from './table/Table';
-import { TableStatistics } from './TableStatistics';
 import { useAnswers } from '../../hooks/useAnswers';
 import { useComments } from '../../hooks/useComments';
 import { useForm } from '../../hooks/useForm';
@@ -13,7 +12,6 @@ import { useUser } from '../../hooks/useUser';
 import { useState } from 'react';
 import { SettingsModal } from './settingsModal/SettingsModal';
 import RedirectBackButton from '../../components/buttons/RedirectBackButton';
-import { useQueryClient } from '@tanstack/react-query';
 import { SkeletonLoader } from '@/components/SkeletonLoader';
 import { Button } from '@/components/ui/button';
 import { Settings } from 'lucide-react';
@@ -21,7 +19,6 @@ import { Settings } from 'lucide-react';
 export default function ActivityPage() {
   const params = useParams();
   const contextId = params.contextId;
-  const queryClient = useQueryClient();
 
   const {
     data: context,
@@ -40,6 +37,7 @@ export default function ActivityPage() {
     error: tableError,
     isPending: tableIsPending,
   } = useForm(context?.formId);
+
   const {
     data: comments,
     error: commentError,
@@ -116,13 +114,6 @@ export default function ActivityPage() {
             >
               <p className="text-lg font-semibold"> Team: {teamName} </p>
             </SkeletonLoader>
-            <SkeletonLoader
-              loading={tableIsPending || answerIsPending || commentIsPending}
-              width="w-full"
-              height="h-6"
-            >
-              <TableStatistics filteredData={tableData?.records ?? []} />
-            </SkeletonLoader>
           </div>
           <SkeletonLoader
             loading={
@@ -147,6 +138,9 @@ export default function ActivityPage() {
                   data={tableData?.records ?? []}
                   tableData={tableData}
                   user={userinfo.user}
+                  isLoading={
+                    tableIsPending || answerIsPending || commentIsPending
+                  }
                 />
               )}
           </SkeletonLoader>

--- a/frontend/beCompliant/src/pages/activityPage/TableStatistics.tsx
+++ b/frontend/beCompliant/src/pages/activityPage/TableStatistics.tsx
@@ -1,14 +1,36 @@
+import { Switch } from '@/components/ui/switch';
 import { Question } from '../../api/types';
 import { Progress } from '@/components/ui/progress';
+import { Table } from '@tanstack/react-table';
+import { useState } from 'react';
 
 interface Props {
   filteredData: Question[];
+  table: Table<any>;
 }
 
-export const TableStatistics = ({ filteredData }: Props) => {
-  const numberOfQuestions = filteredData.length;
+export const TableStatistics = ({ filteredData, table }: Props) => {
+  const hasActiveFilters = table.getState().columnFilters.length > 0;
+  const showForActiveFiltersLocalstorage = localStorage.getItem(
+    'showForActiveFilters'
+  );
+  const [showForActiveFilters, setShowForActiveFilters] = useState<boolean>(
+    showForActiveFiltersLocalstorage
+      ? JSON.parse(showForActiveFiltersLocalstorage)
+      : true
+  );
+  const rows = showForActiveFilters
+    ? table.getFilteredRowModel().rows
+    : table.getPreFilteredRowModel().rows;
+  const numberOfQuestions = showForActiveFilters
+    ? rows.length
+    : filteredData.length;
   const numberOfAnswers = filteredData.reduce((count, data) => {
-    if (data.answers?.[0]?.answer && data.answers.at(-1)?.answer !== '') {
+    if (
+      rows.some((row) => row.original.recordId === data.recordId) &&
+      data.answers?.[0]?.answer &&
+      data.answers.at(-1)?.answer !== ''
+    ) {
       count++;
     }
     return count;
@@ -17,6 +39,11 @@ export const TableStatistics = ({ filteredData }: Props) => {
   const percentageAnswered = Math.round(
     (numberOfAnswers / numberOfQuestions) * 100
   );
+
+  const updateShowForActiveFilters = (show: boolean) => {
+    setShowForActiveFilters(show);
+    localStorage.setItem('showForActiveFilters', JSON.stringify(show));
+  };
 
   return (
     <div className="max-w-[40%]">
@@ -30,6 +57,15 @@ export const TableStatistics = ({ filteredData }: Props) => {
           {percentageAnswered}%)
         </span>
       </div>
+      {hasActiveFilters && (
+        <div className="font-bold">
+          Vis for aktivt filter{' '}
+          <Switch
+            onCheckedChange={(e) => updateShowForActiveFilters(e)}
+            checked={showForActiveFilters}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/beCompliant/src/pages/activityPage/table/DataTable.tsx
+++ b/frontend/beCompliant/src/pages/activityPage/table/DataTable.tsx
@@ -1,5 +1,4 @@
 import { Table as TanstackTable, flexRender } from '@tanstack/react-table';
-import React from 'react';
 import { PaginationButtonContainer } from './pagination/PaginationButtonContainer';
 import { TableStateProvider } from './TableState';
 import {
@@ -37,7 +36,7 @@ export function DataTable<TData>({ table }: Props<TData>) {
             </TableHeader>
 
             <TableBody>
-              {table.getRowModel().rows.map((row, rowIndex) => (
+              {table.getRowModel().rows.map((row) => (
                 <TableRow key={row.id}>
                   {row.getVisibleCells().map((cell) => (
                     <TableCell

--- a/frontend/beCompliant/src/pages/activityPage/table/Table.tsx
+++ b/frontend/beCompliant/src/pages/activityPage/table/Table.tsx
@@ -33,6 +33,8 @@ import { DataTableSearch } from './DataTableSearch';
 import { CSVDownload } from './csvDownload/CSVDownload';
 import { ColumnActions } from '@/pages/activityPage/table/ColumnActions';
 import { cn } from '@/lib/utils';
+import { SkeletonLoader } from '@/components/SkeletonLoader';
+import { TableStatistics } from '../TableStatistics';
 
 type Props = {
   tableMetadata: Column[];
@@ -41,6 +43,7 @@ type Props = {
   tableData: Form;
   user: User;
   contextId: string;
+  isLoading: boolean;
 };
 
 export function TableComponent({
@@ -50,6 +53,7 @@ export function TableComponent({
   user,
   tableMetadata,
   filterByAnswer,
+  isLoading,
 }: Props) {
   const [
     columnVisibility,
@@ -165,7 +169,7 @@ export function TableComponent({
       const answer = row.answers?.at(-1)?.answer;
       return answer ? 'utfylt' : 'ikke utfylt';
     },
-    filterFn: (row, columnId, filterValue: string[]) => {
+    filterFn: (row, _, filterValue: string[]) => {
       const latestAnswer = row.original.answers?.at(-1)?.answer;
       const status = latestAnswer ? 'utfylt' : 'ikke utfylt';
       return filterValue.includes(status);
@@ -260,6 +264,14 @@ export function TableComponent({
 
   return (
     <>
+      <div className="px-10">
+        <SkeletonLoader loading={isLoading} width="w-full" height="h-6">
+          <TableStatistics
+            filteredData={tableData?.records ?? []}
+            table={table}
+          />
+        </SkeletonLoader>
+      </div>
       <div className="flex justify-between items-center px-10 flex-wrap">
         <DataTableSearch table={table} />
         <CSVDownload


### PR DESCRIPTION
**Beskrivelse**

Brukere har ingen god måte å se fremgangen på utfylte svar basert på de aktive filtrene de har valgt.

**Løsning**

Legger til en bryter slik at man kan toggle mellom å se fremgang for hele skjemaet, eller for de radene som vises basert på aktive filtre. Lagrer valget i localstorage slik at man slipper å endre på det hver gang.
![Screenshot 2025-06-10 at 09 50 50](https://github.com/user-attachments/assets/8ef0e15d-98af-40ee-ba77-1b38b656e5e0)
![Screenshot 2025-06-10 at 09 50 43](https://github.com/user-attachments/assets/a1ddb34b-4e70-4ee3-8ce3-42ab73ff6222)


Resolves #793 
