### PR TITLE
Export progress-csv

### DIFF
--- a/app/hooks/useUser.ts
+++ b/app/hooks/useUser.ts
@@ -13,6 +13,7 @@ export type UserInfo = {
   groups: UserGroup[];
   user: User;
   superuser: boolean;
+  reportinguser: boolean;
 };
 
 export const useUser = () => {

--- a/app/hooks/useUser.ts
+++ b/app/hooks/useUser.ts
@@ -1,6 +1,6 @@
-import { axiosFetch } from "../api/Fetch";
+import { axiosFetch } from "@/api/Fetch";
 import { useQuery } from "@tanstack/react-query";
-import type { User } from "../api/types";
+import type { User } from "@/api/types";
 
 const API_URL_BASE = "/api";
 

--- a/app/pages/frontPage/FrontPage.tsx
+++ b/app/pages/frontPage/FrontPage.tsx
@@ -1,11 +1,11 @@
-import { Page } from "../../components/layout/Page";
-import { useUser } from "../../hooks/useUser";
+import { Page } from "@/components/layout/Page";
+import { useUser } from "@/hooks/useUser";
 import RedirectBackButton from "../../components/buttons/RedirectBackButton";
 import TeamContexts from "./TeamContexts";
 import {
   handleExportFullCSV,
   handleExportProgressCSV,
-} from "../../utils/csvExportUtils";
+} from "@/utils/csvExportUtils";
 import { ErrorState } from "@/components/ErrorState";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";

--- a/app/pages/frontPage/FrontPage.tsx
+++ b/app/pages/frontPage/FrontPage.tsx
@@ -2,7 +2,10 @@ import { Page } from "../../components/layout/Page";
 import { useUser } from "../../hooks/useUser";
 import RedirectBackButton from "../../components/buttons/RedirectBackButton";
 import TeamContexts from "./TeamContexts";
