### PR TITLE
Fix bytte av team og visning av teamnavn

### DIFF
--- a/app/hooks/useUser.ts
+++ b/app/hooks/useUser.ts
@@ -53,3 +53,15 @@ export function useSearchUser(userNameQuery: string) {
     enabled: userNameQuery.length >= 1,
   });
 }
+
+export function useFetchTeamName(teamId?: string) {
+  return useQuery({
+    queryKey: ["team-name", teamId],
+    queryFn: () =>
+      axiosFetch<string>({
+        url: `${API_URL_BASE}/teams/${teamId}/name`,
+      }).then((response) => response.data),
+    enabled: !!teamId,
+  });
+
+}

--- a/app/pages/activityPage/ActivityPage.tsx
+++ b/app/pages/activityPage/ActivityPage.tsx
@@ -93,12 +93,14 @@ export default function ActivityPage() {
     <>
       <RedirectBackButton />
       <Page>
-        <div className="flex flex-col max-w-full self-center gap-2">
+        <div className="flex flex-col w-full self-center gap-2">
           <div className="flex flex-col gap-2 px-10">
             <SkeletonLoader
-              loading={contextIsPending || tableIsPending || permissionsIsPending}
+              loading={
+                contextIsPending || tableIsPending || permissionsIsPending
+              }
               width="w-full"
-              height="h-8"
+              height="h-16"
             >
               <div className="flex justify-between">
                 <div className="flex flex-col">
@@ -116,8 +118,8 @@ export default function ActivityPage() {
                         className="text-primary hover:text-primary"
                       >
                         <Settings className="size-5" />
-                      </Button>)
-                    }
+                      </Button>
+                    )}
                   </div>
                 </div>
                 <div className="flex-col items-start bg-color-badge-grey text-secondary-foreground">
@@ -135,7 +137,7 @@ export default function ActivityPage() {
               answerIsPending ||
               commentIsPending
             }
