### PR TITLE
Forbedret logging, tydeligere suksesslogger og deaktivert webhook-refresh for schema-kilder

### DIFF
--- a/src/main/kotlin/no/bekk/plugins/RequestLogging.kt
+++ b/src/main/kotlin/no/bekk/plugins/RequestLogging.kt
@@ -10,12 +10,16 @@ val RequestLoggingPlugin =
     createApplicationPlugin(name = "RequestLoggingPlugin") {
         val logger = LoggerFactory.getLogger("no.bekk.plugins.RequestLogging")
         onCall { call ->
-            call.request.origin.apply {
-                logger.info("${call.getRequestInfo()} Request started")
+            if (call.request.uri != "/health") {
+                call.request.origin.apply {
+                    logger.info("${call.getRequestInfo()} Request started")
+                }
             }
         }
 
         onCallRespond { call ->
-            logger.info("${call.getRequestInfo()} Response: ${call.response.status()}")
+            if (call.request.uri != "/health") {
+                logger.info("${call.getRequestInfo()} Response: ${call.response.status()}")
+            }
         }
     }

--- a/src/main/kotlin/no/bekk/providers/AirTableProvider.kt
+++ b/src/main/kotlin/no/bekk/providers/AirTableProvider.kt
@@ -279,7 +279,7 @@ class AirTableProvider(
                 true
             }
             else -> {
-                logger.error("Failed to refresh webhook $webhookId with status $responseStatus")
+                logger.warn("Failed to refresh webhook $webhookId for table $tableId with status $responseStatus")
                 false
             }
         }

--- a/src/main/kotlin/no/bekk/routes/FormRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/FormRouting.kt
@@ -20,6 +20,7 @@ fun Route.formRouting(formService: FormService) {
                 val forms = formService.getFormProviders().map {
                     it.getForm().let { FormsMetadataDto(it.id, it.name) }
                 }
+                logger.info("${call.getRequestInfo()} Successfully retrieved ${forms.size} forms")
                 call.respond(HttpStatusCode.OK, forms)
             } catch (e: Exception) {
                 logger.error("${call.getRequestInfo()} Error retrieving forms", e)
@@ -38,6 +39,7 @@ fun Route.formRouting(formService: FormService) {
                 }
 
                 val table = formService.getFormProvider(formId).getForm()
+                logger.info("${call.getRequestInfo()} Form found: $formId")
                 call.respond(HttpStatusCode.OK, table)
             } catch (e: ValidationException) {
                 ErrorHandlers.handleValidationException(call, e)


### PR DESCRIPTION
[Jira-task](https://kartverket.atlassian.net/jira/software/projects/EDSKVIS/boards/177?selectedIssue=EDSKVIS-894)

# Endringer
- ```RequestLogging.kt```:
Lagt til if (call.request.uri != "/health")-guard i både onCall og onCallRespond.
Dette hindrer at health-check-prober fyller loggene unødvendig.
- ```FormRouting.kt```
Lagt til eksplisitte suksesslogger:
	•	GET /forms: Logger "Successfully retrieved N forms" etter at listen er bygget.
	•	GET /forms/{formId}: Logger "Form found: <id>" etter vellykket henting.
Dette gjør det tydelig i loggene når et kall er vellykket, og skiller det fra eksisterende ERROR-logg ved "Form not found".

- ```AirTableProvider.kt```
Nedgradert loggnivå for webhook refresh-feil fra logger.error til logger.warn.
Oppdatert loggmeldingen til å inkludere tableId for bedre kontekst ved feilsøking.