### PR TITLE
Filtrere på Exipred svar

### DIFF
--- a/app/pages/activityPage/table/Table.tsx
+++ b/app/pages/activityPage/table/Table.tsx
@@ -24,6 +24,7 @@ import { ColumnActions } from "@/pages/activityPage/table/ColumnActions";
 import { cn } from "@/lib/utils";
 import { SkeletonLoader } from "@/components/SkeletonLoader";
 import { TableStatistics } from "../TableStatistics";
+import { isOlderThan } from "@/utils/formatTime";
 
 type Props = {
   columnMetadata: Column[];
@@ -167,7 +168,13 @@ export function TableComponent({
       filterFn: (row, _, filterValue) => {
         const latestAnswer = row.original.answers?.at(-1)?.answer;
         const status = latestAnswer ? "utfylt" : "ikke utfylt";
-        return filterValue.includes(status);
+        const expired = isOlderThan(
+          row.original.answers.at(-1)?.updated ?? new Date(),
+          row.original.metadata?.answerMetadata.expiry,
+        )
+          ? "utgaatt"
+          : "ikke utgaatt";
+        return filterValue.includes(status) || filterValue.includes(expired);
       },
       enableColumnFilter: true,
       header: () => null, // don't show header

--- a/app/pages/activityPage/table/TableActions.tsx
+++ b/app/pages/activityPage/table/TableActions.tsx
@@ -57,6 +57,7 @@ export const TableActions = <TData,>({
             filterOptions={[
               { name: "Utfylt", value: "utfylt" },
               { name: "Ikke utfylt", value: "ikke utfylt" },
+              { name: "Utgått", value: "utgaatt" },
             ]}
             filterName="Status"
             column={statusFilterKolonne}


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**

Lagt til "utgått" alternativet på statusfilteret, slik at man kan se hvilke kontrollere som er utgått. 

**Hvorfor trenger vi denne funskjonaliteten?**

Etter tilbakemelding fra bruker om at det kan være kjekt å få en visning med kun de utgåtte kontrollerne.

**Hvem er funskjonaliteten for?**

Team som skal fylle ut skjemaet på nytt pga utgåtte kontrollere, som kun ønsker å fokusere på de utgåtte svarene. 

<img width="252" height="210" alt="image" src="https://github.com/user-attachments/assets/134f39e2-20df-4a43-8aef-e64803bb1826" />

<img width="1313" height="603" alt="image" src="https://github.com/user-attachments/assets/ff175c4a-092f-4408-b360-80243a9e3238" />