-import { handleExportCSV } from "../../utils/csvExportUtils";
+import {
+  handleExportFullCSV,
+  handleExportProgressCSV,
+} from "../../utils/csvExportUtils";
 import { ErrorState } from "@/components/ErrorState";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -28,6 +31,7 @@ export default function FrontPage() {
 
   const teams = userinfo ? userinfo.groups : [];
 
+
   if (!isUserinfoLoading && !teams.length) {
     return (
       <>
@@ -44,19 +48,29 @@ export default function FrontPage() {
         <div className="flex flex-col mx-auto px-8 items-start ">
           <h1 className="text-4xl font-bold">Dine team</h1>
           <div className="flex flex-col items-start">
-            {userinfo?.superuser && (
-              <>
+            <div className="flex flex-row gap-8">
+              {userinfo?.superuser && (
                 <Button
                   variant="link"
                   className="w-fit font-bold has-[>svg]:px-0 my-2"
-                  onClick={() => handleExportCSV()}
+                  onClick={() => handleExportFullCSV()}
                 >
                   Eksporter skjemautfyllinger
                   <Download className="size-5" />
                 </Button>
-                <Separator className="my-5" />
-              </>
-            )}
+              )}
+              {userinfo?.reportinguser && (
+                <Button
+                  variant="link"
+                  className="w-fit font-bold has-[>svg]:px-0 my-2"
+                  onClick={() => handleExportProgressCSV()}
+                >
+                  Eksporter utfyllingstilstand
+                  <Download className="size-5" />
+                </Button>
+              )}
+            </div>
+            <Separator className="my-5" />
             <SkeletonLoader loading={isUserinfoLoading}>
               {teams.map((team) => {
                 return (

--- a/app/utils/csvExportUtils.ts
+++ b/app/utils/csvExportUtils.ts
@@ -1,4 +1,4 @@
-import { axiosFetch } from "../api/Fetch";
+import { axiosFetch } from "@/api/Fetch";
 import { toast } from "sonner";
 
 const API_URL_BASE = "/api";

--- a/app/utils/csvExportUtils.ts
+++ b/app/utils/csvExportUtils.ts
@@ -3,10 +3,10 @@ import { toast } from "sonner";
 
 const API_URL_BASE = "/api";
 
-export async function handleExportCSV() {
+export async function handleExportFullCSV() {
   try {
     const response = await axiosFetch<Blob>({
-      url: `${API_URL_BASE}/dump-csv`,
+      url: `${API_URL_BASE}/dumpCsv/full`,
       method: "GET",
       responseType: "blob",
     });
@@ -21,7 +21,7 @@ export async function handleExportCSV() {
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
-    link.setAttribute("download", "data.csv");
+    link.setAttribute("download", "full.csv");
 
     document.body.appendChild(link);
     link.click();
@@ -30,8 +30,46 @@ export async function handleExportCSV() {
 
     URL.revokeObjectURL(url);
   } catch (error) {
-    console.error("Error downloading CSV:", error);
-    const toastId = "export-csv-error";
+    console.error("Error downloading full CSV:", error);
+    const toastId = "export-full-csv-error";
+    toast.error("Å nei!", {
+      description:
+        "Det kan være du ikke har tilgang til denne funksjonaliteten",
+      duration: 5000,
+      id: toastId,
+    });
+  }
+}
+
+export async function handleExportProgressCSV() {
+  try {
+    const response = await axiosFetch<Blob>({
+      url: `${API_URL_BASE}/dumpCsv/progress`,
+      method: "GET",
+      responseType: "blob",
+    });
+
+    if (!response.data) {
+      throw new Error("No data received for CSV");
+    }
+
+    const blob = new Blob([response.data], {
+      type: "text/csv;charset=utf-8;",
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.setAttribute("download", "progress.csv");
+
+    document.body.appendChild(link);
+    link.click();
+
+    document.body.removeChild(link);
+
+    URL.revokeObjectURL(url);
+  } catch (error) {
+    console.error("Error downloading progress CSV:", error);
+    const toastId = "export-progress-csv-error";
     toast.error("Å nei!", {
       description:
         "Det kan være du ikke har tilgang til denne funksjonaliteten",

--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -62,6 +62,7 @@ oauth:
   client_id: null
   client_secret: null
   super_user_group: null
+  reporting_user_group: null
 
 #################################### Database ##############################
 

--- a/conf/sample.yaml
+++ b/conf/sample.yaml
@@ -60,6 +60,7 @@
 #   client_id: null
 #   client_secret: null
 #   super_user_group: null
+#   reporting_user_group: null
 #
 # #################################### Database ##############################
 #

--- a/src/main/kotlin/no/bekk/authentication/AuthService.kt
+++ b/src/main/kotlin/no/bekk/authentication/AuthService.kt
@@ -9,7 +9,7 @@ import no.bekk.services.MicrosoftService
 import org.slf4j.LoggerFactory
 
 interface AuthService {
-    suspend fun getGroupsOrEmptyList(call: ApplicationCall): List<MicrosoftGraphGroup>
+    suspend fun getGroupsOrEmptyList(call: ApplicationCall, filter: String? = null): List<MicrosoftGraphGroup>
 
     suspend fun getCurrentUser(call: ApplicationCall): MicrosoftGraphUser
 
@@ -33,13 +33,13 @@ class AuthServiceImpl(
     private val formService: FormService,
 ) : AuthService {
     private val logger = LoggerFactory.getLogger(AuthServiceImpl::class.java)
-    override suspend fun getGroupsOrEmptyList(call: ApplicationCall): List<MicrosoftGraphGroup> {
+    override suspend fun getGroupsOrEmptyList(call: ApplicationCall, filter: String?): List<MicrosoftGraphGroup> {
         val jwtToken =
             call.request.headers["Authorization"]?.removePrefix("Bearer ")
                 ?: throw IllegalStateException("Authorization header missing")
         val oboToken = microsoftService.requestTokenOnBehalfOf(jwtToken)
 
-        return microsoftService.fetchGroups(oboToken)
+        return microsoftService.fetchGroups(oboToken, filter)
     }
 
     override suspend fun getCurrentUser(call: ApplicationCall): MicrosoftGraphUser {

--- a/src/main/kotlin/no/bekk/authentication/AuthService.kt
+++ b/src/main/kotlin/no/bekk/authentication/AuthService.kt
@@ -23,6 +23,8 @@ interface AuthService {
 
     suspend fun hasSuperUserAccess(call: ApplicationCall): Boolean
 
+    suspend fun hasReportingUserAccess(call: ApplicationCall): Boolean
+
     suspend fun getTeamIdFromName(call: ApplicationCall, teamName: String): String?
 }
 
@@ -80,7 +82,7 @@ class AuthServiceImpl(
         if (hasAccess) {
             logger.debug("Team access granted for teamId: $teamId")
         } else {
-            logger.debug("Team access denied for teamId: $teamId - Team not in user's groups: $groups")
+            logger.debug("Team access denied for teamId: {} - Team not in user's groups: {}", teamId, groups)
         }
 
         return hasAccess
@@ -127,6 +129,10 @@ class AuthServiceImpl(
     override suspend fun hasSuperUserAccess(
         call: ApplicationCall,
     ): Boolean = hasTeamAccess(call, oAuthConfig.superUserGroup)
+
+    override suspend fun hasReportingUserAccess(
+        call: ApplicationCall,
+    ): Boolean = hasTeamAccess(call, oAuthConfig.reportingUserGroup)
 
     override suspend fun getTeamIdFromName(call: ApplicationCall, teamName: String): String? {
         val microsoftGroups = getGroupsOrEmptyList(call)

--- a/src/main/kotlin/no/bekk/configuration/AppConfig.kt
+++ b/src/main/kotlin/no/bekk/configuration/AppConfig.kt
@@ -68,6 +68,7 @@ data class OAuthConfig(
     val clientId: String,
     val clientSecret: String,
     val superUserGroup: String,
+    val reportingUserGroup: String,
 )
 
 fun getIssuer(oAuthConfig: OAuthConfig) = oAuthConfig.baseUrl + "/" + oAuthConfig.tenantId + oAuthConfig.issuerPath

--- a/src/main/kotlin/no/bekk/configuration/ConfigBuilder.kt
+++ b/src/main/kotlin/no/bekk/configuration/ConfigBuilder.kt
@@ -209,6 +209,7 @@ class ConfigBuilder {
         clientId = yaml.getString("oauth", "client_id"),
         clientSecret = yaml.getString("oauth", "client_secret"),
         superUserGroup = yaml.getStringOrNull("oauth", "super_user_group") ?: "",
+        reportingUserGroup = yaml.getStringOrNull("oauth", "reporting_user_group") ?: "",
     )
 
     fun buildServerConfig(yaml: YamlConfig): ServerConfig {

--- a/src/main/kotlin/no/bekk/domain/MicrosoftGraphGroupsResponse.kt
+++ b/src/main/kotlin/no/bekk/domain/MicrosoftGraphGroupsResponse.kt
@@ -25,4 +25,5 @@ data class UserInfoResponse(
     val groups: List<MicrosoftGraphGroup>,
     val user: MicrosoftGraphUser,
     val superuser: Boolean,
+    val reportinguser: Boolean,
 )

--- a/src/main/kotlin/no/bekk/plugins/Routing.kt
+++ b/src/main/kotlin/no/bekk/plugins/Routing.kt
@@ -89,7 +89,7 @@ fun Application.configureRouting(
             contextRouting(dependencies.authService, dependencies.answerRepository, dependencies.contextRepository, dependencies.commentRepository, dependencies.formService)
             formRouting(dependencies.formService)
             userInfoRouting(dependencies.authService)
-            uploadCSVRouting(dependencies.authService, dependencies.database)
+            uploadCSVRouting(dependencies.authService, dependencies.formService, dependencies.database)
         }
     }
 

--- a/src/main/kotlin/no/bekk/routes/UploadCSVRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/UploadCSVRouting.kt
@@ -242,12 +242,12 @@ fun List<AnswersCSVDump>.toFullCsv(): String = csvOf(
 
 fun List<AnswerProgressDTO>.toProgressCsv(): String = csvOf(
     headers = listOf(
-        "questionId",
-        "answer_updated",
-        "context_id",
-        "context_name",
-        "form_name",
-        "team_name",
+        "sporsmaal_id",
+        "svar_oppdatert",
+        "skjemautfyllings_id",
+        "skjemautfyllingstittel",
+        "skjemanavn",
+        "teamnavn",
     ),
     rows = map {
         listOf(

--- a/src/main/kotlin/no/bekk/routes/UploadCSVRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/UploadCSVRouting.kt
@@ -49,6 +49,36 @@ fun Route.uploadCSVRouting(authService: AuthService, database: Database) {
                 ErrorHandlers.handleGenericException(call, e)
             }
         }
+        get("/progress") {
+            try {
+                logger.info("${call.getRequestInfo()} Received GET /dump-csv/Progress")
+
+                if (!authService.hasSuperUserAccess(call)) {
+                    logger.warn("${call.getRequestInfo()} Unauthorized access attempt to CSV Progress dump")
+                    throw AuthorizationException("Superuser access required for CSV Progress dump")
+                }
+
+                val csvData = getLatestAnswersAndComments(database)
+                val csv = csvData.toCsv()
+
+                val fileName = "data.csv"
+                call.response.header(
+                    HttpHeaders.ContentDisposition,
+                    ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, fileName).toString(),
+                )
+
+                logger.info("${call.getRequestInfo()} Successfully generated CSV dump with ${csvData.size} records")
+                call.respondBytes(
+                    bytes = csv.toByteArray(Charsets.UTF_8),
+                    contentType = ContentType.Text.CSV.withCharset(Charsets.UTF_8),
+                )
+            } catch (e: AuthorizationException) {
+                ErrorHandlers.handleAuthorizationException(call, e)
+            } catch (e: Exception) {
+                logger.error("${call.getRequestInfo()} Error generating CSV dump", e)
+                ErrorHandlers.handleGenericException(call, e)
+            }
+        }
     }
 }
 
@@ -98,6 +128,48 @@ fun getLatestAnswersAndComments(database: Database): List<AnswersCSVDump> {
     }
 }
 
+fun getLatestAnswerMetadata(database: Database): List<MetaAnswersCSVDump> {
+    val sqlStatement = """
+        SELECT 
+            a.question_id, 
+            a.updated as answer_updated,
+            a.context_id,
+            ctx.name as context_name,
+            ctx.table_id as table_id,
+            ctx.team_id
+        FROM 
+            answers a
+        JOIN 
+            (SELECT question_id, record_id, MAX(updated) as latest 
+             FROM answers 
+             GROUP BY question_id, record_id, context_id) as latest_answers
+            ON a.question_id = latest_answers.question_id 
+               AND a.record_id = latest_answers.record_id 
+               AND a.updated = latest_answers.latest
+        JOIN 
+            contexts ctx ON a.context_id = ctx.id
+        WHERE 
+            a.answer IS NOT NULL AND TRIM(a.answer) != '';
+    """.trimIndent()
+
+    return try {
+        val resultList = mutableListOf<MetaAnswersCSVDump>()
+        database.getConnection().use { conn ->
+            conn.prepareStatement(sqlStatement).use { statement ->
+                val resultSet = statement.executeQuery()
+                while (resultSet.next()) {
+                    resultList.add(mapRowToAnswersCSVDump(resultSet))
+                }
+            }
+        }
+        logger.debug("Successfully fetched ${resultList.size} records for CSV dump")
+        resultList
+    } catch (e: SQLException) {
+        logger.error("Database error while fetching data for CSV dump", e)
+        throw DatabaseException("Failed to fetch data for CSV dump", "getLatestAnswersAndComments", e)
+    }
+}
+
 fun List<AnswersCSVDump>.toCsv(): String {
     val stringWriter = StringWriter()
     stringWriter.append("questionId,answer,answer_type,answer_unit,answer_updated,answer_actor,context_id,context_name,table_id,team_id\n")
@@ -118,8 +190,19 @@ fun mapRowToAnswersCSVDump(rs: ResultSet): AnswersCSVDump = AnswersCSVDump(
     contextId = rs.getString("context_id"),
     tableName = rs.getString("table_id"),
     teamId = rs.getString("team_id"),
-    contextName = rs.getString("context_name"),
+    contextName = authService.getUserByUserId(rs.getString("context_name")),
 )
+
+
+fun mapRowToMetaAnswersCSVDump(rs: ResultSet): MetaAnswersCSVDump = MetaAnswersCSVDump(
+    questionId = rs.getString("question_id"),
+    answerUpdated = rs.getDate("answer_updated"),
+    contextId = rs.getString("context_id"),
+    contextName = rs.getString("context_name"),
+    tableName = rs.getString("table_id"),
+    teamName = rs.getString("team_id"),
+)
+
 
 data class AnswersCSVDump(
     val questionId: String,
@@ -133,3 +216,13 @@ data class AnswersCSVDump(
     val teamId: String,
     val contextName: String,
 )
+
+data class MetaAnswersCSVDump(
+    val questionId: String,
+    val answerUpdated: Date,
+    val contextId: String,
+    val contextName: String,
+    val tableName: String,
+    val teamName: String,
+)
+

--- a/src/main/kotlin/no/bekk/routes/UploadCSVRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/UploadCSVRouting.kt
@@ -9,10 +9,8 @@ import no.bekk.exception.AuthorizationException
 import no.bekk.exception.DatabaseException
 import no.bekk.plugins.ErrorHandlers
 import no.bekk.services.FormService
-import no.bekk.services.FormsMetadataDto
 import no.bekk.util.RequestContext.getRequestInfo
 import org.slf4j.LoggerFactory
-import java.io.StringWriter
 import java.sql.ResultSet
 import java.sql.SQLException
 import java.util.*
@@ -20,10 +18,10 @@ import java.util.*
 private val logger = LoggerFactory.getLogger("no.bekk.routes.UploadCSVRouting")
 
 fun Route.uploadCSVRouting(authService: AuthService, formService: FormService, database: Database) {
-    route("/dump-csv") {
-        get {
+    route("/dumpCsv") {
+        get("full") {
             try {
-                logger.info("${call.getRequestInfo()} Received GET /dump-csv")
+                logger.info("${call.getRequestInfo()} Received GET /dump-csv/full")
 
                 if (!authService.hasSuperUserAccess(call)) {
                     logger.warn("${call.getRequestInfo()} Unauthorized access attempt to CSV dump")
@@ -31,9 +29,9 @@ fun Route.uploadCSVRouting(authService: AuthService, formService: FormService, d
                 }
 
                 val csvData = getLatestAnswersAndComments(database)
-                val csv = csvData.toCsv()
+                val csv = csvData.toFullCsv()
 
-                val fileName = "data.csv"
+                val fileName = "full.csv"
                 call.response.header(
                     HttpHeaders.ContentDisposition,
                     ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, fileName).toString(),
@@ -53,36 +51,34 @@ fun Route.uploadCSVRouting(authService: AuthService, formService: FormService, d
         }
         get("/progress") {
             try {
-                logger.info("${call.getRequestInfo()} Received GET /dump-csv/Progress")
+                logger.info("${call.getRequestInfo()} Received GET /dumpCsv/progress")
 
-                if (!authService.hasSuperUserAccess(call)) {
+                if (!authService.hasReportingUserAccess(call)) {
                     logger.warn("${call.getRequestInfo()} Unauthorized access attempt to CSV Progress dump")
                     throw AuthorizationException("Superuser access required for CSV Progress dump")
                 }
 
-
                 val progressRows = getLatestAnswerMetadata(database)
 
                 val teamIds = progressRows.map { it.teamId }.distinct()
-
-
-                val teamsByIds = authService.getGroupsOrEmptyList(call, "id in $teamIds").associateBy { it.id }
+                val teamFilter = teamIds.joinToString(prefix = "id in (", postfix = ")", separator = ",") { "'$it'" }
+                val teamsByIds = authService.getGroupsOrEmptyList(call, teamFilter).associateBy { it.id }
                 val formsbyIds = formService.getFormProviders().associateBy { it.id }
 
-                progressRows.map { row ->
+                val csvData = progressRows.map { row ->
                     AnswerProgressDTO(
                         questionId = row.questionId,
                         answerUpdated = row.answerUpdated,
                         contextId = row.contextId,
                         contextName = row.contextName,
-                        formName = formsbyIds[row.formId]?.name ?: row.questionId,
+                        formName = formsbyIds[row.formId]?.name ?: row.formId,
                         teamName = teamsByIds[row.teamId]?.displayName ?: row.teamId,
                     )
                 }
 
-                val csv = csvData.toCsv()
+                val csv = csvData.toProgressCsv()
 
-                val fileName = "data.csv"
+                val fileName = "progress.csv"
                 call.response.header(
                     HttpHeaders.ContentDisposition,
                     ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, fileName).toString(),
@@ -178,42 +174,92 @@ fun getLatestAnswerMetadata(database: Database): List<MetaAnswersDB> {
             conn.prepareStatement(sqlStatement).use { statement ->
                 val result = statement.executeQuery()
                 buildList {
-                while (result.next()) {
-                    add(MetaAnswersDB(    questionId = result.getString("question_id"),
-                        answerUpdated = result.getDate("answer_updated"),
-                        contextId = result.getString("context_id"),
-                        contextName = result.getString("context_name"),
-                        formId = result.getString("table_id"),
-                        teamId = result.getString("team_id"),))
-                }
+                    while (result.next()) {
+                        add(
+                            MetaAnswersDB(
+                                questionId = result.getString("question_id"),
+                                answerUpdated = result.getDate("answer_updated"),
+                                contextId = result.getString("context_id"),
+                                contextName = result.getString("context_name"),
+                                formId = result.getString("table_id"),
+                                teamId = result.getString("team_id"),
+                            ),
+                        )
+                    }
                 }
             }
-        }.also{logger.debug("Successfully fetched ${it.size} records for CSV dump")}
+        }.also { logger.debug("Successfully fetched ${it.size} records for CSV dump") }
     } catch (e: SQLException) {
         logger.error("Database error while fetching data for CSV dump", e)
         throw DatabaseException("Failed to fetch data for CSV dump", "getLatestAnswersAndComments", e)
     }
 }
 
-fun List<AnswersCSVDump>.toCsv(): String {
-    val stringWriter = StringWriter()
-    stringWriter.append("questionId,answer,answer_type,answer_unit,answer_updated,answer_actor,context_id,context_name,table_id,team_id\n")
-    this.forEach {
-        stringWriter.append("\"${it.questionId}\",\"${it.answer}\",\"${it.answerType}\",\"${it.answerUnit}\",\"${it.answerUpdated}\",\"${it.answerActor}\",\"${it.contextId}\",\"${it.contextName}\",\"${it.tableName}\",\"${it.teamId}\"\n")
-    }
-
-    return stringWriter.toString()
+private fun csvEscape(value: Any?): String {
+    val text = value?.toString().orEmpty()
+    return "\"${text.replace("\"", "\"\"")}\""
 }
 
-fun List<AnswerProgressDTO>.toCsv(): String {
-    val stringWriter = StringWriter()
-    stringWriter.append("questionId,answer_updated,context_id,context_name,form_name,team_name\n")
-    this.forEach {
-        stringWriter.append("\"${it.questionId}\",\"${it.answerUpdated}\",\"${it.contextId}\",\"${it.contextName}\",\"${it.formName}\",\"${it.teamName}\"\n")
-    }
+private fun csvOf(
+    headers: List<String>,
+    rows: List<List<Any?>>,
+): String = buildString {
+    appendLine(headers.joinToString(","))
 
-    return stringWriter.toString()
+    rows.forEach { row ->
+        appendLine(row.joinToString(",") { csvEscape(it) })
+    }
 }
+
+fun List<AnswersCSVDump>.toFullCsv(): String = csvOf(
+    headers = listOf(
+        "questionId",
+        "answer",
+        "answer_type",
+        "answer_unit",
+        "answer_updated",
+        "answer_actor",
+        "context_id",
+        "context_name",
+        "table_id",
+        "team_id",
+    ),
+    rows = map {
+        listOf(
+            it.questionId,
+            it.answer,
+            it.answerType,
+            it.answerUnit,
+            it.answerUpdated,
+            it.answerActor,
+            it.contextId,
+            it.contextName,
+            it.tableName,
+            it.teamId,
+        )
+    },
+)
+
+fun List<AnswerProgressDTO>.toProgressCsv(): String = csvOf(
+    headers = listOf(
+        "questionId",
+        "answer_updated",
+        "context_id",
+        "context_name",
+        "form_name",
+        "team_name",
+    ),
+    rows = map {
+        listOf(
+            it.questionId,
+            it.answerUpdated,
+            it.contextId,
+            it.contextName,
+            it.formName,
+            it.teamName,
+        )
+    },
+)
 
 fun mapRowToAnswersCSVDump(rs: ResultSet): AnswersCSVDump = AnswersCSVDump(
     questionId = rs.getString("question_id"),
@@ -225,10 +271,8 @@ fun mapRowToAnswersCSVDump(rs: ResultSet): AnswersCSVDump = AnswersCSVDump(
     contextId = rs.getString("context_id"),
     tableName = rs.getString("table_id"),
     teamId = rs.getString("team_id"),
-    contextName = authService.getUserByUserId(rs.getString("context_name")),
+    contextName = rs.getString("context_name"),
 )
-
-
 
 data class AnswersCSVDump(
     val questionId: String,
@@ -260,4 +304,3 @@ data class MetaAnswersDB(
     val formId: String,
     val teamId: String,
 )
-

--- a/src/main/kotlin/no/bekk/routes/UploadCSVRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/UploadCSVRouting.kt
@@ -8,6 +8,8 @@ import no.bekk.configuration.Database
 import no.bekk.exception.AuthorizationException
 import no.bekk.exception.DatabaseException
 import no.bekk.plugins.ErrorHandlers
+import no.bekk.services.FormService
+import no.bekk.services.FormsMetadataDto
 import no.bekk.util.RequestContext.getRequestInfo
 import org.slf4j.LoggerFactory
 import java.io.StringWriter
@@ -17,7 +19,7 @@ import java.util.*
 
 private val logger = LoggerFactory.getLogger("no.bekk.routes.UploadCSVRouting")
 
-fun Route.uploadCSVRouting(authService: AuthService, database: Database) {
+fun Route.uploadCSVRouting(authService: AuthService, formService: FormService, database: Database) {
     route("/dump-csv") {
         get {
             try {
@@ -58,7 +60,26 @@ fun Route.uploadCSVRouting(authService: AuthService, database: Database) {
                     throw AuthorizationException("Superuser access required for CSV Progress dump")
                 }
 
-                val csvData = getLatestAnswersAndComments(database)
+
+                val progressRows = getLatestAnswerMetadata(database)
+
+                val teamIds = progressRows.map { it.teamId }.distinct()
+
+
+                val teamsByIds = authService.getGroupsOrEmptyList(call, "id in $teamIds").associateBy { it.id }
+                val formsbyIds = formService.getFormProviders().associateBy { it.id }
+
+                progressRows.map { row ->
+                    AnswerProgressDTO(
+                        questionId = row.questionId,
+                        answerUpdated = row.answerUpdated,
+                        contextId = row.contextId,
+                        contextName = row.contextName,
+                        formName = formsbyIds[row.formId]?.name ?: row.questionId,
+                        teamName = teamsByIds[row.teamId]?.displayName ?: row.teamId,
+                    )
+                }
+
                 val csv = csvData.toCsv()
 
                 val fileName = "data.csv"
@@ -128,7 +149,7 @@ fun getLatestAnswersAndComments(database: Database): List<AnswersCSVDump> {
     }
 }
 
-fun getLatestAnswerMetadata(database: Database): List<MetaAnswersCSVDump> {
+fun getLatestAnswerMetadata(database: Database): List<MetaAnswersDB> {
     val sqlStatement = """
         SELECT 
             a.question_id, 
@@ -153,17 +174,21 @@ fun getLatestAnswerMetadata(database: Database): List<MetaAnswersCSVDump> {
     """.trimIndent()
 
     return try {
-        val resultList = mutableListOf<MetaAnswersCSVDump>()
         database.getConnection().use { conn ->
             conn.prepareStatement(sqlStatement).use { statement ->
-                val resultSet = statement.executeQuery()
-                while (resultSet.next()) {
-                    resultList.add(mapRowToAnswersCSVDump(resultSet))
+                val result = statement.executeQuery()
+                buildList {
+                while (result.next()) {
+                    add(MetaAnswersDB(    questionId = result.getString("question_id"),
+                        answerUpdated = result.getDate("answer_updated"),
+                        contextId = result.getString("context_id"),
+                        contextName = result.getString("context_name"),
+                        formId = result.getString("table_id"),
+                        teamId = result.getString("team_id"),))
+                }
                 }
             }
-        }
-        logger.debug("Successfully fetched ${resultList.size} records for CSV dump")
-        resultList
+        }.also{logger.debug("Successfully fetched ${it.size} records for CSV dump")}
     } catch (e: SQLException) {
         logger.error("Database error while fetching data for CSV dump", e)
         throw DatabaseException("Failed to fetch data for CSV dump", "getLatestAnswersAndComments", e)
@@ -175,6 +200,16 @@ fun List<AnswersCSVDump>.toCsv(): String {
     stringWriter.append("questionId,answer,answer_type,answer_unit,answer_updated,answer_actor,context_id,context_name,table_id,team_id\n")
     this.forEach {
         stringWriter.append("\"${it.questionId}\",\"${it.answer}\",\"${it.answerType}\",\"${it.answerUnit}\",\"${it.answerUpdated}\",\"${it.answerActor}\",\"${it.contextId}\",\"${it.contextName}\",\"${it.tableName}\",\"${it.teamId}\"\n")
+    }
+
+    return stringWriter.toString()
+}
+
+fun List<AnswerProgressDTO>.toCsv(): String {
+    val stringWriter = StringWriter()
+    stringWriter.append("questionId,answer_updated,context_id,context_name,form_name,team_name\n")
+    this.forEach {
+        stringWriter.append("\"${it.questionId}\",\"${it.answerUpdated}\",\"${it.contextId}\",\"${it.contextName}\",\"${it.formName}\",\"${it.teamName}\"\n")
     }
 
     return stringWriter.toString()
@@ -194,15 +229,6 @@ fun mapRowToAnswersCSVDump(rs: ResultSet): AnswersCSVDump = AnswersCSVDump(
 )
 
 
-fun mapRowToMetaAnswersCSVDump(rs: ResultSet): MetaAnswersCSVDump = MetaAnswersCSVDump(
-    questionId = rs.getString("question_id"),
-    answerUpdated = rs.getDate("answer_updated"),
-    contextId = rs.getString("context_id"),
-    contextName = rs.getString("context_name"),
-    tableName = rs.getString("table_id"),
-    teamName = rs.getString("team_id"),
-)
-
 
 data class AnswersCSVDump(
     val questionId: String,
@@ -217,12 +243,21 @@ data class AnswersCSVDump(
     val contextName: String,
 )
 
-data class MetaAnswersCSVDump(
+data class AnswerProgressDTO(
     val questionId: String,
     val answerUpdated: Date,
     val contextId: String,
     val contextName: String,
-    val tableName: String,
+    val formName: String,
     val teamName: String,
+)
+
+data class MetaAnswersDB(
+    val questionId: String,
+    val answerUpdated: Date,
+    val contextId: String,
+    val contextName: String,
+    val formId: String,
+    val teamId: String,
 )
 

--- a/src/main/kotlin/no/bekk/routes/UserInfoRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/UserInfoRouting.kt
@@ -23,8 +23,9 @@ fun Route.userInfoRouting(authService: AuthService) {
                     val groups = async { authService.getGroupsOrEmptyList(call) }
                     val user = async { authService.getCurrentUser(call) }
                     val superuser = async { authService.hasSuperUserAccess(call) }
+                    val reportinguser = async { authService.hasReportingUserAccess(call) }
 
-                    call.respond(HttpStatusCode.OK, UserInfoResponse(groups.await(), user.await(), superuser.await()))
+                    call.respond(HttpStatusCode.OK, UserInfoResponse(groups.await(), user.await(), superuser.await(), reportinguser.await()))
                 }
             } catch (e: Exception) {
                 logger.error("${call.getRequestInfo()} Error fetching user info", e)

--- a/src/main/kotlin/no/bekk/services/MicrosoftService.kt
+++ b/src/main/kotlin/no/bekk/services/MicrosoftService.kt
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory
 
 interface MicrosoftService {
     suspend fun requestTokenOnBehalfOf(jwtToken: String?): String
-    suspend fun fetchGroups(bearerToken: String): List<MicrosoftGraphGroup>
+    suspend fun fetchGroups(bearerToken: String, filter: String? = null): List<MicrosoftGraphGroup>
     suspend fun fetchCurrentUser(bearerToken: String): MicrosoftGraphUser
     suspend fun fetchUserByUserId(bearerToken: String, userId: String): MicrosoftGraphUser
 }
@@ -74,7 +74,7 @@ class MicrosoftServiceImpl(private val config: Config, private val client: HttpC
     }
 
     override suspend fun fetchGroups(bearerToken: String, filter: String?): List<MicrosoftGraphGroup> {
-        val url = "${config.microsoftGraph.baseUrl + config.microsoftGraph.memberOfPath}?\$count=true&\$select=id,displayName${filter?.let { " &\$filter" to it } ?: ""}"
+        val url = "${config.microsoftGraph.baseUrl}${config.microsoftGraph.memberOfPath}" + "?\$count=true&\$select=id,displayName" + (filter?.let { "&\$filter=$it" } ?: "")
 
         return try {
             ExternalServiceTimer.time("Microsoft", "fetchGroups") {

--- a/src/main/kotlin/no/bekk/services/MicrosoftService.kt
+++ b/src/main/kotlin/no/bekk/services/MicrosoftService.kt
@@ -73,8 +73,8 @@ class MicrosoftServiceImpl(private val config: Config, private val client: HttpC
         }
     }
 
-    override suspend fun fetchGroups(bearerToken: String): List<MicrosoftGraphGroup> {
-        val url = "${config.microsoftGraph.baseUrl + config.microsoftGraph.memberOfPath}?\$count=true&\$select=id,displayName"
+    override suspend fun fetchGroups(bearerToken: String, filter: String?): List<MicrosoftGraphGroup> {
+        val url = "${config.microsoftGraph.baseUrl + config.microsoftGraph.memberOfPath}?\$count=true&\$select=id,displayName${filter?.let { " &\$filter" to it } ?: ""}"
 
         return try {
             ExternalServiceTimer.time("Microsoft", "fetchGroups") {
@@ -172,4 +172,5 @@ class MicrosoftServiceImpl(private val config: Config, private val client: HttpC
             throw ExternalServiceException("Microsoft Graph", "Failed to fetch user $userId: ${e.message}", cause = e)
         }
     }
+
 }

--- a/src/main/kotlin/no/bekk/services/MicrosoftService.kt
+++ b/src/main/kotlin/no/bekk/services/MicrosoftService.kt
@@ -74,15 +74,16 @@ class MicrosoftServiceImpl(private val config: Config, private val client: HttpC
     }
 
     override suspend fun fetchGroups(bearerToken: String, filter: String?): List<MicrosoftGraphGroup> {
-        val url = "${config.microsoftGraph.baseUrl}${config.microsoftGraph.memberOfPath}" + "?\$count=true&\$select=id,displayName" + (filter?.let { "&\$filter=$it" } ?: "")
+        val url = "${config.microsoftGraph.baseUrl}${config.microsoftGraph.memberOfPath}" + $$"?$count=true&$select=id,displayName"
 
+        val combinedFilter = listOfNotNull(filter?.takeIf { it.isNotBlank() }, config.microsoftGraph.groupFilter.takeIf { it.isNotBlank() }).joinToString(" and ")
         return try {
             ExternalServiceTimer.time("Microsoft", "fetchGroups") {
                 val response: HttpResponse = client.get(url) {
                     bearerAuth(bearerToken)
                     header("ConsistencyLevel", "eventual")
-                    if (!config.microsoftGraph.groupFilter.isBlank()) {
-                        parameter("\$filter", config.microsoftGraph.groupFilter)
+                    if (combinedFilter.isNotBlank()) {
+                        parameter("\$filter", combinedFilter)
                     }
                 }
 
@@ -172,5 +173,4 @@ class MicrosoftServiceImpl(private val config: Config, private val client: HttpC
             throw ExternalServiceException("Microsoft Graph", "Failed to fetch user $userId: ${e.message}", cause = e)
         }
     }
-
 }

--- a/src/test/kotlin/no/bekk/ApplicationTest.kt
+++ b/src/test/kotlin/no/bekk/ApplicationTest.kt
@@ -29,7 +29,7 @@ class ApplicationTest {
         mode = "development",
         paths = PathsConfig(""),
         microsoftGraph = MicrosoftGraphConfig("", "", ""),
-        oAuth = OAuthConfig("https://test.com", "test", "", "", "", "", "", "", ""),
+        oAuth = OAuthConfig("https://test.com", "test", "", "", "", "", "", "", "", ""),
         server = ServerConfig("", "", "", 0, false, false, emptyList(), 4096, 8192, 8192),
         database = DatabaseConfig("", "", "", "", ""),
         answerHistoryCleanup = AnswerHistoryCleanupConfig(""),

--- a/src/test/kotlin/no/bekk/MockAuthService.kt
+++ b/src/test/kotlin/no/bekk/MockAuthService.kt
@@ -6,12 +6,13 @@ import no.bekk.domain.MicrosoftGraphGroup
 import no.bekk.domain.MicrosoftGraphUser
 
 interface MockAuthService : AuthService {
-    override suspend fun getGroupsOrEmptyList(call: ApplicationCall): List<MicrosoftGraphGroup> = TODO("Not yet implemented")
+    override suspend fun getGroupsOrEmptyList(call: ApplicationCall, filter: String?): List<MicrosoftGraphGroup> = TODO("Not yet implemented")
     override suspend fun getCurrentUser(call: ApplicationCall): MicrosoftGraphUser = TODO("Not yet implemented")
     override suspend fun getUserByUserId(call: ApplicationCall, userId: String): MicrosoftGraphUser = TODO("Not yet implemented")
     override suspend fun hasTeamAccess(call: ApplicationCall, teamId: String?): Boolean = TODO("Not yet implemented")
     override suspend fun hasContextAccess(call: ApplicationCall, contextId: String): Boolean = TODO("Not yet implemented")
     override suspend fun hasReadContextAccess(call: ApplicationCall, contextId: String): Boolean = TODO("Not yet implemented")
     override suspend fun hasSuperUserAccess(call: ApplicationCall): Boolean = TODO("Not yet implemented")
+    override suspend fun hasReportingUserAccess(call: ApplicationCall): Boolean = TODO("Not yet implemented")
     override suspend fun getTeamIdFromName(call: ApplicationCall, teamName: String): String? = TODO("Not yet implemented")
 }

--- a/src/test/kotlin/no/bekk/MockMicrosoftService.kt
+++ b/src/test/kotlin/no/bekk/MockMicrosoftService.kt
@@ -6,7 +6,7 @@ import no.bekk.services.MicrosoftService
 
 interface MockMicrosoftService : MicrosoftService {
     override suspend fun requestTokenOnBehalfOf(jwtToken: String?): String = TODO("Not yet implemented")
-    override suspend fun fetchGroups(bearerToken: String): List<MicrosoftGraphGroup> = TODO("Not yet implemented")
+    override suspend fun fetchGroups(bearerToken: String, filter: String?): List<MicrosoftGraphGroup> = TODO("Not yet implemented")
     override suspend fun fetchCurrentUser(bearerToken: String): MicrosoftGraphUser = TODO("Not yet implemented")
     override suspend fun fetchUserByUserId(bearerToken: String, userId: String): MicrosoftGraphUser = TODO("Not yet implemented")
 }

--- a/src/test/kotlin/no/bekk/TestUtils.kt
+++ b/src/test/kotlin/no/bekk/TestUtils.kt
@@ -37,7 +37,7 @@ object TestUtils {
             mode = "development",
             paths = PathsConfig(""),
             microsoftGraph = MicrosoftGraphConfig("", "", ""),
-            oAuth = OAuthConfig("https://test.com", "test", "", "", "", "", "", "", ""),
+            oAuth = OAuthConfig("https://test.com", "test", "", "", "", "", "", "", "", ""),
             server = ServerConfig("", "", "", 0, false, false, emptyList(), 4096, 8192, 8192),
             database = DatabaseConfig("", "", "", "", ""),
             answerHistoryCleanup = AnswerHistoryCleanupConfig(""),


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**

<img width="948" height="540" alt="image" src="https://github.com/user-attachments/assets/1a1c0dbc-1cde-42fd-bf1a-b41edb4d768d" />


Lagt til "Eksporter utfyllingstilstand" funksjonaliet, slik man på forsiden i Regelrett kan eksportere en CSV fil som ikke inneholder svar eller detaljer om svar. Vi har allerede funksjonalitet for å eksportere Skjemautfyllinger - her får du da en CSV fil hvor hver rad representerer et svar i en skjemautfylling i regelrett. Her får du da id til svaret, contextId (skjemautfyllingsID på norsk) og contextName (skjemautfyllinsgnavn), når det ble sist oppdatert, formId, teamID, selve svaret, hvem som svarte, og hvilken enhet svaret er i. Denne "fulle-eksporten" er reservert superuser tilgang. Men det kan være andre som fortsatt er interessert i å vite og rapportere på utfyllings-tilstanden til regelrett - altså trenger de ikke å se svaret, men bare hvor mange spørsmål som er besvart. Her kommer eksporter skjemautfyllingstilstand tilstanden inn - her får du bare eksportert "meta-data" om svarene, men ikke selve svaret, ei heller hvem som har gjort det. Dvs følgende kolonner: SpørsmålId, svar_oppdatert, skjemautfyllings_id, skjemautfyllingstittel, skjemanavn, teamnavn. Det skal da være en mindre priviligert rolle enn super-super. 

Ved å legge til en konfigurerbar variabel "reporting_user_group", så styres tilgangen til det nye eksport progressCsven. dette er en miljøvariabel som skal peke på en entra-id group-id.

Den nye eksporten eksporterer også til forskjell fra den andre ut formName i stedet for formId, og teamName i stedet for teamId - dette er for å gjøre det enklere å lage statestikk på csven uten å måtte gjøre oppslag i entra og på formIdene.


[Jira](https://kartverket.atlassian.net/browse/EDSKVIS-1012?atlOrigin=eyJpIjoiYWQwZTI3MmQ5MTA5NDMzZWI0ZGQ3Y2I1YzhiYmZkMDUiLCJwIjoiaiJ9)

