### PR TITLE
Add change context name setting

### DIFF
--- a/app/hooks/useContext.ts
+++ b/app/hooks/useContext.ts
@@ -244,3 +244,30 @@ export function useChangeTeamForContext({
     },
   });
 }
+
+export function useChangeNameForContext({
+  contextId,
+}: {
+  contextId: string;
+}) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (newName: string) => {
+      return axiosFetch({
+        url: contextId
+          ? `${API_URL_BASE}/contexts/${contextId}/name`
+          : undefined,
+        method: "PATCH",
+        data: {
+          name: newName,
+        },
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["contexts", contextId],
+      });
+    },
+  });
+}

--- a/app/pages/activityPage/settingsModal/ChangeContextNameTab.tsx
+++ b/app/pages/activityPage/settingsModal/ChangeContextNameTab.tsx
@@ -1,0 +1,129 @@
+import { Input } from "@/components/ui/input";
+import type { Dispatch, SetStateAction } from "react";
+import React from "react";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button } from "@/components/ui/button";
+import {
+  useChangeNameForContext,
+  useContext,
+} from "@/hooks/useContext";
+import { SkeletonLoader } from "@/components/SkeletonLoader";
+import { ErrorState } from "@/components/ErrorState";
+import { useParams } from "react-router";
+import { isAxiosError } from "axios";
+import { Card, CardContent, CardFooter } from "@/components/ui/card";
+import { toast } from "sonner";
+
+const contextNameFormSchema = z.object({
+  newName: z.string().min(1, { message: "Du må skrive inn et navn." }),
+});
+
+type ChangeContextNameTabProps = {
+  setOpen: Dispatch<SetStateAction<boolean>>;
+};
+
+export function ChangeContextNameTab({ setOpen }: ChangeContextNameTabProps) {
+  const { contextId } = useParams<{ contextId: string }>();
+  const {
+    data: context,
+    error: contextError,
+    isPending: contextIsPending,
+  } = useContext(contextId);
+
+  const nameSubmitMutation = useChangeNameForContext({
+    contextId: contextId ?? "",
+  });
+
+  const contextNameForm = useForm<z.infer<typeof contextNameFormSchema>>({
+    resolver: zodResolver(contextNameFormSchema),
+    defaultValues: { newName: "" },
+  });
+
+  function onSubmit(value: z.infer<typeof contextNameFormSchema>) {
+    nameSubmitMutation.mutate(value.newName, {
+      onSuccess: () => {
+        setOpen(false);
+        toast.success("Endringen er lagret!", {
+          description: `Skjemaet har byttet navn fra ${context?.name} til ${value.newName}.`,
+          duration: 5000,
+          id: "change-context-name-success",
+        });
+      },
+      onError: (error) => {
+        if (isAxiosError(error) && error.response?.status === 409) {
+          contextNameForm.setError("newName", {
+            type: "manual",
+            message:
+              "Et skjema med dette navnet eksisterer allerede, velg et unikt navn",
+          });
+        } else {
+          contextNameForm.setError("newName", {
+            type: "manual",
+            message: "Noe gikk galt. Prøv igjen senere.",
+          });
+        }
+      },
+    });
+  }
+
+  return (
+    <Card>
+      <Form {...contextNameForm}>
+        <form
+          onSubmit={contextNameForm.handleSubmit(onSubmit)}
+          className="space-y-8"
+        >
+          <CardContent className="space-y-2">
+            <h4 className="text-sm font-bold">Skjemautfyllingen heter:</h4>
+            <SkeletonLoader loading={contextIsPending}>
+              {contextError ? (
+                <ErrorState
+                  message={"Klarte ikke hente navnet til skjemautfyllingen"}
+                />
+              ) : (
+                <p className="mb-4">{context?.name}</p>
+              )}
+            </SkeletonLoader>
+
+            <FormField
+              control={contextNameForm.control}
+              name="newName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Skriv inn det nye navnet for skjemautfyllingen:
+                  </FormLabel>
+                  <FormControl>
+                    <Input placeholder="Skjemautfyllingsnavn" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+
+          <CardFooter className="flex justify-end space-x-2">
+            <Button
+              type="reset"
+              variant="outline"
+              onClick={() => setOpen(false)}
+            >
+              Avbryt
+            </Button>
+            <Button type="submit">Lagre</Button>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+}

--- a/app/pages/activityPage/settingsModal/ChangeContextNameTab.tsx
+++ b/app/pages/activityPage/settingsModal/ChangeContextNameTab.tsx
@@ -64,7 +64,7 @@ export function ChangeContextNameTab({ setOpen }: ChangeContextNameTabProps) {
           contextNameForm.setError("newName", {
             type: "manual",
             message:
-              "Et skjema med dette navnet eksisterer allerede, velg et unikt navn",
+              "En skjemautfylling med dette navnet eksisterer allerede, velg et unikt navn",
           });
         } else {
           contextNameForm.setError("newName", {

--- a/app/pages/activityPage/settingsModal/ChangeTeamTab.tsx
+++ b/app/pages/activityPage/settingsModal/ChangeTeamTab.tsx
@@ -66,6 +66,12 @@ export function ChangeTeamTab({ setOpen }: CopyContextTabProps) {
             type: "manual",
             message: "Teamet finnes ikke. Sjekk at du har skrevet riktig.",
           });
+        } else if (isAxiosError(error) && error.response?.status === 409) {
+          teamForm.setError("newTeamName", {
+            type: "manual",
+            message:
+              "Teamet du prøver å overføre til har allerede en skjemautfylling med samme navn for denne skjematypen. Endre navn på en av skjemautfyllingene",
+          });
         } else {
           teamForm.setError("newTeamName", {
             type: "manual",

--- a/app/pages/activityPage/settingsModal/SettingsModal.tsx
+++ b/app/pages/activityPage/settingsModal/SettingsModal.tsx
@@ -9,6 +9,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ChangeTeamTab } from "@/pages/activityPage/settingsModal/ChangeTeamTab";
 import { CopyContextTab } from "@/pages/activityPage/settingsModal/CopyContextTab";
+import { ChangeContextNameTab } from "@/pages/activityPage/settingsModal/ChangeContextNameTab";
 
 type SettingsModalProps = {
   setOpen: Dispatch<SetStateAction<boolean>>;
@@ -24,12 +25,15 @@ export function SettingsModal({ open, setOpen }: SettingsModalProps) {
         </DialogHeader>
 
         <Tabs defaultValue="team" className="w-[400px]">
-          <TabsList className="grid w-full grid-cols-2">
+          <TabsList className="grid w-full grid-cols-3">
             <TabsTrigger value="team" className="data-[state=active]:bg-card">
               Endre team
             </TabsTrigger>
             <TabsTrigger value="copy" className="data-[state=active]:bg-card">
               Kopier svar
+            </TabsTrigger>
+            <TabsTrigger value="name" className="data-[state=active]:bg-card">
+              Endre navn
             </TabsTrigger>
           </TabsList>
 
@@ -39,6 +43,10 @@ export function SettingsModal({ open, setOpen }: SettingsModalProps) {
 
           <TabsContent value="copy">
             <CopyContextTab setOpen={setOpen} />
+          </TabsContent>
+
+          <TabsContent value="name">
+            <ChangeContextNameTab setOpen={setOpen} />
           </TabsContent>
         </Tabs>
       </DialogContent>

--- a/src/main/kotlin/no/bekk/database/ContextRepository.kt
+++ b/src/main/kotlin/no/bekk/database/ContextRepository.kt
@@ -214,9 +214,14 @@ class ContextRepositoryImpl(private val database: Database) : ContextRepository 
                     return statement.executeUpdate() > 0
                 }
             }
-        } catch (e: SQLException) {
-            logger.error("Database error updating team for context $contextId with teamId $newTeamId", e)
-            throw DatabaseException("Failed to update team for context $contextId", "changeTeam", e)
+        }  catch (e: SQLException) {
+            if (e.sqlState == "23505") { // PostgreSQL unique_violation
+                logger.warn("Unique constraint violation when updating contextName: ${e.message}")
+                throw ConflictException("A context with the same team_id and form_id and name already exists.")
+            } else {
+                logger.error("Database error updating team for context $contextId with teamId $newTeamId", e)
+                throw DatabaseException("Failed to update team for context $contextId", "changeTeam", e)
+            }
         }
     }
 
@@ -235,7 +240,7 @@ class ContextRepositoryImpl(private val database: Database) : ContextRepository 
             if (e.sqlState == "23505") { // PostgreSQL unique_violation
                 logger.warn("Unique constraint violation when updating contextName: ${e.message}")
                 throw ConflictException("A context with the same team_id and form_id and name already exists.")
-            }else {
+            } else {
                 logger.error("Database error updating name for context $contextId with name $newName", e)
                 throw DatabaseException("Failed to update name for context $contextId", "changeName", e)
 

--- a/src/main/kotlin/no/bekk/database/ContextRepository.kt
+++ b/src/main/kotlin/no/bekk/database/ContextRepository.kt
@@ -214,7 +214,7 @@ class ContextRepositoryImpl(private val database: Database) : ContextRepository 
                     return statement.executeUpdate() > 0
                 }
             }
-        }  catch (e: SQLException) {
+        } catch (e: SQLException) {
             if (e.sqlState == "23505") { // PostgreSQL unique_violation
                 logger.warn("Unique constraint violation when updating contextName: ${e.message}")
                 throw ConflictException("A context with the same team_id and form_id and name already exists.")
@@ -243,7 +243,6 @@ class ContextRepositoryImpl(private val database: Database) : ContextRepository 
             } else {
                 logger.error("Database error updating name for context $contextId with name $newName", e)
                 throw DatabaseException("Failed to update name for context $contextId", "changeName", e)
-
             }
         }
     }

