### PR TITLE
stop blocking pipeline when pharos fails

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -128,7 +128,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     if: github.ref == 'refs/heads/main'
-    needs: [build, pharos]
+    needs: [build]
     runs-on: ubuntu-latest
     environment:
       name: dev


### PR DESCRIPTION
### Bakgrunn

Ønsker litt mer fleksibilitet for deploy.
Vi klarer helt fint å stoppe deploy til dev/prod når pharos feiler i en PR.

### Løsning
Lar deploy til dev/prod fungere til tross for feil i pharos