### PR TITLE
fix flyway db prefix error

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
 tasks {
     withType<ShadowJar> {
         isZip64 = true
-        mergeServiceFiles{
+        mergeServiceFiles {
             include("META-INF/services/**")
             duplicatesStrategy = DuplicatesStrategy.INCLUDE
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,10 @@ dependencies {
 tasks {
     withType<ShadowJar> {
         isZip64 = true
-        mergeServiceFiles()
+        mergeServiceFiles{
+            include("META-INF/services/**")
+            duplicatesStrategy = DuplicatesStrategy.INCLUDE
+        }
     }
     withType<Test> {
         testLogging {


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**
I Argo er regelrett deployen broken, og returnerer feilmeldingen: "Unknown prefix for location (should be one of filesystem:, classpath:, gcs:, or s3:): classpath:db/callback"

Dette kom etter oppgradering av ktor fra 3.2.3 til 3.3.3, samt en nyere versjon av flyway > 11.13.0

Det ser ut til at flyway og shadowJar ikke fungerer supert i ktor versjoner > 3.2.3, hvor noen  med lignende problem fikset det slik: https://github.com/flyway/flyway/issues/4170

Hvis det ikke fungerer, bør vi degradere ktor eller flyway.

