### PR TITLE
Konfigurerbart filter på grupper

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -50,6 +50,7 @@ server:
 microsoft_graph:
   base_url: "https://graph.microsoft.com"
   member_of_path: "/v1.0/me/memberof/microsoft.graph.group"
+  groupfilter: null
 
 oauth:
   base_url: "https://login.microsoftonline.com"

--- a/conf/sample.yaml
+++ b/conf/sample.yaml
@@ -47,6 +47,8 @@
 # microsoft_graph:
 #   base_url: "https://graph.microsoft.com"
 #   member_of_path: "/v1.0/me/memberof/microsoft.graph.group"
+#   groupfilter: null
+
 #
 # oauth:
 #   base_url: "https://login.microsoftonline.com"

--- a/src/main/kotlin/no/bekk/configuration/AppConfig.kt
+++ b/src/main/kotlin/no/bekk/configuration/AppConfig.kt
@@ -55,6 +55,7 @@ data class FrontendDevServerConfig(
 class MicrosoftGraphConfig(
     val baseUrl: String,
     val memberOfPath: String,
+    val groupnameFilter: String,
 )
 
 data class OAuthConfig(

--- a/src/main/kotlin/no/bekk/configuration/AppConfig.kt
+++ b/src/main/kotlin/no/bekk/configuration/AppConfig.kt
@@ -55,7 +55,7 @@ data class FrontendDevServerConfig(
 class MicrosoftGraphConfig(
     val baseUrl: String,
     val memberOfPath: String,
-    val groupnameFilter: String,
+    val groupFilter: String,
 )
 
 data class OAuthConfig(

--- a/src/main/kotlin/no/bekk/configuration/ConfigBuilder.kt
+++ b/src/main/kotlin/no/bekk/configuration/ConfigBuilder.kt
@@ -196,6 +196,7 @@ class ConfigBuilder {
     fun buildMicrosoftGraphConfig(yaml: YamlConfig) = MicrosoftGraphConfig(
         baseUrl = yaml.getStringOrNull("microsoft_graph", "base_url") ?: "https://graph.microsoft.com",
         memberOfPath = yaml.getStringOrNull("microsoft_graph", "member_of_path") ?: "/v1.0/me/memberOf/microsoft.graph.group",
+        groupnameFilter = yaml.getStringOrNull("microsoft_graph", "groupfilter") ?: "",
     )
 
     fun buildOAuthConfig(yaml: YamlConfig): OAuthConfig = OAuthConfig(

--- a/src/main/kotlin/no/bekk/configuration/ConfigBuilder.kt
+++ b/src/main/kotlin/no/bekk/configuration/ConfigBuilder.kt
@@ -196,7 +196,7 @@ class ConfigBuilder {
     fun buildMicrosoftGraphConfig(yaml: YamlConfig) = MicrosoftGraphConfig(
         baseUrl = yaml.getStringOrNull("microsoft_graph", "base_url") ?: "https://graph.microsoft.com",
         memberOfPath = yaml.getStringOrNull("microsoft_graph", "member_of_path") ?: "/v1.0/me/memberOf/microsoft.graph.group",
-        groupnameFilter = yaml.getStringOrNull("microsoft_graph", "groupfilter") ?: "",
+        groupFilter = yaml.getStringOrNull("microsoft_graph", "groupfilter") ?: "",
     )
 
     fun buildOAuthConfig(yaml: YamlConfig): OAuthConfig = OAuthConfig(

--- a/src/main/kotlin/no/bekk/services/MicrosoftService.kt
+++ b/src/main/kotlin/no/bekk/services/MicrosoftService.kt
@@ -77,7 +77,6 @@ class MicrosoftServiceImpl(private val config: Config, private val client: HttpC
     override suspend fun fetchGroups(bearerToken: String): List<MicrosoftGraphGroup> {
         val url = "${config.microsoftGraph.baseUrl + config.microsoftGraph.memberOfPath}?\$count=true&\$select=id,displayName"
 
-
         return try {
             ExternalServiceTimer.time("Microsoft", "fetchGroups") {
                 val response: HttpResponse = client.get(url) {

--- a/src/main/kotlin/no/bekk/services/MicrosoftService.kt
+++ b/src/main/kotlin/no/bekk/services/MicrosoftService.kt
@@ -83,8 +83,8 @@ class MicrosoftServiceImpl(private val config: Config, private val client: HttpC
                 val response: HttpResponse = client.get(url) {
                     bearerAuth(bearerToken)
                     header("ConsistencyLevel", "eventual")
-                    if (!config.microsoftGraph.groupnameFilter.isBlank()) {
-                        parameter("\$filter",config.microsoftGraph.groupnameFilter)
+                    if (!config.microsoftGraph.groupFilter.isBlank()) {
+                        parameter("\$filter",config.microsoftGraph.groupFilter)
                     }
                 }
 

--- a/src/test/kotlin/no/bekk/ApplicationTest.kt
+++ b/src/test/kotlin/no/bekk/ApplicationTest.kt
@@ -28,7 +28,7 @@ class ApplicationTest {
         homePath = "",
         mode = "development",
         paths = PathsConfig(""),
-        microsoftGraph = MicrosoftGraphConfig("", ""),
+        microsoftGraph = MicrosoftGraphConfig("", "", ""),
         oAuth = OAuthConfig("https://test.com", "test", "", "", "", "", "", "", ""),
         server = ServerConfig("", "", "", 0, false, false, emptyList(), 4096, 8192, 8192),
         database = DatabaseConfig("", "", ""),

--- a/src/test/kotlin/no/bekk/TestUtils.kt
+++ b/src/test/kotlin/no/bekk/TestUtils.kt
@@ -36,7 +36,7 @@ object TestUtils {
             homePath = "",
             mode = "development",
             paths = PathsConfig(""),
-            microsoftGraph = MicrosoftGraphConfig("", ""),
+            microsoftGraph = MicrosoftGraphConfig("", "", ""),
             oAuth = OAuthConfig("https://test.com", "test", "", "", "", "", "", "", ""),
             server = ServerConfig("", "", "", 0, false, false, emptyList(), 4096, 8192, 8192),
             database = DatabaseConfig("", "", ""),


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**

en env variabel `groupfilter` er lagt til slik at man kan sende inn et filter på group name. Så hvis du vil overkjøre den setter man feks  `RR_MICROSOFT_GRAPH_GROUPFILTER=startswith(displayName,'AAD-') or displayName eq 'Kartverket'`

**Hvorfor trenger vi denne funskjonaliteten?**

For å bli kvitt en unødvendig lang liste med teams på forsiden og i teamslisten når man oppretter skjema. I tillegg sparer man litt hentetid da man filterer ut en del irrlevante grupper som da ikke forsøker å hente skjemaer på etc.

**Hvem er funskjonaliteten for?**

Brukere som benytter seg av forsiden og oppretter skjema via /ny siden. 

**Er det potensielle risikoer knyttet til endringen?**

[Legg til informasjon om eventuelle sikkerhetstilak eller vurderinger som bør gjøres]

- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?

<!--

- Lukker automatisk koblet Issue når PR-en blir merget.

Bruk: "Fixes #<issue nummer>", eller "Fixes (paste link til issue)"

-->

Fixes #

**Anmerkninger til vurderingen:**

- [ ] Det virker som forventet fra en brukers perspektiv.
- [ ] Dokumentasjonen er oppdatert.
- [ ] Det er gjort adekvar feilhåndtering og logging.
