### PR TITLE
Legg til kontrollskjemaer for KI-bruk for team og kodebaser

### DIFF
--- a/app/pages/activityPage/table/TableCell.tsx
+++ b/app/pages/activityPage/table/TableCell.tsx
@@ -45,7 +45,7 @@ export const TableCell = ({
     );
   }
 
-  if (value == null) {
+  if (value == null || !value.length) {
     return <></>;
   }
 
@@ -84,10 +84,6 @@ export const TableCell = ({
         </Badge>
       );
     }
-    case OptionalFieldType.TEXT:
-      return <p>{value[0]}</p>
-    default:
-      return <p>Denne svartypen blir ikke støttet</p>;
   }
 
   if (column.name === "Kortnavn" || column.name === "Navn") {

--- a/app/pages/activityPage/table/TableCell.tsx
+++ b/app/pages/activityPage/table/TableCell.tsx
@@ -84,6 +84,10 @@ export const TableCell = ({
         </Badge>
       );
     }
+    case OptionalFieldType.TEXT:
+      return <p>{value[0]}</p>
+    default:
+      return <p>Denne svartypen blir ikke støttet</p>;
   }
 
   if (column.name === "Kortnavn" || column.name === "Navn") {

--- a/src/main/resources/questions/copilot-kodebase.yaml
+++ b/src/main/resources/questions/copilot-kodebase.yaml
@@ -1,0 +1,209 @@
+name: "Kontrollere for KI-bruk i kodebase"
+columns:
+  - type: "OPTION_SINGLE"
+    name: "Område"
+    options:
+      - name: "Kritikalitet"
+      - name: "Tiltak"
+  - type: "TEXT"
+    name: "Kortnavn"
+  - type: "TEXT"
+    name: "Beskrivelse"
+  - type: "OPTION_MULTIPLE"
+    name: "Svar"
+  - type: "TEXT"
+    name: "ID"
+records:
+  - id: "KR-01"
+    question: "Hvilken kritikalitet har koden i denne kodebasen?"
+    metadata:
+      answerMetadata:
+        type: "SELECT_SINGLE"
+        options:
+          - "Lavkritisk kode"
+          - "Mellomkritisk kode"
+          - "Høykritisk kode"
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "Hvilken kritikalitet har koden i denne kodebasen?"
+        - key: "Kortnavn"
+          value:
+            - "Kodens kritikalitet"   
+        - key: "Område"
+          value:
+            - "Kritikalitet"
+  - id: "KR-02"
+    question: "Påvirker denne kodebasen, når den kjøres opp, konfidensiell eller skjermingsverdig informasjon?"
+    metadata:
+      answerMetadata:
+        type: "SELECT_SINGLE"
+        options:
+          - "Ja"
+          - "Nei"
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "Påvirker denne kodebasen, når den kjøres opp, konfidensiell eller skjermingsverdig informasjon?\n\nKonfidensiell informasjon er informasjon som dekkes av sikkerhetsloven (begrenset eller høyere)."
+        - key: "Kortnavn"
+          value:
+            - "Påvirker konfidensiell informasjon"   
+        - key: "Område"
+          value:
+            - "Kritikalitet"
+  - id: "KR-03"
+    question: "Utgjør denne kodebasen, når den kjøres opp, komponenter i skjermingsverdig infrastruktur eller informasjonssystem?"
+    metadata:
+      answerMetadata:
+        type: "SELECT_SINGLE"
+        options:
+          - "Ja"
+          - "Nei"
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "Utgjør denne kodebasen, når den kjøres opp, komponenter i skjermingsverdig infrastruktur eller informasjonssystem?"
+        - key: "Kortnavn"
+          value:
+            - "Del av skjermingsverdig infrastruktur"   
+        - key: "Område"
+          value:
+            - "Kritikalitet"
+  - id: "KR-04"
+    question: "Påvirker denne kodebasen, når den kjøres opp, masterdata som understøtter GNF eller nasjonale sikkerhetsinteresser?"
+    metadata:
+      answerMetadata:
+        type: "SELECT_SINGLE"
+        options:
+          - "Ja"
+          - "Nei"
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "Påvirker denne kodebasen, når den kjøres opp, masterdata som understøtter GNF eller nasjonale sikkerhetsinteresser?"
+        - key: "Kortnavn"
+          value:
+            - "Påvirker GNF/NSI masterdata"   
+        - key: "Område"
+          value:
+            - "Kritikalitet"
+  - id: "TI-01"
+    question: "PR-review er påkrevd for all KI-generert kode"
+    metadata:
+      answerMetadata:
+        type: "CHECKBOX"
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "PR-review er påkrevd for all KI-generert kode"
+        - key: "Kortnavn"
+          value:
+            - "PR-review"   
+        - key: "Område"
+          value:
+            - "Tiltak"
+  - id: "TI-02"
+    question: "CodeQL er aktivert"
+    metadata:
+      answerMetadata:
+        type: "CHECKBOX"
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "CodeQL er aktivert"
+        - key: "Kortnavn"
+          value:
+            - "CodeQL"   
+        - key: "Område"
+          value:
+            - "Tiltak"
+  - id: "TI-03"
+    question: "Dependabot er aktivert"
+    metadata:
+      answerMetadata:
+        type: "CHECKBOX"
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "Dependabot er aktiverte"
+        - key: "Kortnavn"
+          value:
+            - "Dependabot"   
+        - key: "Område"
+          value:
+            - "Tiltak"
+  - id: "TI-04"
+    question: "Deploy-pipeline stoppes ved funn av kritiske sårbarheter"
+    metadata:
+      answerMetadata:
+        type: "CHECKBOX"
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "Deploy-pipeline stoppes ved funn av kritiske sårbarheter"
+        - key: "Kortnavn"
+          value:
+            - "Blokkering av deploy"   
+        - key: "Område"
+          value:
+            - "Tiltak"          
+  - id: "TI-05"
+    question: "Ingen auto-commit eller auto-fix uten review"
+    metadata:
+      answerMetadata:
+        type: "CHECKBOX"
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "Ingen auto-commit eller auto-fix uten review"
+        - key: "Kortnavn"
+          value:
+            - "Menneskelig oversyn"   
+        - key: "Område"
+          value:
+            - "Tiltak"
+  - id: "TI-06"
+    question: "Ekstra reviewer ved høykritisk kode"
+    metadata:
+      answerMetadata:
+        type: "CHECKBOX"
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "Ekstra reviewer ved høykritisk kode"
+        - key: "Kortnavn"
+          value:
+            - "Ekstra reviewer"   
+        - key: "Område"
+          value:
+            - "Tiltak"
+  - id: "TI-07"
+    question: "Teamet er bevisste på hvilke filer, hemmeligheter og miljøvariabler som er tilgjengelige i miljøet der Copilot kjøres"
+    metadata:
+      answerMetadata:
+        type: "CHECKBOX"
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "Teamet er bevisste på hvilke filer, hemmeligheter og miljøvariabler som er tilgjengelige i miljøet der Copilot kjøres"
+        - key: "Kortnavn"
+          value:
+            - "Kontroll på Copilot-miljø"  
+        - key: "Område"
+          value:
+            - "Tiltak"
+  - id: "TI-08"
+    question: "Copilot brukes innenfor rammene fra plattform-/verktøy-ROS"
+    metadata:
+      answerMetadata:
+        type: "CHECKBOX"
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "Copilot brukes innenfor rammene fra plattform-/verktøy-ROS\n\nCopilot skal kun brukes der det er tillatt. Intern kodestandard og policy skal følges. Bruken skal være i tråd med definerte formål."
+        - key: "Kortnavn"
+          value:
+            - "Etterlevelse"
+        - key: "Område"
+          value:
+            - "Tiltak"  

--- a/src/main/resources/questions/copilot-kodebase.yaml
+++ b/src/main/resources/questions/copilot-kodebase.yaml
@@ -25,6 +25,7 @@ records:
           - "Lavkritisk kode"
           - "Mellomkritisk kode"
           - "Høykritisk kode"
+        expiry: 26
       optionalFields:
         - key: "Beskrivelse"
           value:
@@ -46,6 +47,7 @@ records:
         options:
           - "Ja"
           - "Nei"
+        expiry: 26
       optionalFields:
         - key: "Beskrivelse"
           value:
@@ -67,6 +69,7 @@ records:
         options:
           - "Ja"
           - "Nei"
+        expiry: 26
       optionalFields:
         - key: "Beskrivelse"
           value:
@@ -88,6 +91,7 @@ records:
         options:
           - "Ja"
           - "Nei"
+        expiry: 26
       optionalFields:
         - key: "Beskrivelse"
           value:
@@ -106,6 +110,7 @@ records:
     metadata:
       answerMetadata:
         type: "CHECKBOX"
+        expiry: 26
       optionalFields:
         - key: "Beskrivelse"
           value:
@@ -124,6 +129,7 @@ records:
     metadata:
       answerMetadata:
         type: "CHECKBOX"
+        expiry: 26
       optionalFields:
         - key: "Beskrivelse"
           value:
@@ -142,6 +148,7 @@ records:
     metadata:
       answerMetadata:
         type: "CHECKBOX"
+        expiry: 26
       optionalFields:
         - key: "Beskrivelse"
           value:
@@ -160,6 +167,7 @@ records:
     metadata:
       answerMetadata:
         type: "CHECKBOX"
+        expiry: 26
       optionalFields:
         - key: "Beskrivelse"
           value:
@@ -178,6 +186,7 @@ records:
     metadata:
       answerMetadata:
         type: "CHECKBOX"
+        expiry: 26
       optionalFields:
         - key: "Beskrivelse"
           value:
@@ -196,6 +205,7 @@ records:
     metadata:
       answerMetadata:
         type: "CHECKBOX"
+        expiry: 26
       optionalFields:
         - key: "Beskrivelse"
           value:
@@ -214,6 +224,7 @@ records:
     metadata:
       answerMetadata:
         type: "CHECKBOX"
+        expiry: 26
       optionalFields:
         - key: "Beskrivelse"
           value:
@@ -232,6 +243,7 @@ records:
     metadata:
       answerMetadata:
         type: "CHECKBOX"
+        expiry: 26
       optionalFields:
         - key: "Beskrivelse"
           value:

--- a/src/main/resources/questions/copilot-kodebase.yaml
+++ b/src/main/resources/questions/copilot-kodebase.yaml
@@ -4,7 +4,9 @@ columns:
     name: "Område"
     options:
       - name: "Kritikalitet"
+        color: "orangeLight1"
       - name: "Tiltak"
+        color: "greenLight1"
   - type: "TEXT"
     name: "Kortnavn"
   - type: "TEXT"
@@ -33,6 +35,9 @@ records:
         - key: "Område"
           value:
             - "Kritikalitet"
+        - key: "ID"
+          value: 
+            - "KR-01"
   - id: "KR-02"
     question: "Påvirker denne kodebasen, når den kjøres opp, konfidensiell eller skjermingsverdig informasjon?"
     metadata:
@@ -51,6 +56,9 @@ records:
         - key: "Område"
           value:
             - "Kritikalitet"
+        - key: "ID"
+          value: 
+            - "KR-02"
   - id: "KR-03"
     question: "Utgjør denne kodebasen, når den kjøres opp, komponenter i skjermingsverdig infrastruktur eller informasjonssystem?"
     metadata:
@@ -69,6 +77,9 @@ records:
         - key: "Område"
           value:
             - "Kritikalitet"
+        - key: "ID"
+          value: 
+            - "KR-03"
   - id: "KR-04"
     question: "Påvirker denne kodebasen, når den kjøres opp, masterdata som understøtter GNF eller nasjonale sikkerhetsinteresser?"
     metadata:
@@ -87,6 +98,9 @@ records:
         - key: "Område"
           value:
             - "Kritikalitet"
+        - key: "ID"
+          value: 
+            - "KR-04"
   - id: "TI-01"
     question: "PR-review er påkrevd for all KI-generert kode"
     metadata:
@@ -102,6 +116,9 @@ records:
         - key: "Område"
           value:
             - "Tiltak"
+        - key: "ID"
+          value: 
+            - "TI-01"
   - id: "TI-02"
     question: "CodeQL er aktivert"
     metadata:
@@ -117,6 +134,9 @@ records:
         - key: "Område"
           value:
             - "Tiltak"
+        - key: "ID"
+          value: 
+            - "TI-02"
   - id: "TI-03"
     question: "Dependabot er aktivert"
     metadata:
@@ -132,6 +152,9 @@ records:
         - key: "Område"
           value:
             - "Tiltak"
+        - key: "ID"
+          value: 
+            - "TI-03"
   - id: "TI-04"
     question: "Deploy-pipeline stoppes ved funn av kritiske sårbarheter"
     metadata:
@@ -146,7 +169,10 @@ records:
             - "Blokkering av deploy"   
         - key: "Område"
           value:
-            - "Tiltak"          
+            - "Tiltak"
+        - key: "ID"
+          value: 
+            - "TI-04"
   - id: "TI-05"
     question: "Ingen auto-commit eller auto-fix uten review"
     metadata:
@@ -162,6 +188,9 @@ records:
         - key: "Område"
           value:
             - "Tiltak"
+        - key: "ID"
+          value: 
+            - "TI-05"
   - id: "TI-06"
     question: "Ekstra reviewer ved høykritisk kode"
     metadata:
@@ -177,6 +206,9 @@ records:
         - key: "Område"
           value:
             - "Tiltak"
+        - key: "ID"
+          value: 
+            - "TI-06"
   - id: "TI-07"
     question: "Teamet er bevisste på hvilke filer, hemmeligheter og miljøvariabler som er tilgjengelige i miljøet der Copilot kjøres"
     metadata:
@@ -192,6 +224,9 @@ records:
         - key: "Område"
           value:
             - "Tiltak"
+        - key: "ID"
+          value: 
+            - "TI-07"
   - id: "TI-08"
     question: "Copilot brukes innenfor rammene fra plattform-/verktøy-ROS"
     metadata:
@@ -206,4 +241,7 @@ records:
             - "Etterlevelse"
         - key: "Område"
           value:
-            - "Tiltak"  
+            - "Tiltak"
+        - key: "ID"
+          value: 
+            - "TI-08"

--- a/src/main/resources/questions/copilot-kodebase.yaml
+++ b/src/main/resources/questions/copilot-kodebase.yaml
@@ -102,6 +102,24 @@ records:
           value: 
             - "KR-04"
   - id: "TI-01"
+    question: "Risikoer ved innførte feil i kodebasen er hensyntatt i operasjonell RoS"
+    metadata:
+      answerMetadata:
+        type: "CHECKBOX"
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "Risikoer ved innførte feil i kodebasen er hensyntatt i operasjonell RoS.\n\nBruk av KI-verktøy kan innføre nye risikoer eller påvirke sannsynlighet og konsekvens ved eksisterende scenarioer.\nRelevante risikoer å vurdere:\n- Feil funksjonalitet\n- Sårbar kode som ikke oppdages\n- Brudd på API‑kontrakter\n- Feil konfigurasjon / drift\n- Feil som påvirker andre tjenester\n- Logiske feil som ikke oppdages umiddelbart\n- Risiko for logiske hallusineringer"
+        - key: "Kortnavn"
+          value:
+            - "KI hensyntatt i operasjonell RoS"   
+        - key: "Område"
+          value:
+            - "Tiltak"
+        - key: "ID"
+          value: 
+            - "TI-01"
+  - id: "TI-02"
     question: "PR-review er påkrevd for all KI-generert kode"
     metadata:
       answerMetadata:
@@ -118,8 +136,8 @@ records:
             - "Tiltak"
         - key: "ID"
           value: 
-            - "TI-01"
-  - id: "TI-02"
+            - "TI-02"
+  - id: "TI-03"
     question: "CodeQL er aktivert"
     metadata:
       answerMetadata:
@@ -136,8 +154,8 @@ records:
             - "Tiltak"
         - key: "ID"
           value: 
-            - "TI-02"
-  - id: "TI-03"
+            - "TI-03"
+  - id: "TI-04"
     question: "Dependabot er aktivert"
     metadata:
       answerMetadata:
@@ -154,16 +172,16 @@ records:
             - "Tiltak"
         - key: "ID"
           value: 
-            - "TI-03"
-  - id: "TI-04"
-    question: "Deploy-pipeline stoppes ved funn av kritiske sårbarheter"
+            - "TI-04"
+  - id: "TI-05"
+    question: "Deploy-pipeline stoppes ved kritiske funn"
     metadata:
       answerMetadata:
         type: "CHECKBOX"
       optionalFields:
         - key: "Beskrivelse"
           value:
-            - "Deploy-pipeline stoppes ved funn av kritiske sårbarheter"
+            - "Deploy-pipeline stoppes ved kritiske funn\n\nAutomatiske deploy-pipelines bør ha kontrollere for å unngå innføring av uakseptabel risiko. Teamet vurderer selv om man har kontroll på dette i sin deploy-rutine/pipeline"
         - key: "Kortnavn"
           value:
             - "Blokkering av deploy"   
@@ -172,8 +190,8 @@ records:
             - "Tiltak"
         - key: "ID"
           value: 
-            - "TI-04"
-  - id: "TI-05"
+            - "TI-05"
+  - id: "TI-06"
     question: "Ingen auto-commit eller auto-fix uten review"
     metadata:
       answerMetadata:
@@ -190,8 +208,8 @@ records:
             - "Tiltak"
         - key: "ID"
           value: 
-            - "TI-05"
-  - id: "TI-06"
+            - "TI-06"
+  - id: "TI-07"
     question: "Ekstra reviewer ved høykritisk kode"
     metadata:
       answerMetadata:
@@ -208,8 +226,8 @@ records:
             - "Tiltak"
         - key: "ID"
           value: 
-            - "TI-06"
-  - id: "TI-07"
+            - "TI-07"
+  - id: "TI-08"
     question: "Teamet er bevisste på hvilke filer, hemmeligheter og miljøvariabler som er tilgjengelige i miljøet der Copilot kjøres"
     metadata:
       answerMetadata:
@@ -226,8 +244,8 @@ records:
             - "Tiltak"
         - key: "ID"
           value: 
-            - "TI-07"
-  - id: "TI-08"
+            - "TI-08"
+  - id: "TI-09"
     question: "Copilot brukes innenfor rammene fra plattform-/verktøy-ROS"
     metadata:
       answerMetadata:
@@ -244,4 +262,4 @@ records:
             - "Tiltak"
         - key: "ID"
           value: 
-            - "TI-08"
+            - "TI-09"

--- a/src/main/resources/questions/copilot-kodebase.yaml
+++ b/src/main/resources/questions/copilot-kodebase.yaml
@@ -181,7 +181,7 @@ records:
       optionalFields:
         - key: "Beskrivelse"
           value:
-            - "Deploy-pipeline stoppes ved kritiske funn\n\nAutomatiske deploy-pipelines bør ha kontrollere for å unngå innføring av uakseptabel risiko. Teamet vurderer selv om man har kontroll på dette i sin deploy-rutine/pipeline"
+            - "Deploy-pipeline stoppes ved kritiske funn. Automatiske deploy-pipelines bør ha kontrollere for å unngå innføring av uakseptabel risiko. Teamet vurderer selv om man har kontroll på dette i sin deploy-rutine/pipeline"
         - key: "Kortnavn"
           value:
             - "Blokkering av deploy"   
@@ -253,7 +253,7 @@ records:
       optionalFields:
         - key: "Beskrivelse"
           value:
-            - "Copilot brukes innenfor rammene fra plattform-/verktøy-ROS\n\nCopilot skal kun brukes der det er tillatt. Intern kodestandard og policy skal følges. Bruken skal være i tråd med definerte formål."
+            - "Copilot brukes innenfor rammene fra plattform-/verktøy-ROS: Copilot skal kun brukes der det er tillatt. Intern kodestandard og policy skal følges. Bruken skal være i tråd med definerte formål."
         - key: "Kortnavn"
           value:
             - "Etterlevelse"

--- a/src/main/resources/questions/copilot-kodebase.yaml
+++ b/src/main/resources/questions/copilot-kodebase.yaml
@@ -120,17 +120,17 @@ records:
           value: 
             - "TI-01"
   - id: "TI-02"
-    question: "PR-review er påkrevd for all KI-generert kode"
+    question: "Menneskelig PR-review er påkrevd for all KI-generert kode"
     metadata:
       answerMetadata:
         type: "CHECKBOX"
       optionalFields:
         - key: "Beskrivelse"
           value:
-            - "PR-review er påkrevd for all KI-generert kode"
+            - "Menneskelig PR-review er påkrevd for all KI-generert kode"
         - key: "Kortnavn"
           value:
-            - "PR-review"   
+            - "Menneskelig PR-review"   
         - key: "Område"
           value:
             - "Tiltak"
@@ -192,17 +192,17 @@ records:
           value: 
             - "TI-05"
   - id: "TI-06"
-    question: "Ingen auto-commit eller auto-fix uten review"
+    question: "Ingen kodeendringer i hovedbranch uten PR-review. Dette reguleres med branch-protection i Github."
     metadata:
       answerMetadata:
         type: "CHECKBOX"
       optionalFields:
         - key: "Beskrivelse"
           value:
-            - "Ingen auto-commit eller auto-fix uten review"
+            - "Ingen kodeendringer i hovedbranch uten PR-review. Dette reguleres med branch-protection i Github."
         - key: "Kortnavn"
           value:
-            - "Menneskelig oversyn"   
+            - "Kontrollerte kodeendringer"   
         - key: "Område"
           value:
             - "Tiltak"

--- a/src/main/resources/questions/copilot-kodebase.yaml
+++ b/src/main/resources/questions/copilot-kodebase.yaml
@@ -49,7 +49,7 @@ records:
       optionalFields:
         - key: "Beskrivelse"
           value:
-            - "Påvirker denne kodebasen, når den kjøres opp, konfidensiell eller skjermingsverdig informasjon?\n\nKonfidensiell informasjon er informasjon som dekkes av sikkerhetsloven (begrenset eller høyere)."
+            - "Påvirker denne kodebasen, når den kjøres opp, konfidensiell eller skjermingsverdig informasjon? Konfidensiell informasjon er informasjon som dekkes av sikkerhetsloven (begrenset eller høyere)."
         - key: "Kortnavn"
           value:
             - "Påvirker konfidensiell informasjon"   
@@ -245,21 +245,3 @@ records:
         - key: "ID"
           value: 
             - "TI-08"
-  - id: "TI-09"
-    question: "Copilot brukes innenfor rammene fra plattform-/verktøy-ROS"
-    metadata:
-      answerMetadata:
-        type: "CHECKBOX"
-      optionalFields:
-        - key: "Beskrivelse"
-          value:
-            - "Copilot brukes innenfor rammene fra plattform-/verktøy-ROS: Copilot skal kun brukes der det er tillatt. Intern kodestandard og policy skal følges. Bruken skal være i tråd med definerte formål."
-        - key: "Kortnavn"
-          value:
-            - "Etterlevelse"
-        - key: "Område"
-          value:
-            - "Tiltak"
-        - key: "ID"
-          value: 
-            - "TI-09"

--- a/src/main/resources/questions/copilot-team.yaml
+++ b/src/main/resources/questions/copilot-team.yaml
@@ -4,7 +4,9 @@ columns:
     name: "Område"
     options:
       - name: "Bruksområde"
+        color: "tealLight1"
       - name: "Opplæring"
+        color: "yellowLight1"
   - type: "TEXT"
     name: "Kortnavn"
   - type: "TEXT"
@@ -39,6 +41,9 @@ records:
         - key: "Område"
           value:
             - "Bruksområde"
+        - key: "ID"
+          value: 
+            - "BR-01"
   - id: "BR-02"
     question: "Hvor og hvordan kjøres Copilot?"
     metadata:
@@ -61,6 +66,9 @@ records:
         - key: "Område"
           value:
             - "Bruksområde"
+        - key: "ID"
+          value: 
+            - "BR-02"
   - id: "OP-01"
     question: "Teamet er kjent med forskjellen på assistent- og agentisk bruk"
     metadata: 
@@ -76,6 +84,9 @@ records:
         - key: "Område"
           value:
             - "Opplæring"
+        - key: "ID"
+          value: 
+            - "OP-01"
   - id: "OP-02"
     question: "Teamet har gjennomgått Copilots begrensninger"
     metadata: 
@@ -91,6 +102,9 @@ records:
         - key: "Område"
           value:
             - "Opplæring"
+        - key: "ID"
+          value: 
+            - "OP-02"
   - id: "OP-03"
     question: "Teamet har gjennomgått KI-sikkerhetsintro med team SKVIS"
     metadata: 
@@ -106,6 +120,9 @@ records:
         - key: "Område"
           value:
             - "Opplæring"
+        - key: "ID"
+          value: 
+            - "OP-03"
   - id: "OP-04"
     question: "Teamet har gjennomgått teknisk retningslinje for KI i utvikling"
     metadata: 
@@ -120,6 +137,9 @@ records:
             - "Retningslinjer"
         - key: "Område"
           value:
-            - "Opplæring" 
+            - "Opplæring"
+        - key: "ID"
+          value: 
+            - "OP-04"
 
 

--- a/src/main/resources/questions/copilot-team.yaml
+++ b/src/main/resources/questions/copilot-team.yaml
@@ -1,0 +1,95 @@
+name: "Sjekkliste for KI-bruk i teamet"
+columns:
+  - type: "OPTION_SINGLE"
+    name: "Område"
+    options:
+      - name: "Bruksområde"
+      - name: "Tiltak"
+      - name: "Kompetanse"
+  - type: "TEXT"
+    name: "Kortnavn"
+  - type: "TEXT"
+    name: "Beskrivelse"
+  - type: "OPTION_MULTIPLE"
+    name: "Svar"
+  - type: "TEXT"
+    name: "ID"
+records:
+  - id: "BR-01"
+    question: "Hva skal Copilot brukes til?"
+    metadata:
+      answerMetadata:
+        type: "SELECT_MULTIPLE"
+        options:
+          - "Generere ny kode"
+          - "Forbedre eksisterende kode"
+          - "Skrive tester"
+          - "Dokumentasjon"
+          - "Struktur/refaktorering"
+          - "Feilsøking/navigering"
+          - "Arkitekturtest"
+          - "Annet, se kommentar"
+        expiry: 12
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "Hva skal Copilot brukes til?"
+        - key: "Kortnavn"
+          value:
+            - "Anvendelse"
+        - key: "Område"
+          value:
+            - "Bruksområde"
+  - id: "BR-02"
+    question: "Bruksområde"
+    metadata:
+      answerMetadata:
+        type: "SELECT_MULTIPLE"
+        options:
+          - "Copilot brukes som kodeassistent i IDE"
+          - "Copilot brukes til PR-analyse/forslag på Github"
+          - "Agent-modus brukes lokalt"
+          - "Agent-modus brukes på Github"          
+          - "Annet, se kommentar"
+        expiry: 12
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "Hvor og hvordan kjøres Copilot?"
+        - key: "Kortnavn"
+          value:
+            - "Bruksområde"
+        - key: "Område"
+          value:
+            - "Bruksområde"
+  - id: "TI-01"
+    question: "PR-review er påkrevd for all KI-generert kode"
+    metadata:
+      answerMetadata:
+        type: "CHECKBOX"
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "PR-review er påkrevd for all KI-generert kode"
+        - key: "Kortnavn"
+          value:
+            - "PR-review"   
+        - key: "Område"
+          value:
+            - "Tiltak"
+  - id: "TI-02"
+    question: "Ingen auto-commit eller auto-fix uten review"
+    metadata:
+      answerMetadata:
+        type: "CHECKBOX"
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "Ingen auto-commit eller auto-fix uten review"
+        - key: "Kortnavn"
+          value:
+            - "Menneskelig oversyn"   
+        - key: "Område"
+          value:
+            - "Tiltak"
+

--- a/src/main/resources/questions/copilot-team.yaml
+++ b/src/main/resources/questions/copilot-team.yaml
@@ -74,6 +74,7 @@ records:
     metadata: 
       answerMetadata: 
         type: "CHECKBOX"
+        expiry: 26
       optionalFields:
         - key: "Beskrivelse"
           value:
@@ -92,6 +93,7 @@ records:
     metadata: 
       answerMetadata: 
         type: "CHECKBOX"
+        expiry: 26
       optionalFields:
         - key: "Beskrivelse"
           value:
@@ -110,6 +112,7 @@ records:
     metadata: 
       answerMetadata: 
         type: "CHECKBOX"
+        expiry: 26
       optionalFields:
         - key: "Beskrivelse"
           value:
@@ -128,6 +131,7 @@ records:
     metadata: 
       answerMetadata: 
         type: "CHECKBOX"
+        expiry: 26
       optionalFields:
         - key: "Beskrivelse"
           value:

--- a/src/main/resources/questions/copilot-team.yaml
+++ b/src/main/resources/questions/copilot-team.yaml
@@ -1,11 +1,10 @@
-name: "Sjekkliste for KI-bruk i teamet"
+name: "Kontrollere for KI-bruk i teamet"
 columns:
   - type: "OPTION_SINGLE"
     name: "Område"
     options:
       - name: "Bruksområde"
-      - name: "Tiltak"
-      - name: "Kompetanse"
+      - name: "Opplæring"
   - type: "TEXT"
     name: "Kortnavn"
   - type: "TEXT"
@@ -41,7 +40,7 @@ records:
           value:
             - "Bruksområde"
   - id: "BR-02"
-    question: "Bruksområde"
+    question: "Hvor og hvordan kjøres Copilot?"
     metadata:
       answerMetadata:
         type: "SELECT_MULTIPLE"
@@ -62,34 +61,65 @@ records:
         - key: "Område"
           value:
             - "Bruksområde"
-  - id: "TI-01"
-    question: "PR-review er påkrevd for all KI-generert kode"
-    metadata:
-      answerMetadata:
+  - id: "OP-01"
+    question: "Teamet er kjent med forskjellen på assistent- og agentisk bruk"
+    metadata: 
+      answerMetadata: 
         type: "CHECKBOX"
       optionalFields:
         - key: "Beskrivelse"
           value:
-            - "PR-review er påkrevd for all KI-generert kode"
+            - "Teamet er kjent med forskjellen på assistent- og agentisk bruk"
         - key: "Kortnavn"
-          value:
-            - "PR-review"   
+          value: 
+            - "Moduskjennskap"
         - key: "Område"
           value:
-            - "Tiltak"
-  - id: "TI-02"
-    question: "Ingen auto-commit eller auto-fix uten review"
-    metadata:
-      answerMetadata:
+            - "Opplæring"
+  - id: "OP-02"
+    question: "Teamet har gjennomgått Copilots begrensninger"
+    metadata: 
+      answerMetadata: 
         type: "CHECKBOX"
       optionalFields:
         - key: "Beskrivelse"
           value:
-            - "Ingen auto-commit eller auto-fix uten review"
+            - "Teamet har gjennomgått Copilots begrensninger.\n\nInfoside om Copilots tekniske begrensninger og kjente risikoer finnes i Sikkerhetshåndboka på Confluence."
         - key: "Kortnavn"
-          value:
-            - "Menneskelig oversyn"   
+          value: 
+            - "Begrensninger"
         - key: "Område"
           value:
-            - "Tiltak"
+            - "Opplæring"
+  - id: "OP-03"
+    question: "Teamet har gjennomgått KI-sikkerhetsintro med team SKVIS"
+    metadata: 
+      answerMetadata: 
+        type: "CHECKBOX"
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "Teamet har gjennomgått KI-sikkerhetsintro med team SKVIS"
+        - key: "Kortnavn"
+          value: 
+            - "Sikkerhetsintro"
+        - key: "Område"
+          value:
+            - "Opplæring"
+  - id: "OP-04"
+    question: "Teamet har gjennomgått teknisk retningslinje for KI i utvikling"
+    metadata: 
+      answerMetadata: 
+        type: "CHECKBOX"
+      optionalFields:
+        - key: "Beskrivelse"
+          value:
+            - "Teamet har gjennomgått teknisk retningslinje for KI i utvikling.\n\nDokumentet finnes i ITs dokumentarkiv på Sharepoint."
+        - key: "Kortnavn"
+          value: 
+            - "Retningslinjer"
+        - key: "Område"
+          value:
+            - "Opplæring" 
+
 

--- a/src/main/resources/questions/copilot-team.yaml
+++ b/src/main/resources/questions/copilot-team.yaml
@@ -113,7 +113,7 @@ records:
       optionalFields:
         - key: "Beskrivelse"
           value:
-            - "Teamet har gjennomgått KI-sikkerhetsintro med team SKVIS"
+            - "Teamet har gjennomgått KI-sikkerhetsintro med team SKVIS. Legg til en kommentar om hvem som har deltatt fra teamet."
         - key: "Kortnavn"
           value: 
             - "Sikkerhetsintro"
@@ -131,7 +131,7 @@ records:
       optionalFields:
         - key: "Beskrivelse"
           value:
-            - "Teamet har gjennomgått teknisk retningslinje for KI i utvikling. Dokumentet finnes i ITs dokumentarkiv på Sharepoint."
+            - "Teamet har gjennomgått teknisk retningslinje for KI i utvikling. Dokumentet finnes i KVIKK."
         - key: "Kortnavn"
           value: 
             - "Retningslinjer"

--- a/src/main/resources/questions/copilot-team.yaml
+++ b/src/main/resources/questions/copilot-team.yaml
@@ -95,7 +95,7 @@ records:
       optionalFields:
         - key: "Beskrivelse"
           value:
-            - "Teamet har gjennomgått Copilots begrensninger.\n\nInfoside om Copilots tekniske begrensninger og kjente risikoer finnes i Sikkerhetshåndboka på Confluence."
+            - "Teamet har gjennomgått Copilots begrensninger. Infoside om Copilots tekniske begrensninger og kjente risikoer finnes i Sikkerhetshåndboka på Confluence."
         - key: "Kortnavn"
           value: 
             - "Begrensninger"
@@ -131,7 +131,7 @@ records:
       optionalFields:
         - key: "Beskrivelse"
           value:
-            - "Teamet har gjennomgått teknisk retningslinje for KI i utvikling.\n\nDokumentet finnes i ITs dokumentarkiv på Sharepoint."
+            - "Teamet har gjennomgått teknisk retningslinje for KI i utvikling. Dokumentet finnes i ITs dokumentarkiv på Sharepoint."
         - key: "Kortnavn"
           value: 
             - "Retningslinjer"


### PR DESCRIPTION
**Hva er funksjonaliteten du har lagt til?**

Nye kontrollskjemaer for KI-bruk for team og kodebaser. Disse er basert på skjemaene som til nå har ligget i Confluence og vært del av KI-piloten. Se skjema for [team](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/2488991770/Skjema+A+Trygg+bruk+av+Copilot+Teamniv) og [kodebase](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/2490433554/Skjema+B+Trygg+bruk+av+Copilot+Repo+kodebase).

**Hvorfor trenger vi denne funksjonaliteten?**

Det er etterspurt fra KI-piloten at disse skjemaene bør ligge i Regelrett fremfor på Confluence

**Hvem er funksjonaliteten for?**

Team som skal i gang med KI-verktøy

**Anmerkninger til vurderingen:**

- [ ] Det virker som forventet fra en brukers perspektiv.
- [ ] Dokumentasjonen er oppdatert.
- [ ] Det er gjort adekvat feilhåndtering og logging.

<img width="3440" height="2158" alt="image" src="https://github.com/user-attachments/assets/02dac833-7364-4a39-b07d-904ab937b4fe" />
<img width="3448" height="2168" alt="image" src="https://github.com/user-attachments/assets/17c0a18f-a289-431e-8f8c-4f0be0a57e4f" />