--- a/src/main/kotlin/no/bekk/database/ContextRepository.kt
+++ b/src/main/kotlin/no/bekk/database/ContextRepository.kt
@@ -234,7 +234,7 @@ class ContextRepositoryImpl(private val database: Database) : ContextRepository 
         } catch (e: SQLException) {
             if (e.sqlState == "23505") { // PostgreSQL unique_violation
                 logger.warn("Unique constraint violation when updating contextName: ${e.message}")
-                throw ConflictException("A context with the same team_id and and name already exists.")
+                throw ConflictException("A context with the same team_id and form_id and name already exists.")
             }else {
                 logger.error("Database error updating name for context $contextId with name $newName", e)
                 throw DatabaseException("Failed to update name for context $contextId", "changeName", e)

--- a/src/main/kotlin/no/bekk/database/ContextRepository.kt
+++ b/src/main/kotlin/no/bekk/database/ContextRepository.kt
@@ -217,7 +217,7 @@ class ContextRepositoryImpl(private val database: Database) : ContextRepository 
         } catch (e: SQLException) {
             if (e.sqlState == "23505") { // PostgreSQL unique_violation
                 logger.warn("Unique constraint violation when updating contextName: ${e.message}")
-                throw ConflictException("A context with the same team_id and form_id and name already exists.")
+                throw ConflictException("A context with the same team_id, form_id and name already exists.")
             } else {
                 logger.error("Database error updating team for context $contextId with teamId $newTeamId", e)
                 throw DatabaseException("Failed to update team for context $contextId", "changeTeam", e)

--- a/src/main/kotlin/no/bekk/database/ContextRepository.kt
+++ b/src/main/kotlin/no/bekk/database/ContextRepository.kt
@@ -16,6 +16,7 @@ interface ContextRepository {
     fun getContext(id: String): DatabaseContext
     fun deleteContext(id: String): Boolean
     fun changeTeam(contextId: String, newTeamId: String): Boolean
+    fun changeName(contextId: String, newName: String): Boolean
     fun getContextMetrics(): List<DatabaseContextMetrics>
     fun getContextsByName(name: String): List<DatabaseContext>
 }
@@ -216,6 +217,29 @@ class ContextRepositoryImpl(private val database: Database) : ContextRepository 
         } catch (e: SQLException) {
             logger.error("Database error updating team for context $contextId with teamId $newTeamId", e)
             throw DatabaseException("Failed to update team for context $contextId", "changeTeam", e)
+        }
+    }
+
+    override fun changeName(contextId: String, newName: String): Boolean {
+        logger.debug("Changing name for context $contextId")
+        val sqlStatement = "UPDATE contexts SET name = ? WHERE id = ?"
+        try {
+            database.getConnection().use { conn ->
+                conn.prepareStatement(sqlStatement).use { statement ->
+                    statement.setString(1, newName)
+                    statement.setObject(2, UUID.fromString(contextId))
+                    return statement.executeUpdate() > 0
+                }
+            }
+        } catch (e: SQLException) {
+            if (e.sqlState == "23505") { // PostgreSQL unique_violation
+                logger.warn("Unique constraint violation when updating contextName: ${e.message}")
+                throw ConflictException("A context with the same team_id and and name already exists.")
+            }else {
+                logger.error("Database error updating name for context $contextId with name $newName", e)
+                throw DatabaseException("Failed to update name for context $contextId", "changeName", e)
+
+            }
         }
     }
 

--- a/src/main/kotlin/no/bekk/routes/ContextRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ContextRouting.kt
@@ -210,6 +210,8 @@ fun Route.contextRouting(
                 } catch (e: BadRequestException) {
                     logger.error("Bad request: ${e.message}", e)
                     call.respond(HttpStatusCode.BadRequest, e.message ?: "Bad request")
+                } catch (e: ConflictException) {
+                    ErrorHandlers.handleConflictException(call, e)
                 } catch (e: Exception) {
                     logger.error("Unexpected error when processing PATCH /contexts", e)
                     call.respond(HttpStatusCode.InternalServerError, "An unexpected error occurred.")

--- a/src/main/kotlin/no/bekk/routes/ContextRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ContextRouting.kt
@@ -262,6 +262,32 @@ fun Route.contextRouting(
                     call.respond(HttpStatusCode.InternalServerError, "An unexpected error occurred.")
                 }
             }
+
+            patch("/name") {
+                try {
+                    logger.info("Received PATCH /{contextId}/name with id: ${call.parameters["contextId"]}")
+                    val contextId = call.parameters["contextId"] ?: throw BadRequestException("Missing contextId")
+
+                    if (!authService.hasContextAccess(call, contextId)) {
+                        call.respond(HttpStatusCode.Forbidden)
+                        return@patch
+                    }
+
+                    val payload = call.receive<NameUpdateRequest>()
+
+                    contextRepository.changeName(contextId, payload.name)
+                    call.respond(HttpStatusCode.OK)
+                    return@patch
+                } catch (e: BadRequestException) {
+                    logger.error("Bad request: ${e.message}", e)
+                    call.respond(HttpStatusCode.BadRequest, e.message ?: "Bad request")
+                } catch (e: ConflictException) {
+                    ErrorHandlers.handleConflictException(call, e)
+                } catch (e: Exception) {
+                    logger.error("Unexpected error when processing PATCH /contexts", e)
+                    call.respond(HttpStatusCode.InternalServerError, "An unexpected error occurred.")
+                }
+            }
         }
     }
 }
