### PR TITLE
oppgradere ktor og slette netty

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,8 +46,6 @@ dependencies {
     implementation(libs.flyway.database.core)
     implementation(libs.flyway.database.postgresql)
     implementation(libs.ben.manes.caffeine)
-    implementation(libs.netty.codec.http2)
-    implementation(libs.netty.transport.native.epoll)
 
     constraints {
         implementation("com.fasterxml.jackson:jackson-bom:2.21.4") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 [versions]
 kotlin-version = "2.3.21"
 kotlinx-html-version = "0.12.0"
-ktor-version = "3.5.0"
+ktor-version = "3.5.1"
 logback-version = "1.5.34"
 flyway-version = "12.7.0"
 ajalt-clikt-version = "5.1.0"
@@ -12,7 +12,6 @@ ben-manes-caffeine-version = "3.2.4"
 testcontainers-version = "1.21.4"
 postgresql-driver-version = "42.7.13"
 ktlint-version = "14.2.0"
-netty-version = "4.2.15.Final"
 
 [libraries]
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor-version" }
@@ -46,8 +45,6 @@ testcontainers-testcontainers = { module = "org.testcontainers:testcontainers", 
 testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers-version" }
 junit-platform-launcher = { module = 'org.junit.platform:junit-platform-launcher' }
 junit-jupiter = { module = 'org.junit.jupiter:junit-jupiter', version = "6.1.0" }
-netty-codec-http2 = { module='io.netty:netty-codec-http2', version.ref = 'netty-version' } #kan fjernes når ktor oppggraderer til å bruke ny versjon netty2
-netty-transport-native-epoll = { module='io.netty:netty-transport-native-epoll', version.ref = 'netty-version' }
 
 
 [plugins]


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**

oppgradert ktor fra 3.5.0 -> 3.5.1 som tar i bruk ny versjon av netty, og vi kan derfor endelig slette forcen av netty, siden det er ktor som transitivt dro inn en lavere versjon av netty med sårbarheter. 
