### PR TITLE
Fix expired-answers-metrics calculation 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(libs.flyway.database.core)
     implementation(libs.flyway.database.postgresql)
     implementation(libs.ben.manes.caffeine)
+    implementation(libs.netty.codec.http2)
 
     testImplementation(libs.testcontainers.testcontainers)
     testImplementation(libs.testcontainers.postgresql)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ ben-manes-caffeine-version = "3.2.2"
 testcontainers-version = "1.21.4"
 postgresql-driver-version = "42.7.7"
 ktlint-version = "13.1.0"
+netty-version = "4.2.12.Final"
 
 [libraries]
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor-version" }
@@ -46,6 +47,7 @@ ben-manes-caffeine = { module = "com.github.ben-manes.caffeine:caffeine", versio
 testcontainers-testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers-version" }
 testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers-version" }
 junit-platform-launcher = { module = 'org.junit.platform:junit-platform-launcher' }
+netty-codec-http2 = { module='io.netty:netty-codec-http2', version.ref = 'netty-version' } #kan fjernes når ktor oppggraderer til å bruke ny versjon netty2
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin-version" }

--- a/src/main/kotlin/no/bekk/routes/ContextRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ContextRouting.kt
@@ -278,7 +278,7 @@ fun buildContextMetrics(
             val expiry = q.metadata.answerMetadata.expiry ?: return@count false
             val answer = latestAnswers[q.recordId] ?: return@count false
             val updatedDate = java.time.LocalDate.parse(answer.updated.substring(0, 10))
-            updatedDate.plusDays(expiry.toLong()).isBefore(today)
+            updatedDate.plusWeeks(expiry.toLong()).isBefore(today)
         }
         val answeredCount = questions.count { q -> latestAnswers.containsKey(q.recordId) }
         DatabaseContextWithMetrics(

--- a/src/test/kotlin/no/bekk/routes/ContextRoutingTest.kt
+++ b/src/test/kotlin/no/bekk/routes/ContextRoutingTest.kt
@@ -533,7 +533,7 @@ class ContextRoutingTest {
                     override fun getContextsByName(name: String): List<DatabaseContext> = listOf(mockedContext)
                 },
                 answerRepository = object : MockAnswerRepository {
-                    override fun getLatestAnswersByContextIdFromDatabase(contextId: String): List<no.bekk.database.DatabaseAnswer> = listOf(expiredAnswer)
+                    override fun getLatestAnswersByContextIdFromDatabase(contextId: String): List<DatabaseAnswer> = listOf(expiredAnswer)
                 },
                 authService = object : MockAuthService {
                     override suspend fun hasContextAccess(call: ApplicationCall, contextId: String): Boolean = true

--- a/src/test/kotlin/no/bekk/routes/ContextRoutingTest.kt
+++ b/src/test/kotlin/no/bekk/routes/ContextRoutingTest.kt
@@ -11,11 +11,16 @@ import no.bekk.MockAuthService
 import no.bekk.MockFormService
 import no.bekk.TestUtils.generateTestToken
 import no.bekk.TestUtils.testModule
+import no.bekk.database.DatabaseAnswer
 import no.bekk.database.DatabaseContext
 import no.bekk.database.DatabaseContextRequest
 import no.bekk.database.DatabaseContextWithMetrics
 import no.bekk.exception.ConflictException
+import no.bekk.model.internal.AnswerMetadata
+import no.bekk.model.internal.AnswerType
 import no.bekk.model.internal.Form
+import no.bekk.model.internal.Question
+import no.bekk.model.internal.QuestionMetadata
 import no.bekk.providers.FormProvider
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -499,18 +504,18 @@ class ContextRoutingTest {
             formId = "formId",
             name = "name",
         )
-        val mockedQuestion = no.bekk.model.internal.Question(
+        val mockedQuestion = Question(
             id = "q1",
             recordId = "rec1",
             question = "Test question",
-            metadata = no.bekk.model.internal.QuestionMetadata(
-                answerMetadata = no.bekk.model.internal.AnswerMetadata(
-                    type = no.bekk.model.internal.AnswerType.TEXT_SINGLE_LINE,
+            metadata = QuestionMetadata(
+                answerMetadata = AnswerMetadata(
+                    type = AnswerType.TEXT_SINGLE_LINE,
                     expiry = 30,
                 ),
             ),
         )
-        val expiredAnswer = no.bekk.database.DatabaseAnswer(
+        val expiredAnswer = DatabaseAnswer(
             actor = "actor",
             recordId = "rec1",
             questionId = "q1",


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**

Expired-metrikken som skal holde styr på hvor mange svar i skjemautfyllingen som er gått ut på dato, har regnet dette ut feil ved å bruke plusDays i stedet for plusWeeks, da antall uker et svar er gyldig, ikke antall dager. 

I tillegg har jeg ryddet litt opp i testen til denne funksjonen. 
Og forcet Netty dependencyen for å fikse pharos.

**Hvorfor trenger vi denne funskjonaliteten?**

For å gi riktige data på de to context-endepunktene som tilbyr denne dataen.  

**Hvem er funskjonaliteten for?**

Tjenester som ønsker å bruke statistikk om konteksten der de henter den. 


