### PR TITLE
Fix refresh by answer update bug

### DIFF
--- a/app/pages/activityPage/table/AnswerCell.tsx
+++ b/app/pages/activityPage/table/AnswerCell.tsx
@@ -12,7 +12,7 @@ import { useIsMutating } from "@tanstack/react-query";
 import MultiSelectAnswer from "@/components/answers/MultiSelectAnswer";
 
 type Props = {
-  value: string | undefined;
+  value: string;
   answerType: AnswerType;
   unit?: string;
   units?: string[] | null;

--- a/app/pages/activityPage/table/TableCell.tsx
+++ b/app/pages/activityPage/table/TableCell.tsx
@@ -1,7 +1,7 @@
 import type { Row } from "@tanstack/react-table";
 import { AnswerCell } from "./AnswerCell";
 import type { Column, Question, User } from "@/api/types";
-import { AnswerType, OptionalFieldType } from "@/api/types";
+import { OptionalFieldType } from "@/api/types";
 import colorUtils from "@/utils/colorUtils";
 import Markdown from "react-markdown";
 import { markdownComponents } from "@/utils/markdownComponents";

--- a/app/pages/activityPage/table/TableCell.tsx
+++ b/app/pages/activityPage/table/TableCell.tsx
@@ -28,7 +28,7 @@ export const TableCell = ({
   if (answerable) {
     return (
       <AnswerCell
-        value={row.original.answers.at(-1)?.answer}
+        value={row.original.answers.at(-1)?.answer ?? ""}
         answerType={row.original.metadata?.answerMetadata.type}
         unit={row.original.answers.at(-1)?.answerUnit}
         units={row.original.metadata?.answerMetadata.units}


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**

Lagt til optimistisk loading (tanstack funksjonalitet) for å umiddelbart vise verdien du har skrevet/trykket inn i inputfeltet, før det sendes til backenden og hentes inn igjen til frontenden. 

**Hvorfor trenger vi denne funskjonaliteten?**

Første problemet var at selv om man fylte inn svaret oppdaterte ikke uiet seg før man refreset pga feil invalidering av query. Da dette ble rettte opp i viste det seg at dette skapte dette en delay i ui - slik at du skriver noe inn i tabellen, det blir sendt til backenden og så hentet av frontenden - i mellomrtiden rekker du kanskje å krive ett tall i inputfeltet under før innlastingen skjer på nytt og refresher hele tabbel og det du hadde skrevet inn i input-feltet forsvinner. Dette løser optimistisk loading ved at den oppdaterer queryen direkte mens du sender den til backenden. 

**Hvem er funskjonaliteten for?**

skjema-utfyllere

**Er det potensielle risikoer knyttet til endringen?**

Irritasjon: hvis du trykker deg direkte inn i et annet input-felt etter å ha skrevet noe vil du miste fokus 1 gang. Ikke klart å finne en smidig løsning på dette. 

- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?

<!--

- Lukker automatisk koblet Issue når PR-en blir merget.

Bruk: "Fixes #<issue nummer>", eller "Fixes (paste link til issue)"

-->

Fixes #

**Anmerkninger til vurderingen:**

- [ ] Det virker som forventet fra en brukers perspektiv.
- [ ] Dokumentasjonen er oppdatert.
- [ ] Det er gjort adekvar feilhåndtering og logging.