-            width="w-full"
+            width="w-auto mx-10"
             height="min-h-[100vh]"
           >
             {!!tableData &&

--- a/app/pages/activityPage/ActivityPage.tsx
+++ b/app/pages/activityPage/ActivityPage.tsx
@@ -131,9 +131,7 @@ export default function ActivityPage() {
                 <div className="flex-col items-start bg-color-badge-grey text-secondary-foreground">
                   <p className="text-xs">Team - skjemaeier</p>
                   <p className="text-sm font-semibold">
-                    {teamNameError
-                      ? "Feil ved henting av bruker"
-                      : teamName}
+                    {teamNameError ? "Feil ved henting av teamnavn" : teamName}
                   </p>
                 </div>
               </div>

--- a/app/pages/activityPage/ActivityPage.tsx
+++ b/app/pages/activityPage/ActivityPage.tsx
@@ -8,8 +8,8 @@ import { mapTableDataRecords } from "@/utils/mapperUtil";
 import { AnswerType } from "@/api/types";
 import { ErrorState } from "@/components/ErrorState";
 import { useContext, useContextPermissions } from "@/hooks/useContext";
-import { useUser } from "@/hooks/useUser";
-import { useState } from "react";
+import { useFetchTeamName, useUser } from "@/hooks/useUser";
+import React, { useState } from "react";
 import { SettingsModal } from "./settingsModal/SettingsModal";
 import RedirectBackButton from "../../components/buttons/RedirectBackButton";
 import { SkeletonLoader } from "@/components/SkeletonLoader";
@@ -31,6 +31,12 @@ export default function ActivityPage() {
     error: userinfoError,
     isPending: userinfoIsPending,
   } = useUser();
+
+  const {
+    data: teamName,
+    error: teamNameError,
+    isPending: teamNameIsPending,
+  } = useFetchTeamName(context?.teamId);
 
   const {
     data: tableData,
@@ -85,9 +91,6 @@ export default function ActivityPage() {
       record.metadata?.answerMetadata?.type === AnswerType.SELECT_SINGLE,
   );
 
-  const teamName = userinfo?.groups.find(
-    (team) => team.id === context?.teamId,
-  )?.displayName;
 
   return (
     <>
@@ -97,7 +100,10 @@ export default function ActivityPage() {
           <div className="flex flex-col gap-2 px-10">
             <SkeletonLoader
               loading={
-                contextIsPending || tableIsPending || permissionsIsPending
+                contextIsPending ||
+                tableIsPending ||
+                permissionsIsPending ||
+                teamNameIsPending
               }
               width="w-full"
               height="h-16"
@@ -124,7 +130,11 @@ export default function ActivityPage() {
                 </div>
                 <div className="flex-col items-start bg-color-badge-grey text-secondary-foreground">
                   <p className="text-xs">Team - skjemaeier</p>
-                  <p className="text-sm font-semibold">{teamName}</p>
+                  <p className="text-sm font-semibold">
+                    {teamNameError
+                      ? "Feil ved henting av bruker"
+                      : teamName}
+                  </p>
                 </div>
               </div>
             </SkeletonLoader>

--- a/app/pages/createContextPage/CreateContextPage.tsx
+++ b/app/pages/createContextPage/CreateContextPage.tsx
@@ -123,6 +123,7 @@ export default function CreateContextPage() {
                     { replace: true },
                   )
                 }
+                disabled={isUserLoading}
               >
                 <SelectTrigger className="w-90 bg-card">
                   <SelectValue placeholder="Velg team" />
@@ -154,6 +155,7 @@ export default function CreateContextPage() {
                     { replace: true },
                   )
                 }
+                disabled={formIsPending}
               >
                 <SelectTrigger className="w-90 bg-card">
                   <SelectValue placeholder="Velg skjema" />

--- a/src/main/kotlin/no/bekk/authentication/AuthService.kt
+++ b/src/main/kotlin/no/bekk/authentication/AuthService.kt
@@ -32,7 +32,6 @@ interface AuthService {
     suspend fun getTeamIdFromName(call: ApplicationCall, teamName: String): String?
 
     suspend fun getTeamNameFromId(call: ApplicationCall, teamId: String): String?
-
 }
 
 class AuthServiceImpl(

--- a/src/main/kotlin/no/bekk/authentication/AuthService.kt
+++ b/src/main/kotlin/no/bekk/authentication/AuthService.kt
@@ -30,6 +30,9 @@ interface AuthService {
     suspend fun hasReportingUserAccess(call: ApplicationCall): Boolean
 
     suspend fun getTeamIdFromName(call: ApplicationCall, teamName: String): String?
+
+    suspend fun getTeamNameFromId(call: ApplicationCall, teamId: String): String?
+
 }
 
 class AuthServiceImpl(
@@ -148,6 +151,8 @@ class AuthServiceImpl(
     override suspend fun getTeamIdFromName(call: ApplicationCall, teamName: String): String? {
         val microsoftGroups = getGroupsOrEmptyList(call)
 
-        return microsoftGroups.find { it.displayName == teamName }?.id
+        val oboToken = microsoftService.requestTokenOnBehalfOf(jwtToken)
+
+        return microsoftService.fetchGroupById(oboToken, teamId)?.displayName
     }
 }

--- a/src/main/kotlin/no/bekk/authentication/AuthService.kt
+++ b/src/main/kotlin/no/bekk/authentication/AuthService.kt
@@ -149,7 +149,17 @@ class AuthServiceImpl(
     ): Boolean = hasTeamAccess(call, oAuthConfig.reportingUserGroup)
 
     override suspend fun getTeamIdFromName(call: ApplicationCall, teamName: String): String? {
-        val microsoftGroups = getGroupsOrEmptyList(call)
+        val jwtToken = call.request.headers["Authorization"]?.removePrefix("Bearer ")
+            ?: throw IllegalStateException("Authorization header missing")
+
+        val oboToken = microsoftService.requestTokenOnBehalfOf(jwtToken)
+
+        return microsoftService.fetchGroupByDisplayName(oboToken, teamName)?.id
+    }
+
+    override suspend fun getTeamNameFromId(call: ApplicationCall, teamId: String): String? {
+        val jwtToken = call.request.headers["Authorization"]?.removePrefix("Bearer ")
+            ?: throw IllegalStateException("Authorization header missing")
 
         val oboToken = microsoftService.requestTokenOnBehalfOf(jwtToken)
 

--- a/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/ReadGrantRouting.kt
@@ -74,35 +74,35 @@ fun Route.readGrantRouting(authService: AuthService, readGrantRepository: ReadGr
                 }
             }
 
-patch("/{readGrantId}/expiry") {
-    try {
-        logger.info("Received PATCH /readGrants/{contextId}/{readGrantId}/expiry with readGrantId: ${call.parameters["readGrantId"]}")
-        val contextId = call.parameters["contextId"] ?: throw BadRequestException("Missing contextId")
-        val readGrantId = call.parameters["readGrantId"] ?: throw BadRequestException("Missing readGrantId")
+            patch("/{readGrantId}/expiry") {
+                try {
+                    logger.info("Received PATCH /readGrants/{contextId}/{readGrantId}/expiry with readGrantId: ${call.parameters["readGrantId"]}")
+                    val contextId = call.parameters["contextId"] ?: throw BadRequestException("Missing contextId")
+                    val readGrantId = call.parameters["readGrantId"] ?: throw BadRequestException("Missing readGrantId")
 
-        if (!authService.hasWriteContextAccess(call, contextId)) {
-            call.respond(HttpStatusCode.Forbidden)
-            return@patch
-        }
+                    if (!authService.hasWriteContextAccess(call, contextId)) {
+                        call.respond(HttpStatusCode.Forbidden)
+                        return@patch
+                    }
 
-        val revoked = readGrantRepository.revokeReadGrantOnContext(readGrantId, contextId)
-        if (!revoked) {
-            call.respond(HttpStatusCode.NotFound)
-            return@patch
-        }
+                    val revoked = readGrantRepository.revokeReadGrantOnContext(readGrantId, contextId)
+                    if (!revoked) {
+                        call.respond(HttpStatusCode.NotFound)
+                        return@patch
+                    }
 
-        call.respond(HttpStatusCode.NoContent)
-        return@patch
-    } catch (e: BadRequestException) {
-        logger.error("Bad request: ${e.message}", e)
-        call.respond(HttpStatusCode.BadRequest, e.message ?: "Bad request")
-    } catch (e: IllegalArgumentException) {
-        call.respond(HttpStatusCode.BadRequest, "Invalid contextId or readGrantId")
-    } catch (e: Exception) {
-        logger.error("Unexpected error when processing PATCH /readGrants/{contextId}/{readGrantId}/expiry", e)
-        call.respond(HttpStatusCode.InternalServerError, "An unexpected error occurred.")
-    }
-}
+                    call.respond(HttpStatusCode.NoContent)
+                    return@patch
+                } catch (e: BadRequestException) {
+                    logger.error("Bad request: ${e.message}", e)
+                    call.respond(HttpStatusCode.BadRequest, e.message ?: "Bad request")
+                } catch (e: IllegalArgumentException) {
+                    call.respond(HttpStatusCode.BadRequest, "Invalid contextId or readGrantId")
+                } catch (e: Exception) {
+                    logger.error("Unexpected error when processing PATCH /readGrants/{contextId}/{readGrantId}/expiry", e)
+                    call.respond(HttpStatusCode.InternalServerError, "An unexpected error occurred.")
+                }
+            }
         }
     }
 }

--- a/src/main/kotlin/no/bekk/routes/UserInfoRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/UserInfoRouting.kt
@@ -1,7 +1,7 @@
 package no.bekk.routes
 
 import io.ktor.http.*
-import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.NotFoundException
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.coroutines.Dispatchers
@@ -87,13 +87,13 @@ fun Route.userInfoRouting(authService: AuthService) {
                     throw ValidationException("teamId parameter is required", field = "teamId")
                 }
 
-                val teamName = authService.getTeamNameFromId(call, teamId) ?: throw BadRequestException("TeamId: $teamId not valid")
+                val teamName = authService.getTeamNameFromId(call, teamId) ?: throw NotFoundException("TeamId $teamId not valid")
                 logger.info("${call.getRequestInfo()} Successfully retrieved display name for teamId: $teamId")
                 call.respond(HttpStatusCode.OK, teamName)
             } catch (e: ValidationException) {
                 ErrorHandlers.handleValidationException(call, e)
-            } catch (e: BadRequestException) {
-                logger.error("Bad request: ${e.message}", e)
+            } catch (e: NotFoundException) {
+                logger.error("Not found exception: ${e.message}", e)
                 call.respond(HttpStatusCode.BadRequest, e.message ?: "Bad request")
             } catch (e: Exception) {
                 logger.error("${call.getRequestInfo()} Error retrieving display name for teamId: ${call.parameters["teamId"]}", e)

--- a/src/main/kotlin/no/bekk/routes/UserInfoRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/UserInfoRouting.kt
@@ -75,4 +75,31 @@ fun Route.userInfoRouting(authService: AuthService) {
             }
         }
     }
+    route("/teams") {
+        get("/{teamId}/name"){
+            try {
+                val teamId = call.parameters["teamId"]
+                logger.info("${call.getRequestInfo()} Received GET /teams/{teamId}/name with id $teamId")
+
+                if (teamId == null) {
+                    logger.warn("${call.getRequestInfo()} Missing teamId parameter")
+                    throw ValidationException("teamId parameter is required", field = "teamId")
+                }
+
+                val teamName = authService.getTeamNameFromId(call, teamId) ?: throw BadRequestException("TeamId: ${teamId} not valid")
+                logger.info("${call.getRequestInfo()} Successfully retrieved display name for teamId: $teamId")
+                call.respond(HttpStatusCode.OK, teamName)
+            } catch (e: ValidationException) {
+                ErrorHandlers.handleValidationException(call, e)
+
+            } catch (e: BadRequestException) {
+                logger.error("Bad request: ${e.message}", e)
+                call.respond(HttpStatusCode.BadRequest, e.message ?: "Bad request")
+            }
+            catch (e: Exception) {
+                logger.error("${call.getRequestInfo()} Error retrieving display name for teamId: ${call.parameters["teamId"]}", e)
+                ErrorHandlers.handleGenericException(call, e)
+            }
+        }
+    }
 }

