### PR TITLE
Fix multiSelect answer component

### DIFF
--- a/app/components/answers/MultiSelectAnswer.tsx
+++ b/app/components/answers/MultiSelectAnswer.tsx
@@ -33,7 +33,7 @@ export default function MultiDropdownMenuAnswer({
   const [debounceTimeout, setDebounceTimeout] = useState<number>();
   const [updatedAt, setUpdatedAt] = useState(updated);
   const [selected, setSelected] = useState<string[]>(
-    value?.split(";").map((val) => val.trim()) ?? [],
+    value?.split(";").map((val) => val.trim()).filter(Boolean) ?? [],
   );
 
   function submitIfModified(newAnswer: string) {


### PR DESCRIPTION
**Hva er funskjonaliteten du har lagt til?**

Input-widgeten for svar av type multiSelect hadde en bug hvor du så en tom grå boks med en x til venstre for pluss knappen på render, altså uten at bruker hadde interagert med den. Dette var pga når answers er tom (altså det finnes ingen svar på dette spørsmålet) så får komponenten inn en liste med en tom streng - og det er denne tomme strengen vi ser som den grå boksen. Derfor har jeg fikset opp hvordan selected initieres for å fjerne evt tomme strenger. 


|Før | Etter|
|--|--|
| <img width="233" height="112" alt="bilde" src="https://github.com/user-attachments/assets/801b11e6-6b0a-4bec-afc7-30f47afd0270" /> | <img width="244" height="110" alt="bilde" src="https://github.com/user-attachments/assets/f35f51f2-d8f3-4237-b592-526dbfe6a301" /> |


Bilde ref for hvor i RR vi er: 
<img width="1428" height="446" alt="bilde" src="https://github.com/user-attachments/assets/01813ed8-1360-420c-a58b-33a7a9eb5f94" />