@@ -295,6 +321,10 @@ fun buildContextMetrics(
 
 @Serializable
 data class TeamUpdateRequest(val teamName: String? = null, val teamId: String? = null)
+
+@Serializable
+data class NameUpdateRequest(val name: String)
+
 
 @Serializable
 data class CopyContextRequest(val copyContextId: String?)

--- a/src/main/kotlin/no/bekk/routes/ContextRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ContextRouting.kt
@@ -327,7 +327,6 @@ data class TeamUpdateRequest(val teamName: String? = null, val teamId: String? =
 @Serializable
 data class NameUpdateRequest(val name: String)
 
-
 @Serializable
 data class CopyContextRequest(val copyContextId: String?)
 

--- a/src/test/kotlin/no/bekk/routes/MockContextRepository.kt
+++ b/src/test/kotlin/no/bekk/routes/MockContextRepository.kt
@@ -30,6 +30,10 @@ interface MockContextRepository : ContextRepository {
         TODO("Not yet implemented")
     }
 
+    override fun changeName(contextId: String, newName: String): Boolean {
+        TODO("Not yet implemented")
+    }
+
     override fun getContextByTeamIdAndFormId(teamId: String, formId: String): List<DatabaseContext> {
         TODO("Not yet implemented")
     }


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**

Lagt til en tab for å kunne bytte navn på en skjemautfylling under innstillings-knappen på skjemautfyllingsiden. 

<img width="450" height="375" alt="image" src="https://github.com/user-attachments/assets/80c04d56-76eb-47e4-a303-8e81588e69ca" />

<img width="1485" height="831" alt="image" src="https://github.com/user-attachments/assets/71938517-e53e-4e00-a1b0-74f59f574ac4" />
<img width="1440" height="958" alt="image" src="https://github.com/user-attachments/assets/6fc35100-65ca-4c5b-b89c-bd79a01805f9" />


Feilhåndtering hvis teamet allerede har en skjemautfylling (samme type skjema) med likt navnt: 


<img width="455" height="436" alt="image" src="https://github.com/user-attachments/assets/e34c415f-ca8a-4dcf-b815-faa8c1a6316b" />




I tillegg har jeg lagt til feilhåndtering hvis man skal bytte eier av teamet for en skjemautfyling, og det teamet allerede har en skjemautfylling av samme type skjema med samme navn:

<img width="450" height="467" alt="image" src="https://github.com/user-attachments/assets/585fe47a-8363-470b-b9b2-a809e73b32e9" />
(før returnerte den bare "noe gikk galt")



**Hvorfor trenger vi denne funskjonaliteten?**

For å enkelt endre navn på et skjema når infrastruktur andre ting rundt navnevalget på skjemaer endrer seg, uten å lage et helt nytt skjema og kopiere over svar. 
Feks ved oppkobling mot andre systemer kan denne funksjonaliteten brukes for knytte til en connection mellom skjemaer. 


**Hvem er funskjonaliteten for?**

Alle brukere, sælrig teamleads eller andre på teamet med overordnet ansvar. 



**Anmerkninger til vurderingen:**

- [ ] Det virker som forventet fra en brukers perspektiv.
- [ ] Dokumentasjonen er oppdatert.
- [ ] Det er gjort adekvar feilhåndtering og logging.
