### PR TITLE
Only non-webhook-airtable-schemas uses cache to fetch Form

### DIFF
--- a/src/main/kotlin/no/bekk/util/RefreshWebhookBackgroundTask.kt
+++ b/src/main/kotlin/no/bekk/util/RefreshWebhookBackgroundTask.kt
@@ -4,15 +4,19 @@ import io.ktor.server.application.*
 import kotlinx.coroutines.*
 import no.bekk.providers.AirTableProvider
 import no.bekk.services.FormService
+import kotlin.time.Duration.Companion.hours
 
 fun Application.configureBackgroundTasks(formService: FormService) {
     launchBackgroundTask {
         while (isActive) {
             try {
                 val airTableProviders = formService.getFormProviders().filterIsInstance<AirTableProvider>()
+                var hasProvidersWithoutWebhook = false
                 airTableProviders.forEach { provider ->
                     if (provider.webhookId.isNullOrEmpty()) {
-                        logger.info("Table ${provider.id} has no webhook id. Nothing to refresh.")
+                        logger.info("Table ${provider.id} has no webhook id. Updating cache instead.")
+                        provider.updateCaches()
+                        hasProvidersWithoutWebhook = true
                         return@forEach
                     }
                     val success = provider.refreshWebhook()
@@ -24,8 +28,9 @@ fun Application.configureBackgroundTasks(formService: FormService) {
                     provider.updateCaches() // temp solution while webhooks don't work at SKIP
                 }
 
-                // Delay for 24 hours
-                delay(1 * 60 * 60 * 1000L) // changed to 1 hour while webhooks are not working as intended
+                // Delay for 1 hour if one provider uses cache, and 24 hours if all providers uses webhooks.
+                val delayMillis = if (hasProvidersWithoutWebhook)  1.hours else 24.hours
+                delay(delayMillis)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**

Har endret cache-logikken slik at vi nå skiller tydelig mellom bruk av webhooks og polling/cache.

RefreshWebhookBackgroundTask ble for lenge siden endret til å oppdaterer en cache hver time, fordi webhooks ikke fungerte på platformen regelrett kjørte på - fordi den ikke var internett-eksponert. Vi visste ikke at det var pga plattform begrensninger, og quickfixen ble derfor stående.  
Hvis du ikke provisjonerte opp en webhookId i din skjema-provisjonering av airtable skjemaer så ble ikke cachen benyttet i det hele tatt, og henting av inholdet blir ganske tregt. Dette er jo feil - man vil jo heller benytte cache når man ikke har sendt med webhooks, og benytte webhooks når man sender dem med.
Nå gjør vi følgende:

* Hvis en provider ikke har webhookId → vi bruker cache og refresher hver time
* Hvis alle providers har webhookId → vi antar at webhooks fungerer og kjører tasken kun hver 24. time
* Vi oppdaterer ikke cache når webhooks er i bruk, siden webhooks i praksis fungerer som en cache

Dette gjør at vi får raskere datainnhenting uten webhooks, og unngår unødvendig polling når webhooks er satt opp 👍
