### PR TITLE
remove old traces of read_access_group_id

### DIFF
--- a/conf/provisioning/schemasources/sample.yaml
+++ b/conf/provisioning/schemasources/sample.yaml
@@ -55,9 +55,6 @@
 #     # AirTable field that holds the answer expiry in weeks.
 #     # Defaults to "Svarvarighet".
 #     answer_expiry_column: Svarvarighet
-#     # <string, optional, for Airtable and YAML scheams sources>
-#     # entra id group id which is given read access to specefied schema
-#     read_access_group_id:
 #     ##### Additional parameters for specifying Yaml schema     #####
 #     ##### sources.                                             #####
 #     # Either endpoint or resourcePath must be set

--- a/src/main/kotlin/no/bekk/providers/AirTableProvider.kt
+++ b/src/main/kotlin/no/bekk/providers/AirTableProvider.kt
@@ -18,7 +18,6 @@ import java.net.HttpURLConnection
 class AirTableProvider(
     override val name: String,
     override val id: String,
-    override val readAccessGroupId: String? = null,
     private val airtableClient: AirTableClient,
     private val baseId: String,
     private val formId: String,

--- a/src/main/kotlin/no/bekk/providers/FormProvider.kt
+++ b/src/main/kotlin/no/bekk/providers/FormProvider.kt
@@ -5,7 +5,6 @@ import no.bekk.model.internal.*
 interface FormProvider {
     val name: String
     val id: String
-    val readAccessGroupId: String?
     suspend fun getForm(): Form
     suspend fun getQuestion(recordId: String): Question
     suspend fun getColumns(): List<Column>

--- a/src/main/kotlin/no/bekk/providers/YamlProvider.kt
+++ b/src/main/kotlin/no/bekk/providers/YamlProvider.kt
@@ -11,7 +11,6 @@ import no.bekk.model.internal.*
 class YamlProvider(
     override val name: String,
     override val id: String,
-    override val readAccessGroupId: String? = null,
     private val httpClient: HttpClient? = null,
     private val endpoint: String? = null,
     private val resourcePath: String? = null,

--- a/src/main/kotlin/no/bekk/services/FormService.kt
+++ b/src/main/kotlin/no/bekk/services/FormService.kt
@@ -76,7 +76,6 @@ class FormServiceImpl : FormService {
                 viewId = cmd.view_id,
                 webhookId = cmd.webhook_id,
                 webhookSecret = cmd.webhook_secret,
-                readAccessGroupId = cmd.read_access_group_id,
                 answerColumn = cmd.answer_column,
                 answerTypeColumn = cmd.answer_type_column,
                 answerUnitColumn = cmd.answer_unit_column,
@@ -88,7 +87,6 @@ class FormServiceImpl : FormService {
                 name = cmd.name,
                 id = uuid,
                 endpoint = cmd.url,
-                readAccessGroupId = cmd.read_access_group_id,
                 resourcePath = cmd.resource_path,
             )
             else -> throw IllegalStateException("Illegal type \"${cmd.type}\"")

--- a/src/main/kotlin/no/bekk/services/provisioning/schemasources/ConfigReader.kt
+++ b/src/main/kotlin/no/bekk/services/provisioning/schemasources/ConfigReader.kt
@@ -46,7 +46,6 @@ class ConfigReader {
                     expandEnv(it.view_id),
                     expandEnv(it.webhook_id),
                     expandEnv(it.webhook_secret),
-                    expandEnv(it.read_access_group_id),
                     expandEnv(it.resource_path),
                     expandEnv(it.answer_column),
                     expandEnv(it.answer_type_column),

--- a/src/main/kotlin/no/bekk/services/provisioning/schemasources/Types.kt
+++ b/src/main/kotlin/no/bekk/services/provisioning/schemasources/Types.kt
@@ -19,7 +19,6 @@ data class UpsertDataFromConfig(
     val view_id: String? = null,
     val webhook_id: String? = null,
     val webhook_secret: String? = null,
-    val read_access_group_id: String? = null,
     val resource_path: String? = null,
     val answer_column: String = "Svar",
     val answer_type_column: String = "Svartype",

--- a/src/test/kotlin/no/bekk/routes/ContextRoutingTest.kt
+++ b/src/test/kotlin/no/bekk/routes/ContextRoutingTest.kt
@@ -542,7 +542,6 @@ class ContextRoutingTest {
                     override fun getFormProvider(formId: String): FormProvider = object : FormProvider {
                         override val name = "formName"
                         override val id = "formId"
-                        override val readAccessGroupId: String? = null
                         override suspend fun getForm(): Form = mockedForm
                         override suspend fun getQuestion(recordId: String) = TODO()
                         override suspend fun getColumns() = emptyList<no.bekk.model.internal.Column>()


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**

Fjernet rester i koden fra `read_access_group_id` miljøvariabelen. Denne er en del av et gammelt første utkast på lesetilganger på skjematyper hvor man skulle lage en egen gruppe hvor alle i den fikk lesetilgang til alle skjema av en skjematype. Dette ble erstattet av `readGrant`, og har bare ikke blitt fjernet helt.
