### PR TITLE
Add migration user regelrett

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -266,6 +266,14 @@ The database user
 
 The database user's password. If the password contains `#`, `:` or `-` you have to wrap it with quotes. For example "#password"
 
+#### `migration_user`
+
+The database migration username. Usefull when you want to differentiate between privileges for the migration-user and application-user. If not set then migration-username will match the database user.
+
+#### `migration-password`
+
+The database migration user's password. Usefull when you want to differentiate between privileges for the migration-user and application-user. If not set then migration-password will match the database user.
+
 #### `max_idle_conn`
 
 The maximum number of connections in the idle connection pool.

--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -75,6 +75,11 @@ database:
   user: "postgres"
   password: pwd
 
+  # Specify username and password for the db-migration. Usefull when you want to differentiate between privileges for the migration-user and application-user.
+  # If not set then migration-username and -password will match user and password set above or defaults.
+  migration_user: null
+  migration_password: null
+
   # Max idle conn setting default is 2
   max_idle_conn: 2
 

--- a/src/main/kotlin/no/bekk/configuration/AppConfig.kt
+++ b/src/main/kotlin/no/bekk/configuration/AppConfig.kt
@@ -91,6 +91,8 @@ class DatabaseConfig(
     val url: String,
     val username: String,
     val password: String,
+    val migrationUser: String,
+    val migrationPassword: String,
 )
 
 class AnswerHistoryCleanupConfig(

--- a/src/main/kotlin/no/bekk/configuration/AppConfig.kt
+++ b/src/main/kotlin/no/bekk/configuration/AppConfig.kt
@@ -91,7 +91,7 @@ class DatabaseConfig(
     val url: String,
     val username: String,
     val password: String,
-    val migrationUser: String,
+    val migrationUsername: String,
     val migrationPassword: String,
 )
 

--- a/src/main/kotlin/no/bekk/configuration/ConfigBuilder.kt
+++ b/src/main/kotlin/no/bekk/configuration/ConfigBuilder.kt
@@ -234,10 +234,14 @@ class ConfigBuilder {
     fun buildDatabaseConfig(yaml: YamlConfig): DatabaseConfig {
         val host = yaml.getStringOrNull("database", "host") ?: "127.0.0.1:5432"
         val name = yaml.getStringOrNull("database", "name") ?: "regelrett"
+        val username = yaml.getStringOrNull("database", "user") ?: "postgres"
+        val password = yaml.getStringOrNull("database", "password") ?: ""
         return DatabaseConfig(
             url = "jdbc:postgresql://$host/$name",
-            username = yaml.getStringOrNull("database", "user") ?: "postgres",
-            password = yaml.getStringOrNull("database", "password") ?: "",
+            username = username,
+            password = password,
+            migrationUser = yaml.getStringOrNull("database", "migration_user") ?: username,
+            migrationPassword = yaml.getStringOrNull("database", "migration_password") ?: password,
         )
     }
 

--- a/src/main/kotlin/no/bekk/configuration/ConfigBuilder.kt
+++ b/src/main/kotlin/no/bekk/configuration/ConfigBuilder.kt
@@ -240,7 +240,7 @@ class ConfigBuilder {
             url = "jdbc:postgresql://$host/$name",
             username = username,
             password = password,
-            migrationUser = yaml.getStringOrNull("database", "migration_user") ?: username,
+            migrationUsername = yaml.getStringOrNull("database", "migration_user") ?: username,
             migrationPassword = yaml.getStringOrNull("database", "migration_password") ?: password,
         )
     }

--- a/src/main/kotlin/no/bekk/configuration/JDBCDatabase.kt
+++ b/src/main/kotlin/no/bekk/configuration/JDBCDatabase.kt
@@ -25,8 +25,8 @@ class JDBCDatabase(
             .defaultSchema("regelrett")
             .dataSource(
                 dbConfig.url,
-                dbConfig.username,
-                dbConfig.password,
+                dbConfig.migrationUser,
+                dbConfig.migrationPassword,
             )
             .validateMigrationNaming(true)
             .load()

--- a/src/main/kotlin/no/bekk/configuration/JDBCDatabase.kt
+++ b/src/main/kotlin/no/bekk/configuration/JDBCDatabase.kt
@@ -25,7 +25,7 @@ class JDBCDatabase(
             .defaultSchema("regelrett")
             .dataSource(
                 dbConfig.url,
-                dbConfig.migrationUser,
+                dbConfig.migrationUsername,
                 dbConfig.migrationPassword,
             )
             .validateMigrationNaming(true)

--- a/src/test/kotlin/no/bekk/ApplicationTest.kt
+++ b/src/test/kotlin/no/bekk/ApplicationTest.kt
@@ -31,7 +31,7 @@ class ApplicationTest {
         microsoftGraph = MicrosoftGraphConfig("", "", ""),
         oAuth = OAuthConfig("https://test.com", "test", "", "", "", "", "", "", ""),
         server = ServerConfig("", "", "", 0, false, false, emptyList(), 4096, 8192, 8192),
-        database = DatabaseConfig("", "", ""),
+        database = DatabaseConfig("", "", "", "", ""),
         answerHistoryCleanup = AnswerHistoryCleanupConfig(""),
         frontendDevServer = FrontendDevServerConfig("", 0, "", ""),
         raw = YamlConfig(Yaml.decodeYamlMapFromString("value: null")),

--- a/src/test/kotlin/no/bekk/TestDatabase.kt
+++ b/src/test/kotlin/no/bekk/TestDatabase.kt
@@ -12,6 +12,8 @@ class TestDatabase {
         url = postgresContainer.jdbcUrl,
         username = postgresContainer.username,
         password = postgresContainer.password,
+        migrationUsername = postgresContainer.username,
+        migrationPassword = postgresContainer.password,
     )
 
     fun stopTestDatabase() {

--- a/src/test/kotlin/no/bekk/TestUtils.kt
+++ b/src/test/kotlin/no/bekk/TestUtils.kt
@@ -39,7 +39,7 @@ object TestUtils {
             microsoftGraph = MicrosoftGraphConfig("", "", ""),
             oAuth = OAuthConfig("https://test.com", "test", "", "", "", "", "", "", ""),
             server = ServerConfig("", "", "", 0, false, false, emptyList(), 4096, 8192, 8192),
-            database = DatabaseConfig("", "", ""),
+            database = DatabaseConfig("", "", "", "", ""),
             answerHistoryCleanup = AnswerHistoryCleanupConfig(""),
             frontendDevServer = FrontendDevServerConfig("", 0, "", ""),
             raw = YamlConfig(Yaml.decodeYamlMapFromString("value: null")),


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**

lagt til to miljøvariabler:

- migrationUser 
- migrationPassword

Slik at man kan differensiere mellom application-user og migration-user til databasen.

**Hvorfor trenger vi denne funskjonaliteten?**

Sånn at man kan ha ulike priviligier på de ulike brukerene, typisk færre privilegier på application-user.