--- a/src/main/kotlin/no/bekk/routes/UserInfoRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/UserInfoRouting.kt
@@ -1,6 +1,7 @@
 package no.bekk.routes
 
 import io.ktor.http.*
+import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.coroutines.Dispatchers

--- a/src/main/kotlin/no/bekk/routes/UserInfoRouting.kt
+++ b/src/main/kotlin/no/bekk/routes/UserInfoRouting.kt
@@ -77,7 +77,7 @@ fun Route.userInfoRouting(authService: AuthService) {
         }
     }
     route("/teams") {
-        get("/{teamId}/name"){
+        get("/{teamId}/name") {
             try {
                 val teamId = call.parameters["teamId"]
                 logger.info("${call.getRequestInfo()} Received GET /teams/{teamId}/name with id $teamId")
@@ -87,17 +87,15 @@ fun Route.userInfoRouting(authService: AuthService) {
                     throw ValidationException("teamId parameter is required", field = "teamId")
                 }
 
-                val teamName = authService.getTeamNameFromId(call, teamId) ?: throw BadRequestException("TeamId: ${teamId} not valid")
+                val teamName = authService.getTeamNameFromId(call, teamId) ?: throw BadRequestException("TeamId: $teamId not valid")
                 logger.info("${call.getRequestInfo()} Successfully retrieved display name for teamId: $teamId")
                 call.respond(HttpStatusCode.OK, teamName)
             } catch (e: ValidationException) {
                 ErrorHandlers.handleValidationException(call, e)
-
             } catch (e: BadRequestException) {
                 logger.error("Bad request: ${e.message}", e)
                 call.respond(HttpStatusCode.BadRequest, e.message ?: "Bad request")
-            }
-            catch (e: Exception) {
+            } catch (e: Exception) {
                 logger.error("${call.getRequestInfo()} Error retrieving display name for teamId: ${call.parameters["teamId"]}", e)
                 ErrorHandlers.handleGenericException(call, e)
             }

--- a/src/main/kotlin/no/bekk/services/MicrosoftService.kt
+++ b/src/main/kotlin/no/bekk/services/MicrosoftService.kt
@@ -156,8 +156,7 @@ class MicrosoftServiceImpl(private val config: Config, private val client: HttpC
                 val response: HttpResponse = client.get(url) {
                     bearerAuth(bearerToken)
                     header("ConsistencyLevel", "eventual")
-                    parameter("\$filter", "displayName eq '$displayName'")
-                }
+                    parameter("\$filter", "displayName eq '${displayName.replace("'", "''")}'")
 
                 if (response.status != HttpStatusCode.OK) {
                     val responseBody = response.body<String>()

--- a/src/main/kotlin/no/bekk/services/MicrosoftService.kt
+++ b/src/main/kotlin/no/bekk/services/MicrosoftService.kt
@@ -157,6 +157,7 @@ class MicrosoftServiceImpl(private val config: Config, private val client: HttpC
                     bearerAuth(bearerToken)
                     header("ConsistencyLevel", "eventual")
                     parameter("\$filter", "displayName eq '${displayName.replace("'", "''")}'")
+                }
 
                 if (response.status != HttpStatusCode.OK) {
                     val responseBody = response.body<String>()

--- a/src/main/kotlin/no/bekk/services/MicrosoftService.kt
+++ b/src/main/kotlin/no/bekk/services/MicrosoftService.kt
@@ -22,6 +22,8 @@ import org.slf4j.LoggerFactory
 interface MicrosoftService {
     suspend fun requestTokenOnBehalfOf(jwtToken: String?): String
     suspend fun fetchGroups(bearerToken: String, filter: String? = null): List<MicrosoftGraphGroup>
+    suspend fun fetchGroupById(bearerToken: String, groupId: String): MicrosoftGraphGroup?
+    suspend fun fetchGroupByDisplayName(bearerToken: String, displayName: String): MicrosoftGraphGroup?
     suspend fun fetchCurrentUser(bearerToken: String): MicrosoftGraphUser
     suspend fun fetchUserByUserId(bearerToken: String, userId: String): MicrosoftGraphUser
     suspend fun searchUsersbyName(bearerToken: String, query: String, limit: Int): List<MicrosoftGraphUser>
@@ -116,6 +118,63 @@ class MicrosoftServiceImpl(private val config: Config, private val client: HttpC
         } catch (e: Exception) {
             logger.error("Unexpected error fetching groups from Microsoft Graph", e)
             throw ExternalServiceException("Microsoft Graph", "Failed to fetch groups: ${e.message}", cause = e)
+        }
+    }
+
+    override suspend fun fetchGroupById(bearerToken: String, groupId: String): MicrosoftGraphGroup? {
+        val url = "${config.microsoftGraph.baseUrl}/v1.0/groups/$groupId" + $$"?$select=id,displayName"
+
+        return try {
+            ExternalServiceTimer.time("Microsoft", "fetchGroupById") {
+                val response: HttpResponse = client.get(url) {
+                    bearerAuth(bearerToken)
+                }
+
+                when (response.status) {
+                    HttpStatusCode.OK -> json.decodeFromString<MicrosoftGraphGroup>(response.body<String>())
+                    HttpStatusCode.NotFound -> null
+                    else -> {
+                        val responseBody = response.body<String>()
+                        logger.warn("Failed to fetch group $groupId - Status: ${response.status}, Body: $responseBody")
+                        throw ExternalServiceException("Microsoft Graph", "Failed to fetch group $groupId", response.status.value)
+                    }
+                }
+            }
+        } catch (e: ExternalServiceException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error("Unexpected error fetching group $groupId from Microsoft Graph", e)
+            throw ExternalServiceException("Microsoft Graph", "Failed to fetch group $groupId: ${e.message}", cause = e)
+        }
+    }
+
+    override suspend fun fetchGroupByDisplayName(bearerToken: String, displayName: String): MicrosoftGraphGroup? {
+        val url = "${config.microsoftGraph.baseUrl}/v1.0/groups" + $$"?$select=id,displayName&$top=1"
+
+        return try {
+            ExternalServiceTimer.time("Microsoft", "fetchGroupByDisplayName") {
+                val response: HttpResponse = client.get(url) {
+                    bearerAuth(bearerToken)
+                    header("ConsistencyLevel", "eventual")
+                    parameter("\$filter", "displayName eq '$displayName'")
+                }
+
+                if (response.status != HttpStatusCode.OK) {
+                    val responseBody = response.body<String>()
+                    logger.warn("Failed to lookup group by name '$displayName' - Status: ${response.status}, Body: $responseBody")
+                    throw ExternalServiceException("Microsoft Graph", "Failed to lookup group by name", response.status.value)
+                }
+
+                json.decodeFromString<MicrosoftGraphGroupsResponse>(response.body<String>())
+                    .value
+                    .firstOrNull()
+                    ?.let { MicrosoftGraphGroup(id = it.id, displayName = it.displayName) }
+            }
+        } catch (e: ExternalServiceException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error("Unexpected error looking up group by name '$displayName' from Microsoft Graph", e)
+            throw ExternalServiceException("Microsoft Graph", "Failed to lookup group by name: ${e.message}", cause = e)
         }
     }
 

--- a/src/test/kotlin/no/bekk/MockAuthService.kt
+++ b/src/test/kotlin/no/bekk/MockAuthService.kt
@@ -17,4 +17,5 @@ interface MockAuthService : AuthService {
     override suspend fun hasSuperUserAccess(call: ApplicationCall): Boolean = TODO("Not yet implemented")
     override suspend fun hasReportingUserAccess(call: ApplicationCall): Boolean = TODO("Not yet implemented")
     override suspend fun getTeamIdFromName(call: ApplicationCall, teamName: String): String? = TODO("Not yet implemented")
+    override suspend fun getTeamNameFromId(call: ApplicationCall, teamId: String): String? = TODO("Not yet implemented")
 }


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**

De to største hovedtingene jeg har fikset på er:
1. Å bytte eier av skjemautfyllingen funker ikke hvis du skal bytte til et team du ikke selv er medlem av 
2. Teamnavn vistes ikke på delte skjemautfyllinger. 

### Bytte av eier av skjemautfylling
Under settings til en skjemautfyllings skal man kunne skifte eier (team), men det funket ikke fordi når man sendte inn et team-navn, og backenden skulle bytte dette mot en teamId for å bytte verdien i context-tabellen i databasen så kalte den endepunktet i msal som kun returnerer brukerens grupper. Derfor har jeg endret på metoden og lagt til funkjsonalitet for å hente fra /groups endepunktet.  
<img width="429" height="384" alt="bilde" src="https://github.com/user-attachments/assets/45a0136c-23fc-428b-a96e-4232e9547b2a" />


### Teamnavn
Regelrett lagrer kun teamId i db, så lookup etter navn ble gjort ved å hente brukerens egne grupper og sjekke alle etter matchende id. Men hvis skjemaet har blitt delt med en person vil ikke bruker være medlem av dette teamet, og det ble derfor ikke funnet et teamnavn. 
Nå spør frontenden et nytt enedepunkt for å hente teamnavn, hvor backend spør groups endepunktet til msal for å kunne hente grupper som ikke bare tilhører brukeren. Her henter den grupper på id, og retunerer kun display-name. 
| Før | Etter |
|--|--|
|<img width="1469" height="140" alt="bilde" src="https://github.com/user-attachments/assets/3d39fad2-2c17-478c-963c-b775eb56accf" /> | <img width="1460" height="103" alt="bilde" src="https://github.com/user-attachments/assets/359e0114-e727-4d35-8212-1871f2804d6f" /> |




### Div andre ui fix


**Disable input under loading**
på /ny siden ( `CreateContextPage`) var inputfeltene fortsatt klikkbare når dataen som blir menyvalgene til selecten lastet inn. Har slengt på en disabled når tilhørende data isPending. 
| Før | Etter |
|--|--|
| <img width="534" height="425" alt="bilde" src="https://github.com/user-attachments/assets/6edc9294-e3f3-4a0b-ab53-4908a21126b2" />  <img width="423" height="97" alt="bilde" src="https://github.com/user-attachments/assets/f056e3d8-5faf-42a9-8520-7ec481efc998" /> | <img width="632" height="495" alt="bilde" src="https://github.com/user-attachments/assets/e95bcbd9-7b9b-463a-a7d0-65d9c6921456" />|


**Loading activity page**
Skeleton loaderen er veldig mye smalere enn innholdet den laster inn. Fikset på cssen for å gi den rikig størrekse ifht innholdet det laster inn. 

| Før | Etter |
|--|--|
| <img width="1473" height="1000" alt="bilde" src="https://github.com/user-attachments/assets/07b358ae-759b-4daf-a098-cfe4288792e7" /> | <img width="1471" height="993" alt="bilde" src="https://github.com/user-attachments/assets/e9c0e5e1-a698-4399-8933-41dd8882fbc9" /> |


**Hvorfor trenger vi denne funskjonaliteten?**

Kunne bytte team ved navn: gjøre det enklere for bruker å skrive inn display-navnet på teamet fremfor id - da man da er mer bevist og sikker på hvem man overfører en sensetiv skjemautfylling til.  

Se navnet til eier av skjema: for å være klar over eier av skjema - særlig viktig på delte skjema da dette ikke står på oversiktssiden. 


