### PR TITLE
Feat invoke read grants

### DIFF
--- a/app/hooks/useGrants.ts
+++ b/app/hooks/useGrants.ts
@@ -35,7 +35,7 @@ export function useGrants(contextId: string){
     queryKey: ["ReadGrants", contextId],
     queryFn: () =>
       axiosFetch<ReadGrant[]>({
-        url: `${API_URL_BASE}/contexts/${contextId}/readGrants`,
+        url: `${API_URL_BASE}/readGrants/${contextId}`,
       }).then((response) => response.data),
     select: formatReadGrantData,
   });
@@ -43,7 +43,7 @@ export function useGrants(contextId: string){
   const grantReadAccess = useMutation({
     mutationFn: (body: SubmitReadGrantRequest) => {
       return axiosFetch<ReadGrant>({
-        url: `${API_URL_BASE}/contexts/${contextId}/grantReadAccess`,
+        url: `${API_URL_BASE}/readGrants/${contextId}`,
         method: "POST",
         data: body,
       });
@@ -56,7 +56,7 @@ export function useGrants(contextId: string){
         id: toastId,
       });
       await queryClient.invalidateQueries({
-        queryKey: ["GrantReadAccess", contextId],
+        queryKey: ["ReadGrants", contextId],
       });
     },
   });
@@ -73,7 +73,7 @@ export function useReadGrantsByUser(userId: string){
     queryKey: ["UsersGrantedReadAccesses", userId],
     queryFn: () =>
       axiosFetch<ReadGrant[]>({
-        url: `${API_URL_BASE}/contexts/usersReadGrants?userId=${userId}`,
+        url: `${API_URL_BASE}/readGrants?userId=${userId}`,
       }).then((response) => response.data),
     select: formatReadGrantData,
   });

