### PR TITLE
Add tabs, fix overflow and loading on frontpage

### DIFF
--- a/app/pages/frontPage/ContextLink.tsx
+++ b/app/pages/frontPage/ContextLink.tsx
@@ -20,7 +20,7 @@ export function ContextLink({
   canDelete = true,
 }: {
   contextId: string;
-  formId: string;
+  formId?: string;
   canDelete?: boolean;
 }) {
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
@@ -98,8 +98,8 @@ export function ContextLink({
                   </div>
                   <SkeletonLoader
                     loading={answerIsPending}
-                    width="w-[450px]"
-                    height="h-[98px]"
+                    width="w-[200px]"
+                    height="h-[30px]"
                   >
                     <p className="text-xs text-muted-foreground">
                       Sist endret:{" "}

--- a/app/pages/frontPage/FrontPage.tsx
+++ b/app/pages/frontPage/FrontPage.tsx
@@ -12,6 +12,7 @@ import { Separator } from "@/components/ui/separator";
 import { Download } from "lucide-react";
 import { SkeletonLoader } from "@/components/SkeletonLoader";
 import React from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import ReadGrantedContextsSection from "@/pages/frontPage/ReadGrantedContextsSection";
 import { useReadGrantsByUser } from "@/hooks/useGrants";
 
@@ -54,8 +55,25 @@ export default function FrontPage() {
       <RedirectBackButton />
       <Page>
         <div className="flex flex-col mx-auto px-8 items-start ">
-          {hasTeams && (
-            <>
+          <Tabs defaultValue="teams">
+            <TabsList className="grid w-[400px] grid-cols-2">
+              <TabsTrigger
+                value="teams"
+                className="data-[state=active]:bg-card"
+              >
+                Dine Team
+              </TabsTrigger>
+              <TabsTrigger
+                value="granted"
+                className="data-[state=active]:bg-card"
+              >
+                Delt med deg
+              </TabsTrigger>
+            </TabsList>
+            {hasTeams && (
+              <>
+            <TabsContent value={"teams"}>
+
               <h1 className="text-4xl font-bold">Dine team</h1>
               <div className="flex flex-col items-start">
                 <div className="flex flex-row gap-8">
@@ -94,8 +112,11 @@ export default function FrontPage() {
                   })}
                 </SkeletonLoader>
               </div>
+            </TabsContent>
+
             </>
           )}
+          </Tabs>
           {userinfo?.user.id && (
             <ReadGrantedContextsSection userId={userinfo.user.id} />
           )}

--- a/app/pages/frontPage/FrontPage.tsx
+++ b/app/pages/frontPage/FrontPage.tsx
@@ -8,13 +8,12 @@ import {
 } from "@/utils/csvExportUtils";
 import { ErrorState } from "@/components/ErrorState";
 import { Button } from "@/components/ui/button";
-import { Separator } from "@/components/ui/separator";
-import { Download } from "lucide-react";
+import { Download, FileText } from "lucide-react";
 import { SkeletonLoader } from "@/components/SkeletonLoader";
 import React from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import ReadGrantedContextsSection from "@/pages/frontPage/ReadGrantedContextsSection";
-import { useReadGrantsByUser } from "@/hooks/useGrants";
+
 
 export default function FrontPage() {
   const {
@@ -22,11 +21,6 @@ export default function FrontPage() {
     isPending: isUserinfoLoading,
     isError: isUserinfoError,
   } = useUser();
-
-  const {
-    data: readGrants,
-    isPending: isReadGrantsLoading,
-  } = useReadGrantsByUser(userinfo?.user.id || "");
 
   if (isUserinfoError) {
     return (
@@ -38,25 +32,16 @@ export default function FrontPage() {
   }
 
   const teams = userinfo ? userinfo.groups : [];
-  const hasTeams = teams.length > 0;
-  const hasGrantedReadAccess = readGrants && readGrants.length > 0;
 
-  if (!isUserinfoLoading && !isReadGrantsLoading && !hasTeams && !hasGrantedReadAccess) {
-    return (
-      <>
-        <RedirectBackButton />
-        <ErrorState message="Vi fant dessverre ingen grupper som tilhører din bruker, og ingenting er delt med deg." />
-      </>
-    );
-  }
+
 
   return (
     <div>
       <RedirectBackButton />
       <Page>
-        <div className="flex flex-col mx-auto px-8 items-start ">
-          <Tabs defaultValue="teams">
-            <TabsList className="grid w-[400px] grid-cols-2">
+        <div className="w-full max-w-8xl mx-auto px-4 sm:px-8">
+          <Tabs defaultValue="teams" className="w-full">
+            <TabsList className="grid w-full max-w-md grid-cols-2 mb-8">
               <TabsTrigger
                 value="teams"
                 className="data-[state=active]:bg-card"
@@ -70,56 +55,74 @@ export default function FrontPage() {
                 Delt med deg
               </TabsTrigger>
             </TabsList>
-            {hasTeams && (
-              <>
-            <TabsContent value={"teams"}>
 
-              <h1 className="text-4xl font-bold">Dine team</h1>
-              <div className="flex flex-col items-start">
-                <div className="flex flex-row gap-8">
-                  {userinfo?.superuser && (
-                    <Button
-                      variant="link"
-                      className="w-fit font-bold has-[>svg]:px-0 my-2"
-                      onClick={() => handleExportFullCSV()}
-                    >
-                      Eksporter skjemautfyllinger
-                      <Download className="size-5" />
-                    </Button>
-                  )}
-                  {userinfo?.reportinguser && (
-                    <Button
-                      variant="link"
-                      className="w-fit font-bold has-[>svg]:px-0 my-2"
-                      onClick={() => handleExportProgressCSV()}
-                    >
-                      Eksporter utfyllingstilstand
-                      <Download className="size-5" />
-                    </Button>
-                  )}
-                </div>
-                <Separator className="my-5" />
-                <SkeletonLoader loading={isUserinfoLoading}>
-                  {teams.map((team) => {
-                    return (
-                      <div key={team.id}>
-                        <h2 className="text-2xl font-bold py-4 w-fit">
-                          {team.displayName}
-                        </h2>
-                        <TeamContexts teamId={team.id} />
-                      </div>
-                    );
-                  })}
-                </SkeletonLoader>
-              </div>
+            <TabsContent value={"teams"} className="w-full space-y-6">
+              <SkeletonLoader loading={isUserinfoLoading} height={"h-[700px]"}>
+                {teams.length > 0 ? (
+                  <>
+                    <div>
+                      <h1 className="text-4xl font-bold mb-2">Dine team</h1>
+                      <p className="text-muted-foreground">
+                        Administrer og fyll ut skjemaer for dine team
+                      </p>
+                    </div>
+
+                    <div className="flex flex-row gap-4 flex-wrap">
+                      {userinfo?.superuser && (
+                        <Button
+                          variant="outline"
+                          className="gap-2"
+                          onClick={() => handleExportFullCSV()}
+                        >
+                          <Download className="size-4" />
+                          Eksporter skjemautfyllinger
+                        </Button>
+                      )}
+                      {userinfo?.reportinguser && (
+                        <Button
+                          variant="outline"
+                          className="gap-2"
+                          onClick={() => handleExportProgressCSV()}
+                        >
+                          <Download className="size-4" />
+                          Eksporter utfyllingstilstand
+                        </Button>
+                      )}
+                    </div>
+
+                    <div className="space-y-6">
+                      {teams.map((team) => {
+                        return (
+                          <div key={team.id}>
+                            <h2 className="text-2xl font-bold py-4 w-fit">
+                              {team.displayName}
+                            </h2>
+                            <TeamContexts teamId={team.id} />
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </>
+                ) : (
+                  <div className="text-center py-12">
+                    <FileText className="size-12 mx-auto mb-4 text-muted-foreground" />
+                    <h2 className="text-lg font-semibold">
+                      Vi fant ingen team
+                    </h2>
+                    <p className="text-muted-foreground mt-1">
+                      Du har ikke tilgang til noen team ennå
+                    </p>
+                  </div>
+                )}
+              </SkeletonLoader>
             </TabsContent>
 
-            </>
-          )}
+            <TabsContent value={"granted"} className="w-full">
+              {userinfo?.user.id && (
+                <ReadGrantedContextsSection userId={userinfo.user.id} />
+              )}
+            </TabsContent>
           </Tabs>
-          {userinfo?.user.id && (
-            <ReadGrantedContextsSection userId={userinfo.user.id} />
-          )}
         </div>
       </Page>
     </div>

--- a/app/pages/frontPage/ProgressCircle.tsx
+++ b/app/pages/frontPage/ProgressCircle.tsx
@@ -41,8 +41,8 @@ export function ProgressCircle({
   return (
     <SkeletonLoader
       loading={formIsPending || answerIsPending}
-      width={`w-[${size}px]`}
-      height={`h-[${size}px]`}
+      width={`w-[70px]`}
+      height={`h-[70px]`}
     >
       <div className="relative" style={{ width: size, height: size }}>
         <svg height={size} width={size} className="transform -rotate-90">

--- a/app/pages/frontPage/ReadGrantedContextsSection.tsx
+++ b/app/pages/frontPage/ReadGrantedContextsSection.tsx
@@ -1,7 +1,8 @@
 import { SkeletonLoader } from "@/components/SkeletonLoader";
-import { Separator } from "@/components/ui/separator";
 import { useReadGrantsByUser } from "@/hooks/useGrants";
 import { ContextLink } from "@/pages/frontPage/ContextLink";
+import { Share2 } from "lucide-react";
+import React from "react";
 
 type ReadGrantedContextsSectionProps = {
   userId: string
@@ -18,27 +19,41 @@ export default function ReadGrantedContextsSection({
 
   if (
     !readGrantsLoading &&
-    (!readGrants || readGrants.length === 0)
+    !readGrants
   ) {
     return null;
   }
 
+  if(readGrants?.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <Share2 className="size-12 mx-auto mb-4 text-muted-foreground" />
+        <h2 className="text-lg font-semibold">
+          Ingen skjema har blitt delt med deg
+        </h2>
+        <p className="text-muted-foreground mt-1">
+          Du har ikke fått lesetilgang til noen skjema utenfor ditt team.
+        </p>
+      </div>
+    );
+  }
+
   return (
-    <>
-      <Separator className="my-5" />
-      <h1 className="text-4xl font-bold">Delt med deg</h1>
+    <div className="w-full space-y-6">
+      <div>
+        <h1 className="text-4xl font-bold mb-2">Delt med deg</h1>
+        <p className="text-muted-foreground">
+          Skjemaer du har fått midlertidig lesetilgang til
+        </p>
+      </div>
       <SkeletonLoader loading={readGrantsLoading}>
-        <div className="flex flex-col gap-4 items-start py-4">
+        <div className="space-y-3 flex flex-col w-[450px]">
           {readGrants?.map((readGrant) => (
-            <ContextLink
-              key={readGrant.id}
-              contextId={readGrant.contextId}
-              formId=""
-            />
+              <ContextLink key={readGrant.id} contextId={readGrant.contextId} />
           ))}
         </div>
       </SkeletonLoader>
-    </>
+    </div>
   );
 }
 

--- a/app/pages/frontPage/TeamContexts.tsx
+++ b/app/pages/frontPage/TeamContexts.tsx
@@ -25,7 +25,7 @@ export default function TeamContexts({ teamId }: { teamId: string }) {
       loading={contextsIsPending || formsPending}
       height="min-h-[98px]"
     >
-      <div className="flex flex-col lg:flex-row gap-6">
+      <div className="flex flex-col lg:flex-row gap-6 flex-wrap">
         {contextForms?.map((form) => {
           const contextsForForm = contexts.filter(
             (context) => context.formId === form.id,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,12 @@ dependencies {
     implementation(libs.ben.manes.caffeine)
     implementation(libs.netty.codec.http2)
     implementation(libs.netty.transport.native.epoll)
-    implementation(libs.jackson.databind )
+
+    constraints {
+        implementation("tools.jackson.core:jackson-databind:3.1.4") {
+            because("Fixes Jackson databind vulnerabilities present in 3.1.1")
+        }
+    }
 
     testImplementation(libs.testcontainers.testcontainers)
     testImplementation(libs.testcontainers.postgresql)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,9 +55,6 @@ dependencies {
         implementation("tools.jackson.core:jackson-databind:3.1.4") {
             because("Fixes Jackson databind vulnerabilities present in 3.1.1")
         }
-        implementation("com.fasterxml.jackson.core:jackson-databind:2.21.5") {
-            because("Fixes vulnerabilities present in 2.21.3")
-        }
     }
 
     testImplementation(libs.testcontainers.testcontainers)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,9 @@ dependencies {
         implementation("tools.jackson.core:jackson-databind:3.1.4") {
             because("Fixes Jackson databind vulnerabilities present in 3.1.1")
         }
+        implementation("com.fasterxml.jackson.core:jackson-databind:2.21.5") {
+            because("Fixes vulnerabilities present in 2.21.3")
+        }
     }
 
     testImplementation(libs.testcontainers.testcontainers)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(libs.ben.manes.caffeine)
     implementation(libs.netty.codec.http2)
     implementation(libs.netty.transport.native.epoll)
+    implementation(libs.jackson.databind )
 
     testImplementation(libs.testcontainers.testcontainers)
     testImplementation(libs.testcontainers.postgresql)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ junit-platform-launcher = { module = 'org.junit.platform:junit-platform-launcher
 junit-jupiter = { module = 'org.junit.jupiter:junit-jupiter', version = "6.1.0" }
 netty-codec-http2 = { module='io.netty:netty-codec-http2', version.ref = 'netty-version' } #kan fjernes når ktor oppggraderer til å bruke ny versjon netty2
 netty-transport-native-epoll = { module='io.netty:netty-transport-native-epoll', version.ref = 'netty-version' }
-jackson-databind = { module='com.fasterxml.jackson.core:jackson-databind', version='3.1.4' }
+
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin-version" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ junit-platform-launcher = { module = 'org.junit.platform:junit-platform-launcher
 junit-jupiter = { module = 'org.junit.jupiter:junit-jupiter', version = "6.1.0" }
 netty-codec-http2 = { module='io.netty:netty-codec-http2', version.ref = 'netty-version' } #kan fjernes når ktor oppggraderer til å bruke ny versjon netty2
 netty-transport-native-epoll = { module='io.netty:netty-transport-native-epoll', version.ref = 'netty-version' }
-
+jackson-databind = { module='com.fasterxml.jackson.core:jackson-databind', version='3.1.4' }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin-version" }


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**


**Tabs på forsiden og fjernet overflow**

Laget tabs for dine skjema og delte med deg, slik at man ikke må scrolle helt ned til nederst på siden for å finne skjemaene du har delt lese-tilgang til. 

I tillegg har jeg lagt på flexwrap slik at man ikke må scrolle sidelengs for å finne alle skjemane, de flekser heller nedover hvis det blir for mange kolonner. 

CSV-nedlastingslenkene har også blitt gjort om til knapper.

| Før | Etter |
|--|--|
| <img width="1482" height="964" alt="bilde" src="https://github.com/user-attachments/assets/87b0811e-ccf6-4f1d-9aeb-a6d3d6364bbb" /> | <img width="1478" height="997" alt="bilde" src="https://github.com/user-attachments/assets/fbdbc1af-ca28-45cc-a97d-0deb6c747367" /> |

| Før | Etter |
|--|--|
| <img width="1307" height="1014" alt="bilde" src="https://github.com/user-attachments/assets/04931918-c3b9-4975-a0dd-343d10783207" />| <img width="1475" height="999" alt="bilde" src="https://github.com/user-attachments/assets/6dd653b0-5435-4827-b801-0eb2ec2531ce" /> |


**Ingen teams / ingen delte skjema**

Hver tab håndterer selv om den er tom eller ei, i stedet for en felles error state som sjekker om man mangler alt. 

| Før | Etter |
|--|--|
| <img width="1474" height="1001" alt="bilde" src="https://github.com/user-attachments/assets/ef42da35-6adf-451e-b53d-9b0acae87b04" />| <img width="1470" height="1002" alt="bilde" src="https://github.com/user-attachments/assets/9e5927f5-4d59-41a6-b750-584e6c0fc378" /> | 

| Før | Etter |
|--|--|
| <img width="1474" height="1001" alt="bilde" src="https://github.com/user-attachments/assets/18666d39-fa8e-40aa-ab30-4cbdbb774a50" />| <img width="1471" height="999" alt="bilde" src="https://github.com/user-attachments/assets/df39ea51-61d4-4f68-98ee-7172e013ffbc" />|





**Loading**
Mange av skeletonene var for store i fht innholdet den lastet inn, så jeg har justert disse til å bli mindre, slik at kortene ikke hopper rundt omkring når den går nn og ut av loading-state.
| Før | Etter |
|--|--|
| <img width="1064" height="256" alt="bilde" src="https://github.com/user-attachments/assets/d20b1937-6038-4e7c-a5e5-ef4f0246a5a7" />| <img width="949" height="135" alt="bilde" src="https://github.com/user-attachments/assets/02ce5aca-6b05-465b-92b4-998b5e707113" /> |


**Hvorfor trenger vi denne funskjonaliteten?**

Gjøre det litt mer oversiktlig for brukere som skal monitorere mange team sine skjema, samt gjøre forsiden litt mer brukanes for den som måtte ønske dette.

**Hvem er funskjonaliteten for?**

Hovedsakelig folk med overordnet ansvar for å følge opp andre teams skjema.


