### PR TITLE
Fix hitbox for back button

### DIFF
--- a/app/pages/questionPage/QuestionPage.tsx
+++ b/app/pages/questionPage/QuestionPage.tsx
@@ -68,7 +68,7 @@ export default function QuestionPage() {
       <Button
         variant="link"
         onClick={handleBackButton}
-        className="flex justify-start ml-2 text-lg"
+        className="flex justify-start ml-2 text-lg w-max"
       >
         <ArrowLeft className="size-5" />
         Tilbake


### PR DESCRIPTION
**Hva er endringen du har gjort?**
La til w-max på tilbake-knappen slik at hitboxen ikke spenner over hele siden.

**Hvorfor trenger vi denne funskjonaliteten?**

Design-bug at hitboxen er utenfor det antatte området

Fixes https://kartverket.atlassian.net/jira/software/projects/EDSKVIS/boards/177?selectedIssue=EDSKVIS-727

**Bilder**
| Før | Etter |
| --- | ----- |
| <img width="1186" height="530" alt="image" src="https://github.com/user-attachments/assets/58d94b8e-9b3b-436f-9797-ef88eb733f78" /> | <img width="1186" height="530" alt="image" src="https://github.com/user-attachments/assets/401e6c90-bb08-4c5c-a295-fa625b5c419d" /> |
