### PR TITLE
validering på filter fra URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG BASE_IMAGE=eclipse-temurin:21-jre-alpine
+ARG BASE_IMAGE=eclipse-temurin:25.0.2_10-jre-alpine-3.23
 ARG JS_IMAGE=node:22-alpine
 ARG JS_PLATFORM=linux/amd64
 ARG GRADLE_IMAGE=gradle:8.14-jdk21-alpine

--- a/app/pages/activityPage/table/Table.tsx
+++ b/app/pages/activityPage/table/Table.tsx
@@ -63,7 +63,7 @@ export function TableComponent({
   const columnHelper = createColumnHelper<Question>();
 
   function urlFilterParamsToColumnFilterState(params: string[]) {
-    const filters: Record<string, string[]> = {
+    const allowedFilters: Record<string, string[]> = {
       ...Object.fromEntries(
       columnMetadata
         .filter(({ name }) => filterByAnswer || name !== "Svar")
@@ -76,7 +76,7 @@ export function TableComponent({
     for (const param of params) {
       const [id, ...rest] = param.split("_");
       const value = rest.join("_");
-      if(!filters[id]?.includes(value)) continue;
+      if (!allowedFilters[id]?.includes(value)) continue;
       grouped[id] = [...(grouped[id] ?? []), value];
     }
 

--- a/app/pages/activityPage/table/Table.tsx
+++ b/app/pages/activityPage/table/Table.tsx
@@ -63,11 +63,20 @@ export function TableComponent({
   const columnHelper = createColumnHelper<Question>();
 
   function urlFilterParamsToColumnFilterState(params: string[]) {
+    const filters: Record<string, string[]> = {
+      ...Object.fromEntries(
+      columnMetadata
+        .filter(({ name }) => filterByAnswer || name !== "Svar")
+        .map((col) => [col.name, col.options?.map((opt) => opt.name)]),
+    ),
+      Status: ["utgaatt", "ikke utfylt", "utfylt"]
+    };
     const grouped: Record<string, string[]> = {};
 
     for (const param of params) {
       const [id, ...rest] = param.split("_");
       const value = rest.join("_");
+      if(!filters[id]?.includes(value)) continue;
       grouped[id] = [...(grouped[id] ?? []), value];
     }
 
@@ -161,20 +170,27 @@ export function TableComponent({
   const statusColumn = columnHelper.accessor(
     (row) => {
       const answer = row.answers?.at(-1)?.answer;
-      return answer ? "utfylt" : "ikke utfylt";
+      const latest = row.answers?.at(-1);
+      const isExpired = isOlderThan(
+        latest?.updated ?? new Date(),
+        row.metadata?.answerMetadata.expiry,
+      );
+      return {
+        status: answer ? "utfylt" : "ikke utfylt",
+        expired: isExpired ? "utgaatt" : "ikke utgaatt",
+      };
     },
     {
       id: "Status",
-      filterFn: (row, _, filterValue) => {
-        const latestAnswer = row.original.answers?.at(-1)?.answer;
-        const status = latestAnswer ? "utfylt" : "ikke utfylt";
-        const expired = isOlderThan(
-          row.original.answers.at(-1)?.updated ?? new Date(),
-          row.original.metadata?.answerMetadata.expiry,
-        )
-          ? "utgaatt"
-          : "ikke utgaatt";
-        return filterValue.includes(status) || filterValue.includes(expired);
+      filterFn: (row, columnId, filterValue) => {
+        const value = row.getValue(columnId) as {
+          status: string;
+          expired: string;
+        };
+        return (
+          filterValue.includes(value.status) ||
+          filterValue.includes(value.expired)
+        );
       },
       enableColumnFilter: true,
       header: () => null, // don't show header


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**

Lagt til en sjekk på filter-url-paramene før de blir lagt til som filtere.
Dette er slik at feil i url-parameteret ikke fører til en blank filter-visning, fordi ingenting matcher en feilaktig filter. 

I tillegg har jeg oppdatert accessoren til status column, slik at utgått er inkludert her, bare for å luke ut potensielle feil. Oppdatert etter dokumentasjonen til tanstack table. 

Baseimage ble oppgradert for å få Pharos til å kjøre

Før:
<img width="888" height="556" alt="image" src="https://github.com/user-attachments/assets/b547b562-f013-45ac-be37-64c0e9f25ffd" />


Etter:
<img width="1023" height="352" alt="image" src="https://github.com/user-attachments/assets/3bdcd692-47a5-4bb9-9e2b-cb1cdfdbbbe3" />


**Hvorfor trenger vi denne funskjonaliteten?**

https://kartverket.atlassian.net/browse/EDSKVIS-982?atlOrigin=eyJpIjoiNWEyMzYxMDE0Y2Q2NGI5MTg2NGIwMWM5YzQ5NDkxNTUiLCJwIjoiaiJ9