--- a/app/hooks/useGrants.ts
+++ b/app/hooks/useGrants.ts
@@ -63,7 +63,7 @@ export function useGrants(contextId: string){
 
   const revokeReadGrant = useMutation({
     mutationFn: (readGrantId: string) => {
-      return axiosFetch<ReadGrant>({
+      return axiosFetch({
         url: `${API_URL_BASE}/readGrants/${contextId}/${readGrantId}/expiry`,
         method: "PATCH",
       });

--- a/app/hooks/useGrants.ts
+++ b/app/hooks/useGrants.ts
@@ -61,9 +61,30 @@ export function useGrants(contextId: string){
     },
   });
 
+  const revokeReadGrant = useMutation({
+    mutationFn: (readGrantId: string) => {
+      return axiosFetch<ReadGrant>({
+        url: `${API_URL_BASE}/readGrants/${contextId}/${readGrantId}/expiry`,
+        method: "PATCH",
+      });
+    },
+    onSuccess: async () => {
+      const toastId = "patch-readGrant-success";
+      toast.success("Suksess", {
+        description: `Lesetilgangen ble slettet`,
+        duration: 5000,
+        id: toastId,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["ReadGrants", contextId],
+      });
+    },
+  });
+
   return {
     readGrants,
-    grantReadAccess
+    grantReadAccess,
+    revokeReadGrant,
   }
 
 }

--- a/app/pages/activityPage/settingsModal/GrantReadAccessTab.tsx
+++ b/app/pages/activityPage/settingsModal/GrantReadAccessTab.tsx
@@ -28,7 +28,7 @@ import { useGrants } from "@/hooks/useGrants";
 import { useContext } from "@/hooks/useContext";
 import { formatDate } from "@/utils/formatTime";
 import { useDebounce } from "@/hooks/useDebounce";
-import { Search } from "lucide-react";
+import { Search, Trash2 } from "lucide-react";
 
 
 const grantReadAccessFormSchema = z.object({
@@ -62,7 +62,9 @@ export function GrantReadAccessTab({ setOpen }: GrantReadAccessTabProps) {
     isPending: userinfoIsPending,
   } = useUser();
 
-  const { readGrants, grantReadAccess } = useGrants(contextId ?? "");
+  const { readGrants, grantReadAccess, revokeReadGrant } = useGrants(
+    contextId ?? "",
+  );
   const readGrantList = readGrants.data ?? [];
 
   const ownerTeamName = userinfo?.groups.find(
@@ -122,7 +124,10 @@ export function GrantReadAccessTab({ setOpen }: GrantReadAccessTabProps) {
   return (
     <Card>
       <Form {...GrantReadAccessForm}>
-        <form onSubmit={GrantReadAccessForm.handleSubmit(onSubmit)} className="space-y-4">
+        <form
+          onSubmit={GrantReadAccessForm.handleSubmit(onSubmit)}
+          className="space-y-4"
+        >
           <CardContent className="space-y-4 pt-4">
             <SkeletonLoader
               loading={
@@ -151,7 +156,10 @@ export function GrantReadAccessTab({ setOpen }: GrantReadAccessTabProps) {
                       </p>
                       <ul className="space-y-1">
                         {readGrantList.map((readGrant) => (
-                          <li key={readGrant.userId} className="text-sm">
+                          <li
+                            key={readGrant.userId}
+                            className="flex items-center justify-between gap-2 text-sm"
+                          >
                             <div className="flex flex-col">
                               <UsernameDisplay userId={readGrant.userId} />
                               {readGrant.expiresAt && (
@@ -160,6 +168,19 @@ export function GrantReadAccessTab({ setOpen }: GrantReadAccessTabProps) {
                                 </span>
                               )}
                             </div>
+                            <Button
+                              type="button"
+                              aria-label="Slett utfylling"
+                              variant="ghost"
+                              size="icon"
+                              disabled={revokeReadGrant.isPending}
+                              onClick={() => {
+                                revokeReadGrant.mutate(readGrant.id);
+                              }}
+                              className="text-destructive hover:text-destructive"
+                            >
+                              <Trash2 />
+                            </Button>
                           </li>
                         ))}
                       </ul>
@@ -214,9 +235,13 @@ export function GrantReadAccessTab({ setOpen }: GrantReadAccessTabProps) {
                                 className="w-full justify-start rounded px-2 py-1 text-left text-sm"
                                 onMouseDown={(event) => {
                                   event.preventDefault();
-                                  GrantReadAccessForm.setValue("userId", user.id, {
-                                    shouldValidate: true,
-                                  });
+                                  GrantReadAccessForm.setValue(
+                                    "userId",
+                                    user.id,
+                                    {
+                                      shouldValidate: true,
+                                    },
+                                  );
                                   setUsernameInput(user.displayName);
                                   setShowSuggestions(false);
                                 }}
@@ -257,7 +282,11 @@ export function GrantReadAccessTab({ setOpen }: GrantReadAccessTabProps) {
                 <FormItem>
                   <FormLabel>Begrunnelse</FormLabel>
                   <FormControl>
-                    <Input type="text" placeholder="Begrunn hvorfor tilgangen gis" {...field} />
+                    <Input
+                      type="text"
+                      placeholder="Begrunn hvorfor tilgangen gis"
+                      {...field}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/app/pages/activityPage/settingsModal/GrantReadAccessTab.tsx
+++ b/app/pages/activityPage/settingsModal/GrantReadAccessTab.tsx
@@ -170,7 +170,7 @@ export function GrantReadAccessTab({ setOpen }: GrantReadAccessTabProps) {
                             </div>
                             <Button
                               type="button"
-                              aria-label="Slett utfylling"
+                              aria-label="Slett lesetilgang"
                               variant="ghost"
                               size="icon"
                               disabled={revokeReadGrant.isPending}

--- a/src/main/kotlin/no/bekk/database/ReadGrantRepository.kt
+++ b/src/main/kotlin/no/bekk/database/ReadGrantRepository.kt
@@ -150,8 +150,8 @@ class ReadGrantRepositoryImpl(private val database: Database) : ReadGrantReposit
         try {
             database.getConnection().use { conn ->
                 conn.prepareStatement(sqlStatement).use { statement ->
-                    statement.setObject(1, readGrantId)
-                    statement.setString(2, contextId)
+                    statement.setObject(1, UUID.fromString(readGrantId))
+                    statement.setObject(2, UUID.fromString(contextId))
                     return statement.executeUpdate() > 0
                 }
             }

--- a/src/main/kotlin/no/bekk/database/ReadGrantRepository.kt
+++ b/src/main/kotlin/no/bekk/database/ReadGrantRepository.kt
@@ -14,6 +14,7 @@ interface ReadGrantRepository {
     fun getReadGrantsByContext(contextId: String): List<DatabaseReadGrant>
     fun getReadGrantsByUserId(userId: String): List<DatabaseReadGrant>
     fun insertReadGrantOnContext(contextId: String, readGrant: DatabaseReadGrantRequest): DatabaseReadGrant
+    fun revokeReadGrantOnContext(readGrantId: String, contextId: String): Boolean
 }
 
 class ReadGrantRepositoryImpl(private val database: Database) : ReadGrantRepository {
@@ -140,6 +141,23 @@ class ReadGrantRepositoryImpl(private val database: Database) : ReadGrantReposit
         } catch (e: SQLException) {
             logger.error("Error fetching granted read accesses for user: $userId", e)
             throw RuntimeException("Error fetching granted read accesses for user: $userId from database", e)
+        }
+    }
+
+    override fun revokeReadGrantOnContext(readGrantId: String, contextId: String): Boolean {
+        val sqlStatement = "UPDATE read_grants SET expires_at = CURRENT_TIMESTAMP WHERE id = ? AND context_id = ?"
+
+        try {
+            database.getConnection().use { conn ->
+                conn.prepareStatement(sqlStatement).use { statement ->
+                    statement.setObject(1, readGrantId)
+                    statement.setString(2, contextId)
+                    return statement.executeUpdate() > 0
+                }
+            }
+        } catch (e: SQLException) {
+            logger.error("Database error revoking read grant $readGrantId", e)
+            throw DatabaseException("Failed to revoke read grant $readGrantId", "revokeReadGrant", e)
         }
     }
 }

--- a/src/main/kotlin/no/bekk/plugins/Routing.kt
+++ b/src/main/kotlin/no/bekk/plugins/Routing.kt
@@ -82,8 +82,9 @@ fun Application.configureRouting(
         route("/api") {
             answerRouting(dependencies.authService, dependencies.answerRepository)
             commentRouting(dependencies.authService, dependencies.commentRepository)
-            contextRouting(dependencies.authService, dependencies.answerRepository, dependencies.contextRepository, dependencies.commentRepository, dependencies.readGrantRepository, dependencies.formService)
+            contextRouting(dependencies.authService, dependencies.answerRepository, dependencies.contextRepository, dependencies.commentRepository, dependencies.formService)
             formRouting(dependencies.formService)
+            readGrantRouting(dependencies.authService, dependencies.readGrantRepository)
             userInfoRouting(dependencies.authService)
             uploadCSVRouting(dependencies.authService, dependencies.formService, dependencies.database)
         }

--- a/src/main/kotlin/no/bekk/routes/ContextRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ContextRouting.kt
@@ -279,7 +279,6 @@ fun Route.contextRouting(
                     call.respond(HttpStatusCode.InternalServerError, "An unexpected error occurred.")
                 }
             }
-
         }
     }
 }

--- a/src/main/kotlin/no/bekk/routes/ContextRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ContextRouting.kt
@@ -22,7 +22,6 @@ fun Route.contextRouting(
     answerRepository: AnswerRepository,
     contextRepository: ContextRepository,
     commentRepository: CommentRepository,
-    readGrantRepository: ReadGrantRepository,
     formService: FormService,
 ) {
     val logger = LoggerFactory.getLogger("no.bekk.routes.ContextRouting")
@@ -127,14 +126,6 @@ fun Route.contextRouting(
             } else {
                 call.respond(HttpStatusCode.OK, Json.encodeToString(contexts))
             }
-            return@get
-        }
-
-        get("/usersReadGrants") {
-            val userId = call.request.queryParameters["userId"] ?: throw BadRequestException("Missing userId parameter")
-
-            val usersReadGrants = readGrantRepository.getReadGrantsByUserId(userId)
-            call.respond(HttpStatusCode.OK, Json.encodeToString(usersReadGrants))
             return@get
         }
 
@@ -289,42 +280,6 @@ fun Route.contextRouting(
                 }
             }
 
-            post("/grantReadAccess") {
-                try {
-                    val contextId = call.parameters["contextId"] ?: throw BadRequestException("Missing contextId")
-
-                    val grantReadAccessRequestJson = call.receiveText()
-                    logger.info("Received POST /context/contextId/grantReadAccess request with body: $grantReadAccessRequestJson")
-                    val grantReadAccessRequest = Json.decodeFromString<DatabaseReadGrantRequest>(grantReadAccessRequestJson)
-
-                    if (!authService.hasWriteContextAccess(call, contextId)) {
-                        call.respond(HttpStatusCode.Forbidden)
-                        return@post
-                    }
-
-                    val readGrant = readGrantRepository.insertReadGrantOnContext(contextId, grantReadAccessRequest)
-
-                    call.respond(HttpStatusCode.Created, Json.encodeToString(readGrant))
-                    return@post
-                } catch (e: ConflictException) {
-                    ErrorHandlers.handleConflictException(call, e)
-                } catch (e: Exception) {
-                    logger.error("Unexpected error when processing post /contexts/contextId/grantReadAccess", e)
-                    call.respond(HttpStatusCode.InternalServerError, "An unexpected error occurred.")
-                }
-            }
-            get("/readGrants") {
-                logger.info("Received GET /context/contextId/readGrants with id: ${call.parameters["contextId"]}")
-                val contextId = call.parameters["contextId"] ?: throw BadRequestException("Missing contextId")
-
-                if (!authService.hasWriteContextAccess(call, contextId) && !authService.hasReadContextAccess(call, contextId)) {
-                    call.respond(HttpStatusCode.Forbidden)
-                    return@get
-                }
-                val context = readGrantRepository.getReadGrantsByContext(contextId)
-                call.respond(HttpStatusCode.OK, Json.encodeToString(context))
-                return@get
-            }
         }
     }
 }

--- a/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
@@ -1,0 +1,95 @@
+package no.bekk.routes
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.parameters
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.request.receive
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.patch
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import no.bekk.authentication.AuthService
+import no.bekk.database.DatabaseReadGrantRequest
+import no.bekk.database.ReadGrantRepository
+import no.bekk.exception.ConflictException
+import no.bekk.plugins.ErrorHandlers
+import org.slf4j.LoggerFactory
+
+fun Route.readGrantRouting(authService: AuthService, readGrantRepository: ReadGrantRepository) {
+    val logger = LoggerFactory.getLogger("no.bekk.routes.AnswerRouting")
+
+
+    route("/readGrants") {
+
+        get {
+            logger.info("Received get /readGrants for user with id: ${call.parameters["userId"]}")
+            val userId = call.request.queryParameters["userId"] ?: throw BadRequestException("Missing userId parameter")
+
+            val usersReadGrants = readGrantRepository.getReadGrantsByUserId(userId)
+            call.respond(HttpStatusCode.OK, Json.encodeToString(usersReadGrants))
+            return@get
+        }
+
+
+        route("/{contextId}") {
+            get {
+                logger.info("Received GET /readGrants/contextId with id: ${call.parameters["contextId"]}")
+                val contextId = call.parameters["contextId"] ?: throw BadRequestException("Missing contextId")
+
+                if (!authService.hasWriteContextAccess(call, contextId) && !authService.hasReadContextAccess(call, contextId)) {
+                    call.respond(HttpStatusCode.Forbidden)
+                    return@get
+                }
+                val context = readGrantRepository.getReadGrantsByContext(contextId)
+                call.respond(HttpStatusCode.OK, Json.encodeToString(context))
+                return@get
+            }
+            post {
+                try {
+                    val contextId = call.parameters["contextId"] ?: throw BadRequestException("Missing contextId")
+
+                    val grantReadAccessRequestJson = call.receiveText()
+                    logger.info("Received POST /readGrants/contextId request with body: $grantReadAccessRequestJson")
+                    val grantReadAccessRequest = Json.decodeFromString<DatabaseReadGrantRequest>(grantReadAccessRequestJson)
+
+                    if (!authService.hasWriteContextAccess(call, contextId)) {
+                        call.respond(HttpStatusCode.Forbidden)
+                        return@post
+                    }
+
+                    val readGrant = readGrantRepository.insertReadGrantOnContext(contextId, grantReadAccessRequest)
+
+                    call.respond(HttpStatusCode.Created, Json.encodeToString(readGrant))
+                    return@post
+                } catch (e: ConflictException) {
+                    ErrorHandlers.handleConflictException(call, e)
+                } catch (e: Exception) {
+                    logger.error("Unexpected error when processing post /contexts/contextId/grantReadAccess", e)
+                    call.respond(HttpStatusCode.InternalServerError, "An unexpected error occurred.")
+                }
+            }
+
+            patch("{readGrantId}/expiry") {
+                logger.info("Received PATCH /readGrants/{contextId}/{readGrantId} with readGrantId: ${call.parameters["readGrantId"]}")
+                val contextId = call.parameters["contextId"] ?: throw BadRequestException("Missing readGrantId")
+                val readGrantId = call.parameters["readGrantId"] ?: throw BadRequestException("Missing readGrantId")
+
+                if (!authService.hasWriteContextAccess(call, contextId)) {
+                    call.respond(HttpStatusCode.Forbidden)
+                    return@patch
+                }
+
+                readGrantRepository.revokeReadGrantOnContext(readGrantId, contextId)
+                call.respond(HttpStatusCode.OK)
+                return@patch
+            }
+
+        }
+
+    }
+}

--- a/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
@@ -31,7 +31,6 @@ fun Route.readGrantRouting(authService: AuthService, readGrantRepository: ReadGr
             return@get
         }
 
-
         route("/{contextId}") {
             get {
                 logger.info("Received GET /readGrants/contextId with id: ${call.parameters["contextId"]}")

--- a/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
@@ -97,6 +97,8 @@ patch("/{readGrantId}/expiry") {
     } catch (e: BadRequestException) {
         logger.error("Bad request: ${e.message}", e)
         call.respond(HttpStatusCode.BadRequest, e.message ?: "Bad request")
+    } catch (e: IllegalArgumentException) {
+        call.respond(HttpStatusCode.BadRequest, "Invalid contextId or readGrantId")
     } catch (e: Exception) {
         logger.error("Unexpected error when processing PATCH /readGrants/{contextId}/{readGrantId}/expiry", e)
         call.respond(HttpStatusCode.InternalServerError, "An unexpected error occurred.")

--- a/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
@@ -25,6 +25,13 @@ fun Route.readGrantRouting(authService: AuthService, readGrantRepository: ReadGr
             logger.info("Received get /readGrants for user with id: ${call.parameters["userId"]}")
             val userId = call.request.queryParameters["userId"] ?: throw BadRequestException("Missing userId parameter")
 
+            val currentUserId = authService.getCurrentUser(call).id
+            val isSuperUser = authService.hasSuperUserAccess(call)
+            if (!isSuperUser && userId != currentUserId) {
+                call.respond(HttpStatusCode.Forbidden)
+                return@get
+            }
+
             val usersReadGrants = readGrantRepository.getReadGrantsByUserId(userId)
             call.respond(HttpStatusCode.OK, Json.encodeToString(usersReadGrants))
             return@get

--- a/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
@@ -64,7 +64,7 @@ fun Route.readGrantRouting(authService: AuthService, readGrantRepository: ReadGr
                 } catch (e: ConflictException) {
                     ErrorHandlers.handleConflictException(call, e)
                 } catch (e: Exception) {
-                    logger.error("Unexpected error when processing post /contexts/contextId/grantReadAccess", e)
+                    logger.error("Unexpected error when processing POST /readGrants/{contextId}", e)
                     call.respond(HttpStatusCode.InternalServerError, "An unexpected error occurred.")
                 }
             }

--- a/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
@@ -3,7 +3,6 @@ package no.bekk.routes
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.parameters
 import io.ktor.server.plugins.BadRequestException
-import io.ktor.server.request.receive
 import io.ktor.server.request.receiveText
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -11,7 +10,6 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.patch
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import no.bekk.authentication.AuthService
 import no.bekk.database.DatabaseReadGrantRequest
@@ -23,9 +21,7 @@ import org.slf4j.LoggerFactory
 fun Route.readGrantRouting(authService: AuthService, readGrantRepository: ReadGrantRepository) {
     val logger = LoggerFactory.getLogger("no.bekk.routes.AnswerRouting")
 
-
     route("/readGrants") {
-
         get {
             logger.info("Received get /readGrants for user with id: ${call.parameters["userId"]}")
             val userId = call.request.queryParameters["userId"] ?: throw BadRequestException("Missing userId parameter")
@@ -88,8 +84,6 @@ fun Route.readGrantRouting(authService: AuthService, readGrantRepository: ReadGr
                 call.respond(HttpStatusCode.OK)
                 return@patch
             }
-
         }
-
     }
 }

--- a/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
@@ -70,7 +70,7 @@ fun Route.readGrantRouting(authService: AuthService, readGrantRepository: ReadGr
 
 patch("/{readGrantId}/expiry") {
     try {
-        logger.info("Received PATCH /readGrants/{contextId}/{readGrantId}/expiry with readGrantId: ${call.parameters[\"readGrantId\"]}")
+        logger.info("Received PATCH /readGrants/{contextId}/{readGrantId}/expiry with readGrantId: ${call.parameters["readGrantId"]}")
         val contextId = call.parameters["contextId"] ?: throw BadRequestException("Missing contextId")
         val readGrantId = call.parameters["readGrantId"] ?: throw BadRequestException("Missing readGrantId")
 

--- a/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
@@ -18,7 +18,7 @@ import no.bekk.plugins.ErrorHandlers
 import org.slf4j.LoggerFactory
 
 fun Route.readGrantRouting(authService: AuthService, readGrantRepository: ReadGrantRepository) {
-    val logger = LoggerFactory.getLogger("no.bekk.routes.AnswerRouting")
+    val logger = LoggerFactory.getLogger("no.bekk.routes.ReadGrantRouting")
 
     route("/readGrants") {
         get {

--- a/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
@@ -26,8 +26,7 @@ fun Route.readGrantRouting(authService: AuthService, readGrantRepository: ReadGr
             val userId = call.request.queryParameters["userId"] ?: throw BadRequestException("Missing userId parameter")
 
             val currentUserId = authService.getCurrentUser(call).id
-            val isSuperUser = authService.hasSuperUserAccess(call)
-            if (!isSuperUser && userId != currentUserId) {
+            if (userId != currentUserId) {
                 call.respond(HttpStatusCode.Forbidden)
                 return@get
             }

--- a/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
@@ -68,20 +68,33 @@ fun Route.readGrantRouting(authService: AuthService, readGrantRepository: ReadGr
                 }
             }
 
-            patch("{readGrantId}/expiry") {
-                logger.info("Received PATCH /readGrants/{contextId}/{readGrantId} with readGrantId: ${call.parameters["readGrantId"]}")
-                val contextId = call.parameters["contextId"] ?: throw BadRequestException("Missing readGrantId")
-                val readGrantId = call.parameters["readGrantId"] ?: throw BadRequestException("Missing readGrantId")
+patch("/{readGrantId}/expiry") {
+    try {
+        logger.info("Received PATCH /readGrants/{contextId}/{readGrantId}/expiry with readGrantId: ${call.parameters[\"readGrantId\"]}")
+        val contextId = call.parameters["contextId"] ?: throw BadRequestException("Missing contextId")
+        val readGrantId = call.parameters["readGrantId"] ?: throw BadRequestException("Missing readGrantId")
 
-                if (!authService.hasWriteContextAccess(call, contextId)) {
-                    call.respond(HttpStatusCode.Forbidden)
-                    return@patch
-                }
+        if (!authService.hasWriteContextAccess(call, contextId)) {
+            call.respond(HttpStatusCode.Forbidden)
+            return@patch
+        }
 
-                readGrantRepository.revokeReadGrantOnContext(readGrantId, contextId)
-                call.respond(HttpStatusCode.OK)
-                return@patch
-            }
+        val revoked = readGrantRepository.revokeReadGrantOnContext(readGrantId, contextId)
+        if (!revoked) {
+            call.respond(HttpStatusCode.NotFound)
+            return@patch
+        }
+
+        call.respond(HttpStatusCode.NoContent)
+        return@patch
+    } catch (e: BadRequestException) {
+        logger.error("Bad request: ${e.message}", e)
+        call.respond(HttpStatusCode.BadRequest, e.message ?: "Bad request")
+    } catch (e: Exception) {
+        logger.error("Unexpected error when processing PATCH /readGrants/{contextId}/{readGrantId}/expiry", e)
+        call.respond(HttpStatusCode.InternalServerError, "An unexpected error occurred.")
+    }
+}
         }
     }
 }

--- a/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
@@ -1,7 +1,6 @@
 package no.bekk.routes
 
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.parameters
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.request.receiveText
 import io.ktor.server.response.respond

--- a/src/test/kotlin/no/bekk/MockAuthService.kt
+++ b/src/test/kotlin/no/bekk/MockAuthService.kt
@@ -9,7 +9,7 @@ interface MockAuthService : AuthService {
     override suspend fun getGroupsOrEmptyList(call: ApplicationCall, filter: String?): List<MicrosoftGraphGroup> = TODO("Not yet implemented")
     override suspend fun getCurrentUser(call: ApplicationCall): MicrosoftGraphUser = TODO("Not yet implemented")
     override suspend fun getUserByUserId(call: ApplicationCall, userId: String): MicrosoftGraphUser = TODO("Not yet implemented")
-    override suspend fun searchUsers(call: ApplicationCall, usernameQuery: String, limit: Int ): List<MicrosoftGraphUser> = TODO("Not yet implemented")
+    override suspend fun searchUsers(call: ApplicationCall, usernameQuery: String, limit: Int): List<MicrosoftGraphUser> = TODO("Not yet implemented")
     override suspend fun hasTeamAccess(call: ApplicationCall, teamId: String?): Boolean = TODO("Not yet implemented")
     override suspend fun hasContextAccess(call: ApplicationCall, contextId: String): Boolean = TODO("Not yet implemented")
     override suspend fun hasWriteContextAccess(call: ApplicationCall, contextId: String): Boolean = TODO("Not yet implemented")


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**

Lagt til en "slettefunksjonalitet" hvor bruker kan "slette", mer presist ugyldiggjøre, en delt lesetilgang (read grant)

<img width="452" height="629" alt="bilde" src="https://github.com/user-attachments/assets/1b5e55ef-0539-4e4e-9cd4-451bd43639b7" />


Sletteknapp i frontend og patch-enedpunkt for å ugyldiggjøre tilgang men som fortsatt beholder historikken. Altså er Read grants en tabell som ogs skal fungere som historikk over alle tilganger som har blitt gitt, når og av hvem. Så selv om en bruker skulle ønsker å slette en tilgang, vil vi beholde den i tabellen for historikk og heller kun oppdatere utløpdatoen slik at den er utløpt og da ugyldig. 

Kun medlemmer av teamet som eier skjemautfyllingen til delingen kan slette en read-grant

**Hvorfor trenger vi denne funskjonaliteten?**

Hvis brukere er raske på avtrekkeren og legger til feil bruker, eller tjenestlig behov for delt lesetilgang endrer seg, er det fint om bruker selv kan ugyldiggjøre tilgangen. 

**Hvem er funskjonaliteten for?**

Team-meldlemmer av teamet som eier funkjsonalietten, men typisk teamleads ol som primært sitter med ansvar for å dele skjema. 
