### PR TITLE
Add custom heading components for markdown

### DIFF
--- a/app/utils/markdownComponents.tsx
+++ b/app/utils/markdownComponents.tsx
@@ -1,6 +1,21 @@
 import type { Components } from "react-markdown";
 
 export const markdownComponents: Components = {
+  h1: ({ children, ...props }) => (
+    <h1 className="text-3xl font-bold mt-4 mb-2" {...props}>
+      {children}
+    </h1>
+  ),
+  h2: ({ children, ...props }) => (
+    <h2 className="text-2xl font-semibold mt-3 mb-1" {...props}>
+      {children}
+    </h2>
+  ),
+  h3: ({ children, ...props }) => (
+    <h3 className="text-xl font-semibold mt-2 mb-1" {...props}>
+      {children}
+    </h3>
+  ),
   a: ({ href, children, ...props }) => (
     <a
       href={href}


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**

Få overskriftsstyling på markdown elementer i spørsmålsbeskrivelsen i regelrett: 
<img width="719" height="561" alt="image" src="https://github.com/user-attachments/assets/3a28aa39-cd96-4705-bf45-272593a72a95" />

**Hvorfor trenger vi denne funskjonaliteten?**

Når det skrives ### eller ## etc i airtable på sprøsmålsbeskrivelsen skal det visuelt rendres til overskriftene h3, h2 etc - I HTMLen ser man at teksten blir rendret til H1, H2... tags, men de mangler stylingen man forventer på h1,h2... tagsene.

Dette fikses ved å definere komponenten h1, h2, og h3 skal rendres til i markdownCompoenents. Her kan man strengt talt overstyre rendringen helt.    

**Hvem er funskjonaliteten for?**

Den som lager forms-ene i airtable/yaml og ønsker å benytte seg av markdown overskrifter i spørsmålbeskrivelsen til skjeamer. 

