### PR TITLE
Add Metrics enpoint

### DIFF
--- a/src/main/kotlin/no/bekk/database/ContextRepository.kt
+++ b/src/main/kotlin/no/bekk/database/ContextRepository.kt
@@ -16,6 +16,7 @@ interface ContextRepository {
     fun getContext(id: String): DatabaseContext
     fun deleteContext(id: String): Boolean
     fun changeTeam(contextId: String, newTeamId: String): Boolean
+    fun getContextMetrics(): List<DatabaseContextMetrics>
 }
 
 class ContextRepositoryImpl(private val database: Database) : ContextRepository {
@@ -182,5 +183,52 @@ class ContextRepositoryImpl(private val database: Database) : ContextRepository 
             logger.error("Database error updating team for context $contextId with teamId $newTeamId", e)
             throw DatabaseException("Failed to update team for context $contextId", "changeTeam", e)
         }
+    }
+
+   override fun getContextMetrics(): List<DatabaseContextMetrics>{
+        logger.debug("Fetching context-stats for team")
+
+
+        val sqlStatement = """
+        SELECT c.id,
+               c.team_id,
+               c.table_id,
+               c.name,
+               COUNT(a.id) AS answer_count,
+               MIN(a.updated) AS oldest_updated
+        FROM contexts c
+        LEFT JOIN answers a ON a.contexts = c.id
+        GROUP BY c.id, c.team_id, c.table_id, c.name
+    """
+        return try {
+            database.getConnection().use { conn ->
+                conn.prepareStatement(sqlStatement).use { statement ->
+
+                    val result = statement.executeQuery()
+                    buildList {
+                        while (result.next()) {
+                            add(
+                                DatabaseContextMetrics(
+                                    id = result.getString("id"),
+                                    teamId = result.getString("team_id"),
+                                    formId = result.getString("table_id"),
+                                    name = result.getString("name"),
+                                    answerCount = result.getInt("answer_count"),
+                                    oldestUpdate = result.getString("oldest_update"),
+                                ),
+                            )
+                        }
+                    }
+                }.also {
+                    logger.debug("Successfully fetched context metrics")
+                }
+
+
+            }
+        } catch (e: SQLException) {
+            logger.error("Database error fetching context metrics", e)
+            throw DatabaseException("Failed to fetch context metrics", "getContextMetrics", e)
+        }
+
     }
 }

--- a/src/main/kotlin/no/bekk/database/ContextRepository.kt
+++ b/src/main/kotlin/no/bekk/database/ContextRepository.kt
@@ -195,9 +195,9 @@ class ContextRepositoryImpl(private val database: Database) : ContextRepository 
                c.table_id,
                c.name,
                COUNT(a.id) AS answer_count,
-               MIN(a.updated) AS oldest_updated
+               MIN(a.updated) AS oldest_update
         FROM contexts c
-        LEFT JOIN answers a ON a.contexts = c.id
+        LEFT JOIN answers a ON a.context_id = c.id
         GROUP BY c.id, c.team_id, c.table_id, c.name
     """
         return try {

--- a/src/main/kotlin/no/bekk/database/DatabaseContext.kt
+++ b/src/main/kotlin/no/bekk/database/DatabaseContext.kt
@@ -27,3 +27,13 @@ data class DatabaseContextRequest(
     val copyContext: String? = null,
     val copyComments: String? = null,
 )
+
+@Serializable
+data class DatabaseContextMetrics(
+    val id: String,
+    val teamId: String,
+    val formId: String,
+    val name: String,
+    val answerCount: Int,
+    val oldestUpdate: String
+)

--- a/src/main/kotlin/no/bekk/database/DatabaseContext.kt
+++ b/src/main/kotlin/no/bekk/database/DatabaseContext.kt
@@ -35,5 +35,5 @@ data class DatabaseContextMetrics(
     val formId: String,
     val name: String,
     val answerCount: Int,
-    val oldestUpdate: String
+    val oldestUpdate: String?
 )

--- a/src/main/kotlin/no/bekk/model/internal/Metrics.kt
+++ b/src/main/kotlin/no/bekk/model/internal/Metrics.kt
@@ -1,0 +1,13 @@
+package no.bekk.model.internal
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ContextMetrics(
+    val teamId: String,
+    val formName: String,
+    val contextName: String,
+    val answerCount: Int,
+    val questionCount: Int,
+    val oldestUpdate: String?
+)

--- a/src/main/kotlin/no/bekk/routes/ContextRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ContextRouting.kt
@@ -203,6 +203,18 @@ fun Route.contextRouting(
             }
         }
     }
+    route("/contextMetrics") {
+        get {
+            logger.info("Received GET /contextMetrics with teamIds")
+
+                val contextMetrics = contextRepository.getContextMetrics()
+
+                call.respond(HttpStatusCode.OK, Json.encodeToString(contextMetrics))
+                return@get
+
+        }
+    }
+
 }
 
 @Serializable

--- a/src/main/kotlin/no/bekk/routes/ContextRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ContextRouting.kt
@@ -203,18 +203,6 @@ fun Route.contextRouting(
             }
         }
     }
-    route("/contextMetrics") {
-        get {
-            logger.info("Received GET /contextMetrics with teamIds")
-
-                val contextMetrics = contextRepository.getContextMetrics()
-
-                call.respond(HttpStatusCode.OK, Json.encodeToString(contextMetrics))
-                return@get
-
-        }
-    }
-
 }
 
 @Serializable

--- a/src/test/kotlin/no/bekk/routes/MockContextRepository.kt
+++ b/src/test/kotlin/no/bekk/routes/MockContextRepository.kt
@@ -2,6 +2,7 @@ package no.bekk.routes
 
 import no.bekk.database.ContextRepository
 import no.bekk.database.DatabaseContext
+import no.bekk.database.DatabaseContextMetrics
 import no.bekk.database.DatabaseContextRequest
 
 interface MockContextRepository : ContextRepository {
@@ -26,6 +27,10 @@ interface MockContextRepository : ContextRepository {
     }
 
     override fun getContextByTeamIdAndFormId(teamId: String, formId: String): List<DatabaseContext> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getContextMetrics(): List<DatabaseContextMetrics> {
         TODO("Not yet implemented")
     }
 }


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**

Lagt til et endepunkt som det er tenkt at sampi skal kunne bruke for å hente metrikker om alle regelrett-skjemautfyllingene. 
Endepunktet returnerer skjemautfyllingsnavn (contextName), skjema navn (formName aka sikkerhetskontrollere/Datasettvurdering...), antall kontrollere besvart, antall kontrollere i skjemaet, og når det siste svaret på en kontroller ble oppdatert. 

**Hvorfor trenger vi denne funskjonaliteten?**

For at smapi skal kunne hente inn metrikker om regelrett og på sikt kunne gi visualiseringer i kartverket dev og annen statestikk. 

**Hvem er funskjonaliteten for?**

Smapi, brukere av kartverket dev, folk somer glad i statestikk. 

**Er det potensielle risikoer knyttet til endringen?**

Endepunktet er ikke under entra - autentisering

- Trengs det noen sikkerhetstiltak eller ytterligere vurderinger?

Bør se på plattform sikring på skip. 

