### PR TITLE
Bug: autogen av uid funker ikke i provisjoneringen

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(libs.flyway.database.core)
     implementation(libs.flyway.database.postgresql)
     implementation(libs.ben.manes.caffeine)
+    implementation(libs.netty.codec.http)
 
     constraints {
         implementation("com.fasterxml.jackson:jackson-bom:2.21.4") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ ben-manes-caffeine-version = "3.2.4"
 testcontainers-version = "1.21.4"
 postgresql-driver-version = "42.7.11"
 ktlint-version = "14.2.0"
+netty-version = "4.2.16.Final"
 
 [libraries]
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor-version" }
@@ -45,6 +46,7 @@ testcontainers-testcontainers = { module = "org.testcontainers:testcontainers", 
 testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers-version" }
 junit-platform-launcher = { module = 'org.junit.platform:junit-platform-launcher' }
 junit-jupiter = { module = 'org.junit.jupiter:junit-jupiter', version = "6.1.0" }
+netty-codec-http = { module='io.netty:netty-codec-http2', version.ref = 'netty-version' } #kan fjernes når ktor oppggraderer til å bruke ny versjon netty2
 
 
 [plugins]

--- a/src/main/kotlin/no/bekk/services/FormService.kt
+++ b/src/main/kotlin/no/bekk/services/FormService.kt
@@ -122,8 +122,6 @@ class FormServiceImpl : FormService {
             if (providers.values.none {it.id == uuid }) {
                 return uuid
             }
-
-            return uuid
         }
         throw IllegalStateException("Failed to generate UID for provider")
     }

--- a/src/main/kotlin/no/bekk/services/FormService.kt
+++ b/src/main/kotlin/no/bekk/services/FormService.kt
@@ -119,8 +119,8 @@ class FormServiceImpl : FormService {
         for (i in 0..3) {
             val uuid = generateNewUid()
 
-            if (providers.firstNotNullOfOrNull { it.value.id == uuid } != null) {
-                continue
+            if (providers.values.none {it.id == uuid }) {
+                return uuid
             }
 
             return uuid


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**

Autogenering av uid hvis du oppgir tomt uid felt fungerer ikke i provisjoneringen av skjema. Se eks på bilde.

<img width="441" height="114" alt="bilde" src="https://github.com/user-attachments/assets/bb62772c-104c-4601-a254-c4b66685da2b" />

Det er fordi koden som er ment for å sjekke om den uiden regelrett har generert ikke kræsjer med en allerede eksisterende uid, evaluerer til false som != null, og derfor går den sin gang og man får aldri generert uid. Derfor har jeg byttet ut syntaxen men en sjekk som heller ser om for noen av de eksisterende skjemaene om noen har lik uid - returner den genererte, hvis ikke prøver den på nytt. 

