### PR TITLE
feat: Netty http header settings configurable

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -37,6 +37,11 @@ server:
   # If not set then origin will be matched over root_url. Supports wildcard symbol "*".
   allowed_origins: "localhost:5173,localhost:8080"
 
+  # Configure http request limits for the netty server
+  max_initial_line_length: 4096
+  max_header_size: 8192
+  max_chunk_size: 8192
+
 #################################### Auth ##############################
 
 microsoft_graph:

--- a/conf/sample.yaml
+++ b/conf/sample.yaml
@@ -3,9 +3,8 @@
 # Everything has defaults so you only need to uncomment things you want to
 # change
 #
-#
 # base:
-# # possible values : production, development
+#   # possible values : production, development
 #   mode: "production"
 #
 # #################################### Server ##############################
@@ -37,6 +36,11 @@
 #   # allowed_origins is a comma-separated list of origins that can establish connection with Regelrett Live.
 #   # If not set then origin will be matched over root_url. Supports wildcard symbol "*".
 #   allowed_origins: "localhost:5173,localhost:8080"
+#
+#   # Configure http request limits for the netty server
+#   max_initial_line_length: 4096
+#   max_header_size: 8192
+#   max_chunk_size: 8192
 #
 # #################################### Auth ##############################
 #
@@ -80,10 +84,10 @@
 #   log_queries: false
 #
 #   # Lock the database for the migrations, default is true.
-#   migration_locking : true
+#   migration_locking: true
 #
 #   # 3000Only if migrationLocking is set. How many seconds to wait before failing to lock the database for the migrations, default is 0.
-#   locking_attempt_timeout_sec : 0
+#   locking_attempt_timeout_sec: 0
 #
 # answer_history_cleanup:
 #   cleanup_interval_weeks: "4"

--- a/src/main/kotlin/no/bekk/Application.kt
+++ b/src/main/kotlin/no/bekk/Application.kt
@@ -49,9 +49,9 @@ class Regelrett : CliktCommand() {
             Netty,
             appProperties,
         ) {
-            maxInitialLineLength = 16384
-            maxHeaderSize = 32768
-            maxChunkSize = 32768
+            maxInitialLineLength = cfg.server.maxInitialLineLength
+            maxHeaderSize = cfg.server.maxHeaderSize
+            maxChunkSize = cfg.server.maxChunkSize
             connectors.add(
                 EngineConnectorBuilder().apply {
                     port = cfg.server.httpPort

--- a/src/main/kotlin/no/bekk/configuration/AppConfig.kt
+++ b/src/main/kotlin/no/bekk/configuration/AppConfig.kt
@@ -80,6 +80,9 @@ data class ServerConfig(
     val httpPort: Int,
     val routerLogging: Boolean,
     val allowedOrigins: List<String>,
+    val maxInitialLineLength: Int,
+    val maxHeaderSize: Int,
+    val maxChunkSize: Int,
 )
 
 class DatabaseConfig(

--- a/src/main/kotlin/no/bekk/configuration/ConfigBuilder.kt
+++ b/src/main/kotlin/no/bekk/configuration/ConfigBuilder.kt
@@ -221,6 +221,9 @@ class ConfigBuilder {
             httpAddr = yaml.getStringOrNull("server", "http_addr") ?: "0.0.0.0",
             routerLogging = yaml.getBoolOrNull("server", "router_logging") ?: false,
             allowedOrigins = yaml.getStringOrNull("server", "allowed_origins")?.split(",") ?: emptyList(),
+            maxInitialLineLength = yaml.getIntOrNull("server", "max_initial_line_length") ?: 4096,
+            maxHeaderSize = yaml.getIntOrNull("server", "max_header_size") ?: 8192,
+            maxChunkSize = yaml.getIntOrNull("server", "max_chunk_size") ?: 8192,
         )
     }
 

--- a/src/test/kotlin/no/bekk/ApplicationTest.kt
+++ b/src/test/kotlin/no/bekk/ApplicationTest.kt
@@ -30,7 +30,7 @@ class ApplicationTest {
         paths = PathsConfig(""),
         microsoftGraph = MicrosoftGraphConfig("", ""),
         oAuth = OAuthConfig("https://test.com", "test", "", "", "", "", "", "", ""),
-        server = ServerConfig("", "", "", 0, false, emptyList()),
+        server = ServerConfig("", "", "", 0, false, emptyList(), 4096, 8192, 8192),
         database = DatabaseConfig("", "", ""),
         answerHistoryCleanup = AnswerHistoryCleanupConfig(""),
         frontendDevServer = FrontendDevServerConfig("", 0, "", ""),

--- a/src/test/kotlin/no/bekk/TestUtils.kt
+++ b/src/test/kotlin/no/bekk/TestUtils.kt
@@ -38,7 +38,7 @@ object TestUtils {
             paths = PathsConfig(""),
             microsoftGraph = MicrosoftGraphConfig("", ""),
             oAuth = OAuthConfig("https://test.com", "test", "", "", "", "", "", "", ""),
-            server = ServerConfig("", "", "", 0, false, emptyList()),
+            server = ServerConfig("", "", "", 0, false, emptyList(), 4096, 8192, 8192),
             database = DatabaseConfig("", "", ""),
             answerHistoryCleanup = AnswerHistoryCleanupConfig(""),
             frontendDevServer = FrontendDevServerConfig("", 0, "", ""),


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**
 
Muligheten for å konfigurere http header innstillinger for netty serveren via konfigurasjonsflyten.

**Hvorfor trenger vi denne funskjonaliteten?**

Mistanke om at miljøet på skip fører til at enkelte kall overstiger defaultverdiene.

**Hvem er funskjonaliteten for?**

Enkelte brukere på kartverket

**Er det potensielle risikoer knyttet til endringen?**

Defaulten er satt for å beskytte mot at angripere sender kunstig store pakker, som kan brukes i DoS-angrep.

- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?

<!--

- Lukker automatisk koblet Issue når PR-en blir merget.

Bruk: "Fixes #<issue nummer>", eller "Fixes (paste link til issue)"

-->

Fixes #

**Anmerkninger til vurderingen:**

- [ ] Det virker som forventet fra en brukers perspektiv.
- [ ] Dokumentasjonen er oppdatert.
- [ ] Det er gjort adekvar feilhåndtering og logging.
